### PR TITLE
revert: charts/pull/294

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,31 +54,12 @@ jobs:
             echo "::set-output name=run-build::true"
           fi
 
-      - name: Add 'test' label to PR
-        id: set_test_label
-        if: |
-          github.event.pull_request.user.login == 'openshift-helm-charts-bot'
-        uses: actions/github-script@v3
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const issue_number = ${{ github.event.number }};
-            github.issues.addLabels({
-                issue_number: Number(issue_number),
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                labels: ['test']
-            })
-            core.setOutput('triggered_by_test', 'true');
-
       - name: Sanity Check PR Content
         id: sanity_check_pr_content
         if: ${{ steps.check_build_required.outputs.run-build == 'true' }}
         continue-on-error: true
         env:
           GITHUB_REF: ${{ github.ref }}
-          TRIGGERED_BY_TEST: ${{ steps.set_test_label.outputs.triggered_by_test }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           INDEX_BRANCH=$(if [ "${GITHUB_REF}" = "refs/heads/main" ]; then echo "refs/heads/gh-pages"; else echo "${GITHUB_REF}-gh-pages"; fi)
            ./ve1/bin/sanity-check-pr --index-branch=${INDEX_BRANCH} --repository=${{ github.repository }} --api-url=${{ github.event.pull_request._links.self.href }}
@@ -287,8 +268,6 @@ jobs:
           CHART_ENTRY_NAME: ${{ steps.sanity_check_pr_content.outputs.chart-entry-name }}
           CHART_NAME_WITH_VERSION: ${{ steps.sanity_check_pr_content.outputs.chart-name-with-version }}
           REDHAT_TO_COMMUNITY: ${{ steps.verify_pr.outputs.redhat_to_community }}
-          TRIGGERED_BY_TEST: ${{ steps.set_test_label.outputs.triggered_by_test }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
         id: release-charts
         run: |
           curl -L -o cr.tar.gz https://github.com/helm/chart-releaser/releases/download/v1.2.0/chart-releaser_1.2.0_linux_amd64.tar.gz

--- a/scripts/src/chartrepomanager/chartrepomanager.py
+++ b/scripts/src/chartrepomanager/chartrepomanager.py
@@ -102,11 +102,7 @@ def push_chart_release(repository, organization, commit_hash):
     org, repo = repository.split("/")
     token = os.environ.get("GITHUB_TOKEN")
     print("[INFO] Upload chart using the chart-releaser")
-    release_name_template = f"{organization}-"+"{{ .Name }}-{{ .Version }}"
-    if os.environ.get('TRIGGERED_BY_TEST') == 'true':
-        pr_number = os.environ.get("PR_NUMBER")
-        release_name_template += f'-test-pr{pr_number}'
-    out = subprocess.run(["cr", "upload", "-c", commit_hash, "-o", org, "-r", repo, "--release-name-template", release_name_template, "-t", token], capture_output=True)
+    out = subprocess.run(["cr", "upload", "-c", commit_hash, "-o", org, "-r", repo, "--release-name-template", f"{organization}-"+"{{ .Name }}-{{ .Version }}", "-t", token], capture_output=True)
     print(out.stdout.decode("utf-8"))
     print(out.stderr.decode("utf-8"))
 
@@ -370,9 +366,6 @@ def main():
         print("[INFO] Updating chart annotation")
         update_chart_annotation(category, organization, chart_file_name, chart, report_path)
         chart_url = f"https://github.com/{args.repository}/releases/download/{organization}-{chart}-{version}/{organization}-{chart}-{version}.tgz"
-        if os.environ.get('TRIGGERED_BY_TEST') == 'true':
-            pr_number = os.environ.get("PR_NUMBER")
-            chart_url = f"https://github.com/{args.repository}/releases/download/{organization}-{chart}-{version}-test-pr{pr_number}/{organization}-{chart}-{version}.tgz"
         print("[INFO] Helm package was released at %s" % chart_url)
         print("[INFO] Creating index from chart")
         chart_entry = create_index_from_chart(indexdir, args.repository, branch, category, organization, chart, version, chart_url)

--- a/scripts/src/sanitycheckpr/sanitycheckpr.py
+++ b/scripts/src/sanitycheckpr/sanitycheckpr.py
@@ -111,10 +111,6 @@ def ensure_only_chart_is_modified(api_url, repository, branch):
                 sys.exit(1)
 
         tag_name = f"{organization}-{chart}-{version}"
-        if os.environ.get('TRIGGERED_BY_TEST') == 'true':
-            pr_number = os.environ.get("PR_NUMBER")
-            tag_name += f'-test-pr{pr_number}'
-
         print(f"::set-output name=chart-name-with-version::{tag_name}")
         tag_api = f"https://api.github.com/repos/{repository}/git/ref/tags/{tag_name}"
         headers = {'Accept': 'application/vnd.github.v3+json'}

--- a/tests/functional/test_chart_src_with_report.py
+++ b/tests/functional/test_chart_src_with_report.py
@@ -321,7 +321,7 @@ def the_index_yaml_is_updated_with_a_new_entry(secrets):
 def the_release_is_published(secrets):
     """a release is published with the chart"""
 
-    expected_tag = f'{secrets.vendor}-{secrets.chart_name}-{secrets.chart_version}-test-pr{secrets.pr_number}'
+    expected_tag = f'{secrets.vendor}-{secrets.chart_name}-{secrets.chart_version}'
     try:
         release = get_release_by_tag(secrets, expected_tag)
         logger.info(f"Released '{expected_tag}' successfully")

--- a/tests/functional/test_chart_src_without_report.py
+++ b/tests/functional/test_chart_src_without_report.py
@@ -311,7 +311,7 @@ def the_index_yaml_is_updated_with_a_new_entry(secrets):
 def the_release_is_published(secrets):
     """a release is published with the chart"""
 
-    expected_tag = f'{secrets.vendor}-{secrets.chart_name}-{secrets.chart_version}-test-pr{secrets.pr_number}'
+    expected_tag = f'{secrets.vendor}-{secrets.chart_name}-{secrets.chart_version}'
     try:
         release = get_release_by_tag(secrets, expected_tag)
         logger.info(f"Released '{expected_tag}' successfully")

--- a/tests/functional/test_chart_tar_with_report.py
+++ b/tests/functional/test_chart_tar_with_report.py
@@ -322,7 +322,7 @@ def the_index_yaml_is_updated_with_a_new_entry(secrets):
 def the_release_is_published(secrets):
     """a release is published with the chart"""
 
-    expected_tag = f'{secrets.vendor}-{secrets.chart_name}-{secrets.chart_version}-test-pr{secrets.pr_number}'
+    expected_tag = f'{secrets.vendor}-{secrets.chart_name}-{secrets.chart_version}'
     try:
         release = get_release_by_tag(secrets, expected_tag)
         logger.info(f"Released '{expected_tag}' successfully")

--- a/tests/functional/test_chart_tar_without_report.py
+++ b/tests/functional/test_chart_tar_without_report.py
@@ -313,7 +313,7 @@ def the_index_yaml_is_updated_with_a_new_entry(secrets):
 def the_release_is_published(secrets):
     """a release is published with the chart"""
 
-    expected_tag = f'{secrets.vendor}-{secrets.chart_name}-{secrets.chart_version}-test-pr{secrets.pr_number}'
+    expected_tag = f'{secrets.vendor}-{secrets.chart_name}-{secrets.chart_version}'
     try:
         release = get_release_by_tag(secrets, expected_tag)
         logger.info(f"Released '{expected_tag}' successfully")

--- a/tests/functional/test_submitted_charts.py
+++ b/tests/functional/test_submitted_charts.py
@@ -411,7 +411,7 @@ def submission_tests_run_for_submitted_charts(secrets):
             repo.git.branch('-D', f'{base_branch}-gh-pages')
 
             # Check release is published
-            expected_tag = f'{vendor_name}-{chart_name}-{chart_version}-test-pr{pr_number}'
+            expected_tag = f'{vendor_name}-{chart_name}-{chart_version}'
             try:
                 release = get_release_by_tag(secrets, expected_tag)
                 logger.info(f"Released '{expected_tag}' successfully")


### PR DESCRIPTION
This commit reverts changes introduced in
https://github.com/openshift-helm-charts/charts/pull/294 because we
don't want to add test logic to `scripts/` and a more test specific fix
was implemented: https://github.com/openshift-helm-charts/development/commit/54ba09ae7b8fc4d032e582990e9e9bcf15a03b56

Closes: https://issues.redhat.com/browse/HELM-233
Signed-off-by: Allen Bai <abai@redhat.com>