### PR TITLE
Fixing a security issue when running pytest

### DIFF
--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -133,7 +133,7 @@ jobs:
           printf "[INFO] Notify ID: '%s'\n" "${{ env.NOTIFY_ID }}"
           printf "[INFO] Software Name: '%s'\n" "${{ env.SOFTWARE_NAME }}"
           printf "[INFO] Software Version: '%s'\n" "${{ env.SOFTWARE_VERSION }}"
-          ve1/bin/pytest tests/functional/test_submitted_charts.py --log-cli-level=WARNING
+          ve1/bin/pytest tests/functional/test_submitted_charts.py --log-cli-level=WARNING --tb=short
 
       - name: (Schedule) Run tests on existing charts
         if: |
@@ -155,7 +155,7 @@ jobs:
           printf "[INFO] Notify ID: '%s'\n" "${{ env.NOTIFY_ID }}"
           printf "[INFO] Software Name: '%s'\n" "${{ env.SOFTWARE_NAME }}"
           printf "[INFO] Software Version: '%s'\n" "${{ env.SOFTWARE_VERSION }}"
-          ve1/bin/pytest tests/functional/test_submitted_charts.py --log-cli-level=WARNING
+          ve1/bin/pytest tests/functional/test_submitted_charts.py --log-cli-level=WARNING --tb=short
 
   check-chart-verifier:
     name: Check Chart Verifier Version
@@ -259,7 +259,7 @@ jobs:
           printf "[INFO] Notify ID: '%s'\n" "${{ env.NOTIFY_ID }}"
           printf "[INFO] Software Name: '%s'\n" "${{ env.SOFTWARE_NAME }}"
           printf "[INFO] Software Version: '%s'\n" "${{ env.SOFTWARE_VERSION }}"
-          ve1/bin/pytest tests/functional/test_submitted_charts.py --log-cli-level=WARNING
+          ve1/bin/pytest tests/functional/test_submitted_charts.py --log-cli-level=WARNING --tb=short
 
       - name: (Schedule) Run tests on existing charts
         if: |
@@ -281,4 +281,4 @@ jobs:
           printf "[INFO] Notify ID: '%s'\n" "${{ env.NOTIFY_ID }}"
           printf "[INFO] Software Name: '%s'\n" "${{ env.SOFTWARE_NAME }}"
           printf "[INFO] Software Version: '%s'\n" "${{ env.SOFTWARE_VERSION }}"
-          ve1/bin/pytest tests/functional/test_submitted_charts.py --log-cli-level=WARNING
+          ve1/bin/pytest tests/functional/test_submitted_charts.py --log-cli-level=WARNING --tb=short

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,7 +81,7 @@ jobs:
           BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
           PR_BODY: "Test triggered by ${{ github.event.pull_request.html_url }}."
         run: |
-          ve1/bin/pytest tests/ --log-cli-level=WARNING --ignore=tests/functional/test_submitted_charts.py
+          ve1/bin/pytest tests/ --log-cli-level=WARNING --ignore=tests/functional/test_submitted_charts.py --tb=short
 
       - name: (Manual) Test CI Workflow
         if: |
@@ -102,4 +102,4 @@ jobs:
           echo "[INFO] Notify ID '${{ env.NOTIFY_ID }}'"
           echo "[INFO] Software Name '${{ env.SOFTWARE_NAME }}'"
           echo "[INFO] Software Version '${{ env.SOFTWARE_VERSION }}'"
-          ve1/bin/pytest tests/functional/test_submitted_charts.py --log-cli-level=WARNING
+          ve1/bin/pytest tests/functional/test_submitted_charts.py --log-cli-level=WARNING --tb=short


### PR DESCRIPTION
Setting the traceback flag to false to avoid traceback printing
partial github token characters. We will need to rotate all our
github tokens after this PR merges.