### PR TITLE
Dev pr for auto release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,12 +36,25 @@ jobs:
           echo "[INFO] check if PR contains only workflow changes and user is authorized"
           ve1/bin/check-pr-for-ci --verify-user=${{ github.event.pull_request.user.login }} --api-url=${{ github.event.pull_request._links.self.href }}
 
+      - name: Check if PR created as part of release process
+        id: check_created_release_pr
+        if: ${{ steps.check_ci_changes.outputs.run-tests != true }}
+        env:
+          BOT_NAME: ${{ secrets.BOT_NAME }}
+        run: |
+          # check if PR was created as part of release processing
+          ./ve1/bin/release-checker --api-url=${{ github.event.pull_request._links.self.href }} \
+                                    --sender='${{ github.event.sender.login }}' \
+                                    --pr_branch='${{ github.event.pull_request.head.ref }}' \
+                                    --pr_body='${{ github.event.pull_request.body }}'
+
       - name: Exit if build not required
         id: check_build_required
         env:
           RUN_TESTS: ${{ steps.check_ci_changes.outputs.run-tests }}
           NOT_CI_AUTHORIZED: ${{ steps.check_ci_changes.outputs.workflow-only-but-not-authorized }}
           NO_CODE_TO_BUILD: ${{ steps.check_ci_changes.outputs.do-not-build }}
+          DEV_PR_FOR_RELEASE: ${{ steps.check_created_release_pr.outputs.dev_release_branch }}
         run: |
           # exit if build not required
           if [ ${RUN_TESTS} == "true" ] || [ ${NOT_CI_AUTHORIZED} == "true" ]; then
@@ -50,6 +63,8 @@ jobs:
           elif [ ${NO_CODE_TO_BUILD} == "true" ]; then
              echo "The PR does not contain changes which need build or test."
              exit 0
+          elif [ ${DEV_PR_FOR_RELEASE} == "true" ]; then
+              echo "The PR is part of release processing for the devleopmnet branch - do not continue."
           else
             echo "::set-output name=run-build::true"
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,20 +24,6 @@ jobs:
           token: ${{ secrets.BOT_TOKEN }}
           path: "pr-branch"
 
-      - name: Checkout charts repo
-        uses: actions/checkout@v2
-        with:
-          repository: ${{ env.REPOSITORY_ORGANIZATION }}/charts
-          token: ${{ secrets.BOT_TOKEN }}
-          path: "charts-repo"
-
-      - name: Checkout development repo
-        uses: actions/checkout@v2
-        with:
-          repository: ${{ env.REPOSITORY_ORGANIZATION }}/development
-          token: ${{ secrets.BOT_TOKEN }}
-          path: "dev-repo"
-
       - name: Set up Python 3.x Part 1
         uses: actions/setup-python@v2
         with:
@@ -52,15 +38,69 @@ jobs:
           cd scripts && ../ve1/bin/pip3 install -r requirements.txt && cd ..
           cd scripts && ../ve1/bin/python3 setup.py install && cd ..
 
-      - name: Check if only release file in PR
-        id: check_version_in_PR
+      - name: Check if only release file in PR and if user is authorized
+        id: check_only_version_in_PR_and_authorized
         working-directory: ./pr-branch
         run: |
-          # check if release file only is included in PR
-          ve1/bin/release-checker --api-url=${{ github.event.pull_request._links.self.href }}
+          # check if release file only is included in PR and if so that user is authorized.
+          ./ve1/bin/release-checker --api-url=${{ github.event.pull_request._links.self.href }} \
+                                  --sender=${{ github.event.sender.login }}
+
+      - name: Check if PR created as part of release process
+        id: check_created_release_pr
+        working-directory: ./pr-branch
+        if: ${{ steps.check_only_version_in_PR_and_authorized.outputs.PR_includes_release_only != 'true' }}
+        env:
+          BOT_NAME: ${{ secrets.BOT_NAME }}
+        run: |
+          # check if PR was created as part of release processing
+          ./ve1/bin/release-checker --api-url=${{ github.event.pull_request._links.self.href }} \
+                                  --sender='${{ github.event.sender.login }}' \
+                                  --pr_branch='${{ github.event.pull_request.head.ref }}' \
+                                  --pr_body='${{ github.event.pull_request.body }}'
+
+      - name: Reflect on PR Content
+        id: reflect_on_pr_content
+        env:
+          RELEASE_INFO_ONLY: ${{ steps.check_only_version_in_PR_and_authorized.outputs.PR_includes_release_only }}
+          NOT_AUTHORIZED: ${{ steps.check_only_version_in_PR_and_authorized.outputs.sender_not_authorized }}
+          DEV_PR_FOR_RELEASE: ${{ steps.check_created_release_pr.outputs.dev_release_branch }}
+        run: |
+          # Determine if and how processing should continue'
+          if [ ${NOT_AUTHORIZED} = 'true' ]; then
+              echo "Unauthorized Request"
+              exit 1
+          elif [ ${RELEASE_INFO_ONLY} == 'true' ]; then
+             echo "PR contains only release_info file"
+             echo '::set-output name=create_pull_requests::true'
+          elif [ ${DEV_PR_FOR_RELEASE} != 'true' ]; then
+             echo "No release work to do"
+             exit
+          fi
+
+      - name: Checkout charts repo
+        if: ${{ steps.reflect_on_pr_content.outputs.create_pull_requests == 'true' }}
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ env.REPOSITORY_ORGANIZATION }}/charts
+          token: ${{ secrets.BOT_TOKEN }}
+          path: "charts-repo"
+
+      - name: Checkout development repo
+        if: ${{ steps.reflect_on_pr_content.outputs.create_pull_requests == 'true' }}
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ env.REPOSITORY_ORGANIZATION }}/development
+          token: ${{ secrets.BOT_TOKEN }}
+          path: "dev-repo"
+
+      - name: Set up Python 3.x Part 1
+        if: ${{ steps.reflect_on_pr_content.outputs.create_pull_requests == 'true' }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.9"
 
       - name: Set up Python scripts on main branch
-        if: ${{ steps.check_version_in_PR.outputs.PR_includes_release == 'true' }}
         run: |
           # set up python scripts
           echo "set up python script in $PWD"
@@ -68,41 +108,70 @@ jobs:
           cd scripts && ../ve1/bin/pip3 install -r requirements.txt && cd ..
           cd scripts && ../ve1/bin/python3 setup.py install && cd ..
 
-      - name: Check for restricted files and user permissiom
-        id: check_authorization
-        if: ${{ steps.check_version_in_PR.outputs.PR_includes_release == 'true' }}
-        run: |
-          # check for a restricted file and, if found, check user has permissiom
-          ve1/bin/check-user --api-url=${{ github.event.pull_request._links.self.href }} --user=${{ github.event.pull_request.user.login }}
-
       - name: Check if version updated
         id: check_version_updated
-        if: ${{ steps.check_version_in_PR.outputs.PR_includes_release == 'true' }}
+        if: ${{ steps.reflect_on_pr_content.outputs.create_pull_requests == 'true' }}
         run: |
           # check if version file was changed
-          ve1/bin/release-checker --version=${{ steps.check_version_in_PR.outputs.PR_version }}
+          ./ve1/bin/release-checker --version=${{ steps.check_only_version_in_PR_and_authorized.outputs.PR_version }}
 
       - name: Sync the repositories
         id: sync_repositories
-        if: ${{ steps.check_version_in_PR.outputs.PR_includes_release == 'true' }}
+        if: ${{ steps.check_version_updated.outputs.release_updated == 'true' }}
         env:
           BOT_NAME: ${{ secrets.BOT_NAME }}
           BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
-          PR_BODY: ${{ steps.check_version_in_PR.outputs.PR_release_body }}
         run: |
           # sync the repositories
-          ve1/bin/releaser --version=${{ steps.check_version_in_PR.outputs.PR_version }} --pr_dir="./pr-branch" --development_dir="./dev-repo" --charts_dir="./charts-repo"
+          ./ve1/bin/releaser --version=${{ steps.check_only_version_in_PR_and_authorized.outputs.PR_version }}\
+                             --pr_dir="./pr-branch" \
+                             --development_dir="./dev-repo" \
+                             --charts_dir="./charts-repo" \
+                             --dev_pr_body="${{ steps.check_only_version_in_PR_and_authorized.outputs.PR_release_body }}"
+
+      - name: Determine if merge and release are needed
+        id: check_merge_and_release
+        env:
+          REPOSITORIES_SYNCED: ${{ steps.check_version_updated.outputs.release_updated }}
+          CHART_PR_ERROR: ${{ steps.sync_repositories.outputs.charts_pr_error }}
+          DEV_PR_ERROR: ${{ steps.sync_repositories.outputs.dev_pr_error }}
+          DEV_PR_NOT_NEEDED: ${{ steps.sync_repositories.outputs.dev_pr_not_needed }}
+          DEV_PR_FOR_RELEASE: ${{ steps.check_created_release_pr.outputs.dev_release_branch }}
+        run: |
+          # determine what should be done next
+          if [ ${REPOSITORIES_SYNCED} == 'true' ]; then
+              if [ ${CHART_PR_ERROR} == 'true' ]; then
+                  echo "Error creating charts pull request"
+                  exit 1
+              elif [ ${DEV_PR_ERROR} == 'true' ]; then
+                  echo "Error creating development pull request"
+                  exit 1
+              else
+                  echo "At least one PR was created - merge this one"
+                  echo '::set-output name=merge::true'
+              fi
+              if [ ${DEV_PR_NOT_NEEDED} = 'true' ]; then
+                  echo "No dev PR so create release"
+                  echo '::set-output name=release_body::${{ steps.check_only_version_in_PR_and_authorized.outputs.PR_release_body }}'
+                  echo '::set-output name=release_tag::${{ steps.check_only_version_in_PR_and_authorized.outputs.PR_version }}'
+              fi
+          elif [ ${DEV_PR_FOR_RELEASE} = 'true' ]; then
+              echo "Dev PR so create release"
+              echo '::set-output name=merge::true'
+              echo '::set-output name=release_body::${{ github.event.pull_request.body }}'
+              echo '::set-output name=release_tag::${{ steps.check_created_release_pr.outputs.PR_version }}'
+          fi
 
       - name: Approve PR
         id: approve_pr
-        if: ${{ steps.check_version_updated.outputs.updated == 'true'}}
+        if: ${{ steps.check_merge_and_release.outputs.merge == 'true' }}
         uses: hmarr/auto-approve-action@v2
         with:
           github-token:  ${{ secrets.GITHUB_TOKEN }}
 
       - name: Merge PR
         id: merge_pr
-        if: ${{ steps.check_version_updated.outputs.updated == 'true'}}
+        if: ${{ steps.check_merge_and_release.outputs.merge == 'true' }}
         uses: pascalgn/automerge-action@v0.13.1
         env:
           GITHUB_TOKEN:  ${{ secrets.GITHUB_TOKEN }}
@@ -110,18 +179,16 @@ jobs:
           MERGE_LABELS: ""
 
       - name: Check for PR merge
-        if: ${{ steps.check_version_updated.outputs.updated == 'true'}}
+        if: ${{ steps.check_merge_and_release.outputs.merge == 'true' }}
         run: |
-          ve1/bin/check-auto-merge --api-url=${{ github.event.pull_request._links.self.href }}
+          ./ve1/bin/check-auto-merge --api-url=${{ github.event.pull_request._links.self.href }}
 
       - name: Create the the release
         id: create_release
-        if: ${{ steps.check_version_updated.outputs.updated == 'true'}}
+        if: ${{ steps.check_merge_and_release.outputs.release_tag  != '' }}
         uses: softprops/action-gh-release@v1
         with:
-          tag_name: ${{ steps.check_version_in_PR.outputs.PR_version }}
-          body: ${{ steps.check_version_in_PR.outputs.PR_release_body }}
+          tag_name: ${{ steps.check_merge_and_release.outputs.release_tag }}
+          body: ${{ steps.check_merge_and_release.outputs.release_body }}
         env:
           GITHUB_TOKEN:  ${{ secrets.GITHUB_TOKEN }}
-
-

--- a/README.md
+++ b/README.md
@@ -16,13 +16,15 @@ To start the proecess:
      - ignores : a directory or files which is part of the merge or replace but should be excluded. This also covers deleted files.
    - For example, release/release_info.json for the charts repository specifies a merge of the charts directory. This means the charts of the charts repository will be merged into the same directory in the development repository. This effectively updates the development repository with the charts which were added since that last release.
    - For example, release/release_info.json for the development repository specifies a replace of the scripts directory. This means the scripts directory will be deleted from the charts repository and replaced with the scripts directory and its contents from the development repository.
-   - For example, release/release_info.json for the development repository specifies an ignore of the scripts/src/release directory. This means after copying the entire content of the scripts to the charts repository the specific directory will then be removed. 
-1. Create a Pull Request against the development repository contaning only the release/release_info.json. The relase workflow then:
+   - For example, release/release_info.json for the development repository specifies an ignore of the .github/workflows/release.yml file. This means after copying the entire content of the .github directory to the charts repository the specific file will then be removed. 
+1. Create a Pull Request against the development repository containing only the release/release_info.json. The release workflow then:
     1. Clones the development and charts repositories.
-    1. Updates each the repositories based on the content of the release/release_info.json.
+    1. Updates each of the repositories based on the content of the release/release_info.json.
     1. Creates a pull request against the chart repository containing workflow updates from the development repository.
         - This PR will need to be manually merged once all tests are finished and clean.
-    1. Creates and pushes a commit to the main branch of the development repository. The branch contains chart updates from the chart repository.
-        - It is expected that the time between cloning the repository and pushing the commit to main will be short enough to prevent overwriting other merged changes.
-    1. Assuming all is good, auto-merges the release/release_info.json pull request, and then creates a release and tag for the release in the development repository.
+    1. Creates a pull request against the development repository containing chart updates from the chart repository.
+        - This PR will be auto-merged in subsequent steps.
+    1. Assuming all is good, auto-merges the release/release_info.json pull request.
+        - Also creates a release if the development repository pull request is not required.
+    1. Detects the incoming pull request against the development repository, merges it and creates a release. 
 

--- a/scripts/src/github/gitutils.py
+++ b/scripts/src/github/gitutils.py
@@ -22,6 +22,10 @@ GITHUB_BASE_URL = 'https://api.github.com'
 CHARTS_REPO = f"{os.environ.get('REPOSITORY_ORGANIZATION')}/charts"
 DEVELOPMENT_REPO = f"{os.environ.get('REPOSITORY_ORGANIZATION')}/development"
 
+PR_CREATED = "PR_CREATED"
+PR_NOT_NEEDED = "PR_NOT_NEEDED"
+PR_FAILED = "PR_FAILED"
+
 # GitHub actions bot email for git email
 GITHUB_ACTIONS_BOT_EMAIL = '41898282+github-actions[bot]@users.noreply.github.com'
 
@@ -71,60 +75,45 @@ def get_bot_name_and_token():
     return bot_name, bot_token
 
 
-def create_charts_pr(version):
+def create_pr(branch_name,skip_files,repository,message):
 
     repo = Repo(os.getcwd())
 
     bot_name, bot_token = get_bot_name_and_token()
     set_git_username_email(repo,bot_name,GITHUB_ACTIONS_BOT_EMAIL)
 
-    branch_name = f"Release-{version}"
     repo.create_head(branch_name)
     print(f"checkout branch {branch_name}")
     repo.git.checkout(branch_name)
 
-    if add_changes(repo,[]):
+    if add_changes(repo,skip_files):
 
         print(f"commit changes with message: {branch_name}")
         repo.index.commit(branch_name)
 
-        print(f"push the branch to {CHARTS_REPO}")
-        repo.git.push(f'https://x-access-token:{bot_token}@github.com/{CHARTS_REPO}',
+        print(f"push the branch to {repo}")
+        repo.git.push(f'https://x-access-token:{bot_token}@github.com/{repository}',
                    f'HEAD:refs/heads/{branch_name}','-f')
 
         print("make the pull request")
         data = {'head': branch_name, 'base': 'main',
-                'title': branch_name, 'body': f'Workflow and script updates from development repository {branch_name}'}
+                'title': branch_name, 'body': f'{message}'}
 
         r = github_api(
-            'post', f'repos/{CHARTS_REPO}/pulls', bot_token, json=data)
+            'post', f'repos/{repository}/pulls', bot_token, json=data)
 
         j = json.loads(r.text)
