### PR TITLE
Enable cluster role deletes in helm uninstall

### DIFF
--- a/scripts/src/saforcharttesting/saforcharttesting.py
+++ b/scripts/src/saforcharttesting/saforcharttesting.py
@@ -73,6 +73,7 @@ rules:
     verbs:
       - 'get'
       - 'create'
+      - 'delete'
   - apiGroups:
       - "admissionregistration.k8s.io"
     resources:
@@ -83,6 +84,7 @@ rules:
       - 'list'
       - 'watch'
       - 'patch'
+      - 'delete'
   - apiGroups:
       - "authentication.k8s.io"
     resources:


### PR DESCRIPTION
Helm uninstall was failing in workflow, 

[ERROR} Error from helm uninstall : Error running process: executing helm with args "uninstall vault-ia25nn4fek --namespace charts-157 []": exit status 1
 ---
 Error: uninstallation completed with 4 error(s): clusterrolebindings.rbac.authorization.k8s.io "vault-ia25nn4fek-server-binding" is forbidden: User "system:serviceaccount:charts-157:charts-157" cannot delete resource "clusterrolebindings" in API group "rbac.authorization.k8s.io" at the cluster scope; clusterrolebindings.rbac.authorization.k8s.io "vault-ia25nn4fek-agent-injector-binding" is forbidden: User "system:serviceaccount:charts-157:charts-157" cannot delete resource "clusterrolebindings" in API group "rbac.authorization.k8s.io" at the cluster scope; clusterroles.rbac.authorization.k8s.io "vault-ia25nn4fek-agent-injector-clusterrole" is forbidden: User "system:serviceaccount:charts-157:charts-157" cannot delete resource "clusterroles" in API group "rbac.authorization.k8s.io" at the cluster scope; mutatingwebhookconfigurations.admissionregistration.k8s.io "vault-ia25nn4fek-agent-injector-cfg" is forbidden: User "system:serviceaccount:charts-157:charts-157" cannot delete resource "mutatingwebhookconfigurations" in API group "admissionregistration.k8s.io" at the cluster scope



this enables the resources to be deleted: