### PR TITLE
Fixing workflow release cleanup issue running on forks

### DIFF
--- a/tests/functional/test_chart_src_with_report.py
+++ b/tests/functional/test_chart_src_with_report.py
@@ -321,8 +321,9 @@ def the_index_yaml_is_updated_with_a_new_entry(secrets):
 def the_release_is_published(secrets):
     """a release is published with the chart"""
 
-    expected_tag = f'{secrets.vendor}-{secrets.chart_name}-{secrets.chart_version}-test-pr{secrets.pr_number}'
+    expected_tag = f'{secrets.vendor}-{secrets.chart_name}-{secrets.chart_version}'
     try:
+        logger.info(f"Checking '{expected_tag}' was released")
         release = get_release_by_tag(secrets, expected_tag)
         logger.info(f"Released '{expected_tag}' successfully")
 

--- a/tests/functional/test_chart_src_without_report.py
+++ b/tests/functional/test_chart_src_without_report.py
@@ -311,8 +311,9 @@ def the_index_yaml_is_updated_with_a_new_entry(secrets):
 def the_release_is_published(secrets):
     """a release is published with the chart"""
 
-    expected_tag = f'{secrets.vendor}-{secrets.chart_name}-{secrets.chart_version}-test-pr{secrets.pr_number}'
+    expected_tag = f'{secrets.vendor}-{secrets.chart_name}-{secrets.chart_version}'
     try:
+        logger.info(f"Checking '{expected_tag}' was released")
         release = get_release_by_tag(secrets, expected_tag)
         logger.info(f"Released '{expected_tag}' successfully")
 

--- a/tests/functional/test_chart_tar_with_report.py
+++ b/tests/functional/test_chart_tar_with_report.py
@@ -322,8 +322,9 @@ def the_index_yaml_is_updated_with_a_new_entry(secrets):
 def the_release_is_published(secrets):
     """a release is published with the chart"""
 
-    expected_tag = f'{secrets.vendor}-{secrets.chart_name}-{secrets.chart_version}-test-pr{secrets.pr_number}'
+    expected_tag = f'{secrets.vendor}-{secrets.chart_name}-{secrets.chart_version}'
     try:
+        logger.info(f"Checking '{expected_tag}' was released")
         release = get_release_by_tag(secrets, expected_tag)
         logger.info(f"Released '{expected_tag}' successfully")
 

--- a/tests/functional/test_chart_tar_without_report.py
+++ b/tests/functional/test_chart_tar_without_report.py
@@ -313,8 +313,9 @@ def the_index_yaml_is_updated_with_a_new_entry(secrets):
 def the_release_is_published(secrets):
     """a release is published with the chart"""
 
-    expected_tag = f'{secrets.vendor}-{secrets.chart_name}-{secrets.chart_version}-test-pr{secrets.pr_number}'
+    expected_tag = f'{secrets.vendor}-{secrets.chart_name}-{secrets.chart_version}'
     try:
+        logger.info(f"Checking '{expected_tag}' was released")
         release = get_release_by_tag(secrets, expected_tag)
         logger.info(f"Released '{expected_tag}' successfully")
 

--- a/tests/functional/test_submitted_charts.py
+++ b/tests/functional/test_submitted_charts.py
@@ -411,8 +411,9 @@ def submission_tests_run_for_submitted_charts(secrets):
             repo.git.branch('-D', f'{base_branch}-gh-pages')
 
             # Check release is published
-            expected_tag = f'{vendor_name}-{chart_name}-{chart_version}-test-pr{pr_number}'
+            expected_tag = f'{vendor_name}-{chart_name}-{chart_version}'
             try:
+                logger.info(f"Checking '{expected_tag}' was released")
                 release = get_release_by_tag(secrets, expected_tag)
                 logger.info(f"Released '{expected_tag}' successfully")
 


### PR DESCRIPTION
Expected tag does not match actual tags used for releases