-        print(f"pull request info: {j['number']}")
+        if 'number' in j:
+            print(f"pull request info: {j['number']}")
+            return PR_CREATED
+        else:
+            print(f"Unexpected response from PR. status code: {r.status_code}, text: {j}")
+            return PR_FAILED
+
     else:
-        print(f"no changes required for {CHARTS_REPO}")
+        print(f"no changes required for {repository}")
+        return PR_NOT_NEEDED
 
-
-
-def commit_development_updates(version,skip_files):
-
-    repo = Repo(os.getcwd())
-
-    print("checkout main")
-    repo.git.checkout("main")
-
-    if add_changes(repo,skip_files):
-
-        print(f"commit changes with message: Version-{version} Update charts from chart repository")
-        repo.index.commit(f"Version-{version} Update charts from chart repository")
-
-        print(f"push the branch to {DEVELOPMENT_REPO}")
-        bot_name, bot_token = get_bot_name_and_token()
-
-        repo.git.push(f'https://x-access-token:{bot_token}@github.com/{DEVELOPMENT_REPO}',
-                  f'HEAD:refs/heads/main', '-f')
-    else:
-        print(f"no changes required for {DEVELOPMENT_REPO}")
 
 
 def add_changes(repo,skip_files):

--- a/scripts/src/owners/checkuser.py
+++ b/scripts/src/owners/checkuser.py
@@ -83,3 +83,5 @@ def main():
             sys.exit(1)
     else:
         print(f"[INFO] no restricted files found in the PR")
