### PR TITLE
test_submitted_charts: add software name to branch names

### DIFF
--- a/tests/functional/test_submitted_charts.py
+++ b/tests/functional/test_submitted_charts.py
@@ -222,8 +222,9 @@ def submission_tests_run_for_submitted_charts(secrets):
 
         for vendor_type, vendor_name, chart_name, chart_version in secrets.submitted_charts:
             chart_dir = f'charts/{vendor_type}/{vendor_name}/{chart_name}'
-            base_branch = f'{secrets.pr_base_branch}-{vendor_type}-{vendor_name}-{chart_name}-{chart_version}'
-            pr_branch = f'{secrets.pr_base_branch}-{vendor_type}-{vendor_name}-{chart_name}-{chart_version}-pr'
+            base_branch = f'{secrets.software_name}-{secrets.pr_base_branch}-{vendor_type}-{vendor_name}-{chart_name}-{chart_version}'
+            pr_branch = f'{secrets.software_name}-{secrets.pr_base_branch}-{vendor_type}-{vendor_name}-{chart_name}-{chart_version}-pr'
+
             secrets.base_branches.append(base_branch)
             secrets.pr_branches.append(pr_branch)
             repo.git.checkout('tmp')


### PR DESCRIPTION
This avoids collision between test runs of oc change and chart-verifier
change.

Signed-off-by: Allen Bai <abai@redhat.com>