### PR TITLE
Add unique vendor name to each test case

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,6 +79,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BOT_NAME: ${{ secrets.BOT_NAME }}
           BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_BODY: "Test triggered by ${{ github.event.pull_request.html_url }}."
         run: |
           ve1/bin/pytest tests/ --log-cli-level=WARNING --ignore=tests/functional/test_submitted_charts.py --tb=short

--- a/tests/functional/test_chart_src_with_report.py
+++ b/tests/functional/test_chart_src_with_report.py
@@ -132,14 +132,14 @@ def test_redhat_chart_src_submission():
 def hashicorp_is_a_valid_partner(secrets):
     """hashicorp is a valid partner"""
     secrets.vendor_type = 'partners'
-    secrets.vendor = 'hashicorp'
+    secrets.vendor = get_unique_vendor('hashicorp')
 
 
 @given("a redhat associate has a valid identity")
 def redhat_associate_is_valid(secrets):
     """a redhat associate has a valid identity"""
     secrets.vendor_type = 'redhat'
-    secrets.vendor = 'redhat'
+    secrets.vendor = get_unique_vendor('redhat')
 
 
 @given("hashicorp has created an error-free chart source and report for vault")

--- a/tests/functional/test_chart_src_without_report.py
+++ b/tests/functional/test_chart_src_without_report.py
@@ -130,14 +130,14 @@ def test_redhat_chart_src_submission():
 def hashicorp_is_a_valid_partner(secrets):
     """hashicorp is a valid partner"""
     secrets.vendor_type = 'partners'
-    secrets.vendor = 'hashicorp'
+    secrets.vendor = get_unique_vendor('hashicorp')
 
 
 @given("a redhat associate has a valid identity")
 def redhat_associate_is_valid(secrets):
     """a redhat associate has a valid identity"""
     secrets.vendor_type = 'redhat'
-    secrets.vendor = 'redhat'
+    secrets.vendor = get_unique_vendor('redhat')
 
 
 @given("hashicorp has created an error-free chart source for vault")

--- a/tests/functional/test_chart_tar_with_report.py
+++ b/tests/functional/test_chart_tar_with_report.py
@@ -131,14 +131,14 @@ def test_redhat_chart_tar_with_report_submission():
 def hashicorp_is_a_valid_partner(secrets):
     """hashicorp is a valid partner"""
     secrets.vendor_type = 'partners'
-    secrets.vendor = 'hashicorp'
+    secrets.vendor = get_unique_vendor('hashicorp')
 
 
 @given("a redhat associate has a valid identity")
 def redhat_associate_is_valid(secrets):
     """a redhat associate has a valid identity"""
     secrets.vendor_type = 'redhat'
-    secrets.vendor = 'redhat'
+    secrets.vendor = get_unique_vendor('redhat')
 
 
 @given("hashicorp has created an error-free chart tar and report for vault")

--- a/tests/functional/test_chart_tar_without_report.py
+++ b/tests/functional/test_chart_tar_without_report.py
@@ -131,14 +131,14 @@ def test_redhat_chart_tar_submission():
 def hashicorp_is_a_valid_partner(secrets):
     """hashicorp is a valid partner"""
     secrets.vendor_type = 'partners'
-    secrets.vendor = 'hashicorp'
+    secrets.vendor = get_unique_vendor('hashicorp')
 
 
 @given("a redhat associate has a valid identity")
 def redhat_associate_is_valid(secrets):
     """a redhat associate has a valid identity"""
     secrets.vendor_type = 'redhat'
-    secrets.vendor = 'redhat'
+    secrets.vendor = get_unique_vendor('redhat')
 
 
 @given("hashicorp has created an error-free chart tar for vault")

--- a/tests/functional/test_report_only_no_errors.py
+++ b/tests/functional/test_report_only_no_errors.py
@@ -129,14 +129,14 @@ def test_redhat_submits_report_without_any_errors():
 def hashicorp_is_a_valid_partner(secrets):
     """hashicorp is a valid partner"""
     secrets.vendor_type = 'partners'
-    secrets.vendor = 'hashicorp'
+    secrets.vendor = get_unique_vendor('hashicorp')
 
 
 @given("a redhat associate has a valid identity")
 def redhat_associate_is_valid(secrets):
     """a redhat associate has a valid identity"""
     secrets.vendor_type = 'redhat'
-    secrets.vendor = 'redhat'
+    secrets.vendor = get_unique_vendor('redhat')
 
 
 @given("hashicorp has created a error-free report")

--- a/tests/functional/utils.py
+++ b/tests/functional/utils.py
@@ -4,6 +4,7 @@
 import os
 import shutil
 import tarfile
+import time
 import json
 
 import pytest
@@ -271,3 +272,9 @@ def github_api(method, endpoint, bot_token, headers={}, data={}, json={}):
     else:
         raise ValueError(
             "Github API method not implemented in helper function")
+
+def get_unique_vendor(vendor):
+    suffix = str(int(time.time())) # unique string based on current time in seconds
+    if "PR_NUMBER" in os.environ:
+        suffix = os.environ["PR_NUMBER"]
+    return f"{vendor}-{suffix}"


### PR DESCRIPTION
In order to avoid release name to collide when two PRs are send
for testing at the same time. Vendor it is used as organization
in the release name template.