+
+

--- a/scripts/src/release/releasechecker.py
+++ b/scripts/src/release/releasechecker.py
@@ -22,14 +22,50 @@ results:
         PR_release_image : The name of the image from the version file from main branch.
 """
 
+
 import re
+import os
 import argparse
 import json
 import requests
 import semver
+import sys
 from release import release_info
+from release import releaser
+
+sys.path.append('../')
+from owners import checkuser
 
 VERSION_FILE = "release/release_info.json"
+TYPE_MATCH_EXPRESSION = "(partners|redhat|community)"
+
+def check_if_only_charts_are_included(api_url):
+
+    files_api_url = f'{api_url}/files'
+    headers = {'Accept': 'application/vnd.github.v3+json'}
+    chart_pattern = re.compile(r"charts/"+TYPE_MATCH_EXPRESSION+"/([\w-]+)/([\w-]+)/([\w\.-]+)/.*")
+    page_number = 1
+    max_page_size,page_size = 100,100
+    file_count = 0
+
+    while page_size == max_page_size:
+
+        files_api_query = f'{files_api_url}?per_page={page_size}&page={page_number}'
+        print(f"Query files : {files_api_query}")
+        pr_files = requests.get(files_api_query,headers=headers)
+        files = pr_files.json()
+        page_size = len(files)
+        file_count += page_size
+        page_number += 1
+
+        for f in files:
+            file_path = f["filename"]
+            match = chart_pattern.match(file_path)
+            if not match:
+                return False
+
+    return True
+
 
 def check_if_only_version_file_is_modified(api_url):
     # api_url https://api.github.com/repos/<organization-name>/<repository-name>/pulls/<pr_number>
@@ -58,6 +94,29 @@ def check_if_only_version_file_is_modified(api_url):
 
     return version_file_found
 
+def check_if_release_branch(sender,pr_branch,pr_body,api_url):
+
+    if not sender==os.environ.get("BOT_NAME"):
+        print(f"Sender indicates PR is not part of a release: {sender}")
+        return False
+
+    if not pr_branch.startswith(releaser.DEV_PR_BRANCH_NAME_PREFIX):
+        print(f"PR branch indicates PR is not part of a release: {pr_branch}")
+        return False
+
+    version = pr_branch.removeprefix(releaser.DEV_PR_BRANCH_NAME_PREFIX)
+    if not semver.VersionInfo.isvalid(version):
+        print(f"Release part ({version}) of branch name {pr_branch} is not a valid semantic version.")
+        return False
+    
+    if not pr_body.startswith(f"Charts workflow version {version}"):
+        print(f"PR title indicates PR is not part of a release: {pr_body}")
+        return False
+
+    return check_if_only_charts_are_included(api_url)
+
+
+
 def make_release_body(version, release_info):
     body = f"Charts workflow version {version} <br><br>"
     body += "This version includes:<br>"
@@ -79,28 +138,51 @@ def main():
                         help="API URL for the pull request")
     parser.add_argument("-v", "--version", dest="version", type=str, required=False,
                         help="Version to compare")
+    parser.add_argument("-s", "--sender", dest="sender", type=str, required=False,
+                        help="sender of the PR")
+    parser.add_argument("-b", "--pr_branch", dest="pr_branch", type=str, required=False,
+                        help="PR branch name")
+    parser.add_argument("-t", "--pr_body", dest="pr_body", type=str, required=False,
+                        help="PR title")
 
     args = parser.parse_args()
-    if args.api_url and check_if_only_version_file_is_modified(args.api_url):
-        ## should be on PR branch
-        version = release_info.get_version("./")
-        version_info = release_info.get_info("./")
-        print(f'[INFO] Release found in PR files : {version}.')
+
+    print(f"[INFO] arg api-url : {args.api_url}")
+    print(f"[INFO] arg version : {args.version}")
+    print(f"[INFO] arg sender : {args.sender}")
+    print(f"[INFO] arg pr_branch : {args.pr_branch}")
+    print(f"[INFO] arg pr_body : {args.pr_body}")
+
+    if args.pr_branch and check_if_release_branch(args.sender,args.pr_branch,args.pr_body,args.api_url):
+        print('[INFO] Dev release pull request found')
+        print(f'::set-output name=dev_release_branch::true')
+        version = args.pr_branch.removeprefix(releaser.DEV_PR_BRANCH_NAME_PREFIX)
         print(f'::set-output name=PR_version::{version}')
-        print(f'::set-output name=PR_release_info::{version_info}')
-        print(f'::set-output name=PR_includes_release::true')
-        make_release_body(version,version_info)
+        print(f"::set-output name=PR_release_body::{args.pr_body}")
+    elif args.api_url:
+        ## should be on PR branch
+        version_only = check_if_only_version_file_is_modified(args.api_url)
+        user_authorized = checkuser.verify_user(args.sender)
+        if version_only and user_authorized:
+            version = release_info.get_version("./")
+            version_info = release_info.get_info("./")
+            print(f'[INFO] Release found in PR files : {version}.')
+            print(f'::set-output name=PR_version::{version}')
+            print(f'::set-output name=PR_release_info::{version_info}')
+            print(f'::set-output name=PR_includes_release_only::true')
+            make_release_body(version,version_info)
+        elif not user_authorized:
+            print(f'[ERROR] sender not authorized : {args.sender}.')
+            print(f'::set-output name=sender_not_authorized::true')
     else:
         version = release_info.get_version("./")
-        version_info = release_info.get_info("./")
         if args.version:
             # should be on main branch
             if semver.compare(args.version,version) > 0 :
                 print(f'[INFO] Release {args.version} found in PR files is newer than: {version}.')
-                print("::set-output name=updated::true")
+                print(f'::set-output name=release_updated::true')
             else:
-                print(f'[INFO] Release found in PR files is not new  : {version_info}.')
+                print(f'[ERROR] Release found in PR files is not new  : {args.version}.')
         else:
-            print(f'::set-output name=PR_version::{version}')
-            print(f'::set-output name=PR_release_image::{version_info}')
-            print("[INFO] PR contains non-release files.")
+            print(f'[ERROR] no valid parameter set to release checker.')
+


### PR DESCRIPTION
Updated auto-release to create a PR for the chart updates to the development repository. 

This PR will  then be detected and auto-merged. After auto-merge the release is created.

.github/workflows/release.yml contains a lot of changes as it is now dual purpose:
1. Create the PR's 
2. detect the development PR and auto-merge it.  

.github/workflows/build.yml was also updated to ignore the development PR.

I also improved the code to make it better at handling errors form github and to cater for corner cases such as the dev pr being not needed , in which case the release is created as part of release/release.info processing step.

Have fully tested and comfortable it works. 



