### PR TITLE
Enable auto merge of charts pr as part of release processing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,10 +64,10 @@ jobs:
             echo "The PR is workflow changes only - do not continue."
             exit 0
           elif [ ${NO_CODE_TO_BUILD} == "true" ]; then
-             echo "The PR does not contain changes which need build or test."
-             exit 0
+            echo "The PR does not contain changes which need build or test."
+            exit 0
           elif [ ${DEV_PR_FOR_RELEASE} == "true" ]; then
-              echo "The PR is part of release processing for the development repository - do not continue."
+            echo "The PR is part of release processing for the development repository - do not continue."
           elif [ ${CHART_PR_FOR_RELEASE} == "true" ]; then
             echo "The PR is part of release processing for the charts repository - do not continue."
           else

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,9 @@ jobs:
           ./ve1/bin/release-checker --api-url=${{ github.event.pull_request._links.self.href }} \
                                     --sender='${{ github.event.sender.login }}' \
                                     --pr_branch='${{ github.event.pull_request.head.ref }}' \
-                                    --pr_body='${{ github.event.pull_request.body }}'
+                                    --pr_body='${{ github.event.pull_request.body }}' \
+                                    --pr_base_repo='${{ github.event.pull_request.base.repo.full_name }}' \
+                                    --pr_head_repo='${{ github.event.pull_request.head.repo.full_name }}'
 
       - name: Exit if build not required
         id: check_build_required
@@ -55,6 +57,7 @@ jobs:
           NOT_CI_AUTHORIZED: ${{ steps.check_ci_changes.outputs.workflow-only-but-not-authorized }}
           NO_CODE_TO_BUILD: ${{ steps.check_ci_changes.outputs.do-not-build }}
           DEV_PR_FOR_RELEASE: ${{ steps.check_created_release_pr.outputs.dev_release_branch }}
+          CHARTS_PR_FOR_RELEASE: ${{ steps.check_created_release_pr.outputs.charts_release_branch }}
         run: |
           # exit if build not required
           if [ ${RUN_TESTS} == "true" ] || [ ${NOT_CI_AUTHORIZED} == "true" ]; then
@@ -64,7 +67,9 @@ jobs:
              echo "The PR does not contain changes which need build or test."
              exit 0
           elif [ ${DEV_PR_FOR_RELEASE} == "true" ]; then
-              echo "The PR is part of release processing for the devleopmnet branch - do not continue."
+              echo "The PR is part of release processing for the development repository - do not continue."
+          elif [ ${CHART_PR_FOR_RELEASE} == "true" ]; then
+            echo "The PR is part of release processing for the charts repository - do not continue."
           else
             echo "::set-output name=run-build::true"
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,8 +8,6 @@ jobs:
   chart-workflow-release:
     name: Chart Workflow Release
     runs-on: ubuntu-20.04
-    env:
-      REPOSITORY_ORGANIZATION: openshift-helm-charts
     if: |
       github.event.pull_request.draft == false
     steps:
@@ -38,13 +36,14 @@ jobs:
           cd scripts && ../ve1/bin/pip3 install -r requirements.txt && cd ..
           cd scripts && ../ve1/bin/python3 setup.py install && cd ..
 
-      - name: Check if only release file in PR and if user is authorized
+      - name: Check if dev repo is targetted, only release file is in PR and user is authorized
         id: check_only_version_in_PR_and_authorized
         working-directory: ./pr-branch
         run: |
-          # check if release file only is included in PR and if so that user is authorized.
+          # if dev repo is targetted check if release file only is included in PR and if so that user is authorized.
           ./ve1/bin/release-checker --api-url=${{ github.event.pull_request._links.self.href }} \
-                                  --sender=${{ github.event.sender.login }}
+                                  --sender=${{ github.event.sender.login }} \
+                                  --pr_base_repo='${{ github.event.pull_request.base.repo.full_name }}'
 
       - name: Check if PR created as part of release process
         id: check_created_release_pr
@@ -57,7 +56,9 @@ jobs:
           ./ve1/bin/release-checker --api-url=${{ github.event.pull_request._links.self.href }} \
                                   --sender='${{ github.event.sender.login }}' \
                                   --pr_branch='${{ github.event.pull_request.head.ref }}' \
-                                  --pr_body='${{ github.event.pull_request.body }}'
+                                  --pr_body='${{ github.event.pull_request.body }}' \
+                                  --pr_base_repo='${{ github.event.pull_request.base.repo.full_name }}' \
+                                  --pr_head_repo='${{ github.event.pull_request.head.repo.full_name }}'
 
       - name: Reflect on PR Content
         id: reflect_on_pr_content
@@ -67,7 +68,7 @@ jobs:
           DEV_PR_FOR_RELEASE: ${{ steps.check_created_release_pr.outputs.dev_release_branch }}
         run: |
           # Determine if and how processing should continue'
-          if [ ${NOT_AUTHORIZED} = 'true' ]; then
+          if [ ${NOT_AUTHORIZED} == 'true' ]; then
               echo "Unauthorized Request"
               exit 1
           elif [ ${RELEASE_INFO_ONLY} == 'true' ]; then
@@ -82,7 +83,8 @@ jobs:
         if: ${{ steps.reflect_on_pr_content.outputs.create_pull_requests == 'true' }}
         uses: actions/checkout@v2
         with:
-          repository: ${{ env.REPOSITORY_ORGANIZATION }}/charts
+          ref: ${{ github.event.pull_request.base.ref }}
+          repository: ${{ steps.check_only_version_in_PR_and_authorized.outputs.charts_repo }}
           token: ${{ secrets.BOT_TOKEN }}
           path: "charts-repo"
 
@@ -90,7 +92,8 @@ jobs:
         if: ${{ steps.reflect_on_pr_content.outputs.create_pull_requests == 'true' }}
         uses: actions/checkout@v2
         with:
-          repository: ${{ env.REPOSITORY_ORGANIZATION }}/development
+          ref: ${{ github.event.pull_request.base.ref }}
+          repository: ${{ github.event.pull_request.base.repo.full_name }}
           token: ${{ secrets.BOT_TOKEN }}
           path: "dev-repo"
 
@@ -100,7 +103,7 @@ jobs:
         with:
           python-version: "3.9"
 
-      - name: Set up Python scripts on main branch
+      - name: Set up Python scripts on dev branch
         run: |
           # set up python scripts
           echo "set up python script in $PWD"
@@ -127,7 +130,9 @@ jobs:
                              --pr_dir="./pr-branch" \
                              --development_dir="./dev-repo" \
                              --charts_dir="./charts-repo" \
-                             --dev_pr_body="${{ steps.check_only_version_in_PR_and_authorized.outputs.PR_release_body }}"
+                             --dev_pr_body="${{ steps.check_only_version_in_PR_and_authorized.outputs.PR_release_body }}" \
+                             --target_branch="${{ github.event.pull_request.base.ref }}" \
+                             --target_repository="${{ github.event.pull_request.base.repo.full_name }}"
 
       - name: Determine if merge and release are needed
         id: check_merge_and_release
@@ -150,12 +155,12 @@ jobs:
                   echo "At least one PR was created - merge this one"
                   echo '::set-output name=merge::true'
               fi
-              if [ ${DEV_PR_NOT_NEEDED} = 'true' ]; then
+              if [ ${DEV_PR_NOT_NEEDED} == 'true' ]; then
                   echo "No dev PR so create release"
                   echo '::set-output name=release_body::${{ steps.check_only_version_in_PR_and_authorized.outputs.PR_release_body }}'
                   echo '::set-output name=release_tag::${{ steps.check_only_version_in_PR_and_authorized.outputs.PR_version }}'
               fi
-          elif [ ${DEV_PR_FOR_RELEASE} = 'true' ]; then
+          elif [ ${DEV_PR_FOR_RELEASE} == 'true' ]; then
               echo "Dev PR so create release"
               echo '::set-output name=merge::true'
               echo '::set-output name=release_body::${{ github.event.pull_request.body }}'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,3 +104,34 @@ jobs:
           echo "[INFO] Software Name '${{ env.SOFTWARE_NAME }}'"
           echo "[INFO] Software Version '${{ env.SOFTWARE_VERSION }}'"
           ve1/bin/pytest tests/functional/test_submitted_charts.py --log-cli-level=WARNING --tb=short
+
+      - name: (PR) check for relase flow
+        id: check_if_release_pr
+        if: |
+          github.event_name == 'pull_request_target' && steps.check_request.outputs.run-tests == 'true'
+        run: |
+          # check if PR was created as part of release processing
+          ./ve1/bin/release-checker --api-url=${{ github.event.pull_request._links.self.href }} \
+                                --sender='${{ github.event.sender.login }}' \
+                                --pr_branch='${{ github.event.pull_request.head.ref }}' \
+                                --pr_body='${{ github.event.pull_request.body }}' \
+                                --pr_base_repo='${{ github.event.pull_request.base.repo.full_name }}' \
+                                --pr_head_repo='${{ github.event.pull_request.head.repo.full_name }}'
+
+      - name: Approve PR
+        id: approve_pr
+        if: ${{ steps.check_if_release_pr.outputs.charts_release_branch == 'true' }}
+        uses: hmarr/auto-approve-action@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Merge PR
+        id: merge_pr
+        if: ${{ steps.check_if_release_pr.outputs.charts_release_branch == 'true' }}
+        uses: pascalgn/automerge-action@v0.13.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MERGE_METHOD: squash
+          MERGE_LABELS: ""
+
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,10 +105,12 @@ jobs:
           echo "[INFO] Software Version '${{ env.SOFTWARE_VERSION }}'"
           ve1/bin/pytest tests/functional/test_submitted_charts.py --log-cli-level=WARNING --tb=short
 
-      - name: (PR) check for relase flow
+      - name: (PR) check for release flow
         id: check_if_release_pr
         if: |
           github.event_name == 'pull_request_target' && steps.check_request.outputs.run-tests == 'true'
+        env:
+          BOT_NAME: ${{ secrets.BOT_NAME }}
         run: |
           # check if PR was created as part of release processing
           ./ve1/bin/release-checker --api-url=${{ github.event.pull_request._links.self.href }} \

--- a/scripts/src/github/gitutils.py
+++ b/scripts/src/github/gitutils.py
@@ -19,8 +19,8 @@ from git import Repo
 from git.exc import GitCommandError
 
 GITHUB_BASE_URL = 'https://api.github.com'
-CHARTS_REPO = f"{os.environ.get('REPOSITORY_ORGANIZATION')}/charts"
-DEVELOPMENT_REPO = f"{os.environ.get('REPOSITORY_ORGANIZATION')}/development"
+CHARTS_REPO = "/charts"
+DEVELOPMENT_REPO = "/development"
 
 PR_CREATED = "PR_CREATED"
 PR_NOT_NEEDED = "PR_NOT_NEEDED"
@@ -75,7 +75,7 @@ def get_bot_name_and_token():
     return bot_name, bot_token
 
 
-def create_pr(branch_name,skip_files,repository,message):
+def create_pr(branch_name,skip_files,repository,message,target_branch):
 
     repo = Repo(os.getcwd())
 
@@ -91,12 +91,12 @@ def create_pr(branch_name,skip_files,repository,message):
         print(f"commit changes with message: {branch_name}")
         repo.index.commit(branch_name)
 
-        print(f"push the branch to {repo}")
+        print(f"push the branch {branch_name} to {repository}")
         repo.git.push(f'https://x-access-token:{bot_token}@github.com/{repository}',
                    f'HEAD:refs/heads/{branch_name}','-f')
 
-        print("make the pull request")
-        data = {'head': branch_name, 'base': 'main',
+        print(f"make the pull request to {target_branch}")
+        data = {'head': branch_name, 'base': f'{target_branch}',
                 'title': branch_name, 'body': f'{message}'}
 
         r = github_api(
@@ -119,6 +119,11 @@ def create_pr(branch_name,skip_files,repository,message):
 def add_changes(repo,skip_files):
 
     if len(skip_files) == 0:
+        changed = [ item.a_path for item in repo.index.diff(None) ]
+        for change in changed:
+            print(f"Changed file: {change}")
+        for add in repo.untracked_files:
+            print(f"Added file: {add}")
         print(f"Add all changes")
         repo.git.add(all=True)
     else:

--- a/scripts/src/release/releasechecker.py
+++ b/scripts/src/release/releasechecker.py
@@ -35,15 +35,24 @@ from release import releaser
 
 sys.path.append('../')
 from owners import checkuser
+from github import gitutils
 
 VERSION_FILE = "release/release_info.json"
 TYPE_MATCH_EXPRESSION = "(partners|redhat|community)"
+CHARTS_PR_BASE_REPO = gitutils.CHARTS_REPO
+CHARTS_PR_HEAD_REPO = gitutils.CHARTS_REPO
+DEV_PR_BASE_REPO = gitutils.DEVELOPMENT_REPO
+DEV_PR_HEAD_REPO = gitutils.DEVELOPMENT_REPO
+DEFAULT_BOT_NAME = "openshift-helm-charts-bot"
+
+
 
 def check_if_only_charts_are_included(api_url):
 
+    print("[INFO] check if PR includes only chart files")
     files_api_url = f'{api_url}/files'
     headers = {'Accept': 'application/vnd.github.v3+json'}
-    chart_pattern = re.compile(r"charts/"+TYPE_MATCH_EXPRESSION+"/([\w-]+)/([\w-]+)/([\w\.-]+)/.*")
+    chart_pattern = re.compile(r"charts/"+TYPE_MATCH_EXPRESSION+"/([\w-]+)/([\w-]+)/.*")
     page_number = 1
     max_page_size,page_size = 100,100
     file_count = 0
@@ -62,10 +71,39 @@ def check_if_only_charts_are_included(api_url):
             file_path = f["filename"]
             match = chart_pattern.match(file_path)
             if not match:
+                print(f"[INFO non chart file found: {file_path}")
                 return False
 
     return True
 
+def check_if_no_charts_are_included(api_url):
+
+    print("[INFO] check if PR contains any chart files")
+    files_api_url = f'{api_url}/files'
+    headers = {'Accept': 'application/vnd.github.v3+json'}
+    chart_pattern = re.compile(r"charts/"+TYPE_MATCH_EXPRESSION+"/([\w-]+)/([\w-]+)/.*")
+    page_number = 1
+    max_page_size,page_size = 100,100
+    file_count = 0
+
+    while page_size == max_page_size:
+
+        files_api_query = f'{files_api_url}?per_page={page_size}&page={page_number}'
+        print(f"Query files : {files_api_query}")
+        pr_files = requests.get(files_api_query,headers=headers)
+        files = pr_files.json()
+        page_size = len(files)
+        file_count += page_size
+        page_number += 1
+
+        for f in files:
+            file_path = f["filename"]
+            match = chart_pattern.match(file_path)
+            if match:
+                print(f"[INFO chart file found: {file_path}")
+                return False
+
+    return True
 
 def check_if_only_version_file_is_modified(api_url):
     # api_url https://api.github.com/repos/<organization-name>/<repository-name>/pulls/<pr_number>
@@ -94,9 +132,11 @@ def check_if_only_version_file_is_modified(api_url):
 
     return version_file_found
 
-def check_if_release_branch(sender,pr_branch,pr_body,api_url):
+def check_if_dev_release_branch(sender,pr_branch,pr_body,api_url,pr_head_repo):
 
-    if not sender==os.environ.get("BOT_NAME"):
+    print("[INFO] check if PR is release branch on dev")
+
+    if not sender==os.environ.get("BOT_NAME") and not sender==DEFAULT_BOT_NAME:
         print(f"Sender indicates PR is not part of a release: {sender}")
         return False
 
@@ -108,13 +148,43 @@ def check_if_release_branch(sender,pr_branch,pr_body,api_url):
     if not semver.VersionInfo.isvalid(version):
         print(f"Release part ({version}) of branch name {pr_branch} is not a valid semantic version.")
         return False
-    
-    if not pr_body.startswith(f"Charts workflow version {version}"):
+
+    if not pr_head_repo.endswith(DEV_PR_HEAD_REPO):
+        print(f"PR does not have the expected origin. Got: {pr_head_repo}, expected: {DEV_PR_HEAD_REPO}")
+        return False
+
+    if not pr_body.startswith(releaser.DEV_PR_BRANCH_BODY_PREFIX):
         print(f"PR title indicates PR is not part of a release: {pr_body}")
         return False
 
     return check_if_only_charts_are_included(api_url)
 
+def check_if_charts_release_branch(sender,pr_branch,pr_body,api_url,pr_head_repo):
+
+    print("[INFO] check if PR is release branch on charts")
+
+    if not sender==os.environ.get("BOT_NAME") and not sender==DEFAULT_BOT_NAME:
+        print(f"Sender indicates PR is not part of a release: {sender}")
+        return False
+
+    if not pr_branch.startswith(releaser.CHARTS_PR_BRANCH_NAME_PREFIX):
+        print(f"PR branch indicates PR is not part of a release: {pr_branch}")
+        return False
+
+    version = pr_branch.removeprefix(releaser.CHARTS_PR_BRANCH_NAME_PREFIX)
+    if not semver.VersionInfo.isvalid(version):
+        print(f"Release part ({version}) of branch name {pr_branch} is not a valid semantic version.")
+        return False
+
+    if not pr_head_repo.endswith(CHARTS_PR_HEAD_REPO):
+        print(f"PR does not have the expected origin. Got: {pr_head_repo}, expected: {CHARTS_PR_HEAD_REPO}")
+        return False
+
+    if not pr_body.startswith(releaser.CHARTS_PR_BRANCH_BODY_PREFIX):
+        print(f"PR title indicates PR is not part of a release: {pr_body}")
+        return False
+
+    return check_if_no_charts_are_included(api_url)
 
 
 def make_release_body(version, release_info):
@@ -144,36 +214,56 @@ def main():
                         help="PR branch name")
     parser.add_argument("-t", "--pr_body", dest="pr_body", type=str, required=False,
                         help="PR title")
+    parser.add_argument("-r", "--pr_base_repo", dest="pr_base_repo", type=str, required=False,
+                        help="PR target repo")
+    parser.add_argument("-z", "--pr_head_repo", dest="pr_head_repo", type=str, required=False,
+                        help="PR source repo")
 
     args = parser.parse_args()
 
+    print("[INFO] release checker inputs:")
     print(f"[INFO] arg api-url : {args.api_url}")
     print(f"[INFO] arg version : {args.version}")
     print(f"[INFO] arg sender : {args.sender}")
     print(f"[INFO] arg pr_branch : {args.pr_branch}")
     print(f"[INFO] arg pr_body : {args.pr_body}")
+    print(f"[INFO] arg pr base repo :  {args.pr_base_repo}")
+    print(f"[INFO] arg pr head repo :  {args.pr_head_repo}")
 
-    if args.pr_branch and check_if_release_branch(args.sender,args.pr_branch,args.pr_body,args.api_url):
-        print('[INFO] Dev release pull request found')
-        print(f'::set-output name=dev_release_branch::true')
-        version = args.pr_branch.removeprefix(releaser.DEV_PR_BRANCH_NAME_PREFIX)
-        print(f'::set-output name=PR_version::{version}')
-        print(f"::set-output name=PR_release_body::{args.pr_body}")
+    if args.pr_branch:
+        if args.pr_base_repo.endswith(DEV_PR_BASE_REPO):
+            if check_if_dev_release_branch(args.sender,args.pr_branch,args.pr_body,args.api_url,args.pr_head_repo):
+                print('[INFO] Dev release pull request found')
+                print(f'::set-output name=dev_release_branch::true')
+                version = args.pr_branch.removeprefix(releaser.DEV_PR_BRANCH_NAME_PREFIX)
+                print(f'::set-output name=PR_version::{version}')
+                print(f"::set-output name=PR_release_body::{args.pr_body}")
+        elif args.pr_base_repo.endswith(CHARTS_PR_BASE_REPO):
+            if check_if_charts_release_branch(args.sender,args.pr_branch,args.pr_body,args.api_url,args.pr_head_repo):
+                print('[INFO] Workflow release pull request found')
+                print(f'::set-output name=charts_release_branch::true')
     elif args.api_url:
         ## should be on PR branch
-        version_only = check_if_only_version_file_is_modified(args.api_url)
-        user_authorized = checkuser.verify_user(args.sender)
-        if version_only and user_authorized:
-            version = release_info.get_version("./")
-            version_info = release_info.get_info("./")
-            print(f'[INFO] Release found in PR files : {version}.')
-            print(f'::set-output name=PR_version::{version}')
-            print(f'::set-output name=PR_release_info::{version_info}')
-            print(f'::set-output name=PR_includes_release_only::true')
-            make_release_body(version,version_info)
-        elif not user_authorized:
-            print(f'[ERROR] sender not authorized : {args.sender}.')
-            print(f'::set-output name=sender_not_authorized::true')
+        if args.pr_base_repo.endswith(DEV_PR_BASE_REPO):
+            version_only = check_if_only_version_file_is_modified(args.api_url)
+            user_authorized = checkuser.verify_user(args.sender)
+            if version_only and user_authorized:
+                organization = args.pr_base_repo.removesuffix(DEV_PR_BASE_REPO)
+                print(f'::set-output name=charts_repo::{organization}{CHARTS_PR_BASE_REPO}')
+                version = release_info.get_version("./")
+                version_info = release_info.get_info("./")
+                print(f'[INFO] Release found in PR files : {version}.')
+                print(f'::set-output name=PR_version::{version}')
+                print(f'::set-output name=PR_release_info::{version_info}')
+                print(f'::set-output name=PR_includes_release_only::true')
+                make_release_body(version,version_info)
+            elif version_only and not user_authorized:
+                print(f'[ERROR] sender not authorized : {args.sender}.')
+                print(f'::set-output name=sender_not_authorized::true')
+            else:
+                print('[INFO] Not a release PR')
+        else:
+            print(f'[INFO] Not a release PR, target is not : {DEV_PR_BASE_REPO}.')
     else:
         version = release_info.get_version("./")
         if args.version:

--- a/scripts/src/release/releasechecker.py
+++ b/scripts/src/release/releasechecker.py
@@ -49,7 +49,7 @@ ERROR_IF_MATCH_FOUND = True
 
 def check_file_in_pr(api_url,pattern,error_value):
 
-    print("[INFO] check if PR includes only chart files")
+    print("[INFO] check if PR for matching files")
     files_api_url = f'{api_url}/files'
     headers = {'Accept': 'application/vnd.github.v3+json'}
     page_number = 1
@@ -59,7 +59,7 @@ def check_file_in_pr(api_url,pattern,error_value):
     while page_size == max_page_size:
 
         files_api_query = f'{files_api_url}?per_page={page_size}&page={page_number}'
-        print(f"Query files : {files_api_query}")
+        print(f"[INFO] Query files : {files_api_query}")
         pr_files = requests.get(files_api_query,headers=headers)
         files = pr_files.json()
         page_size = len(files)
@@ -69,23 +69,28 @@ def check_file_in_pr(api_url,pattern,error_value):
         for f in files:
             file_path = f["filename"]
             match = pattern.match(file_path)
-
-            if match == error_value:
-                print(f"[INFO] stop matching at file  : {file_path}")
+            if not match and not error_value:
+                print(f"[INFO] stop non match found  : {file_path}")
+                return False
+            elif match and error_value:
+                print(f"[INFO] stop match found  : {file_path}")
                 return False
 
     return True
 
 
 def check_if_only_charts_are_included(api_url):
+    print("[INFO] check if only chart files are included")
     chart_pattern = re.compile(r"charts/"+TYPE_MATCH_EXPRESSION+"/([\w-]+)/([\w-]+)/.*")
     return check_file_in_pr(api_url, chart_pattern, ERROR_IF_MATCH_NOT_FOUND)
 
 def check_if_no_charts_are_included(api_url):
+    print("[INFO] check if no chart files are included")
     chart_pattern = re.compile(r"charts/"+TYPE_MATCH_EXPRESSION+"/([\w-]+)/([\w-]+)/.*")
     return check_file_in_pr(api_url, chart_pattern, ERROR_IF_MATCH_FOUND)
 
 def check_if_only_version_file_is_modified(api_url):
+    print("[INFO] check if only version file is modified")
     pattern_versionfile = re.compile(r"release/release_info.json")
     return check_file_in_pr(api_url, pattern_versionfile, ERROR_IF_MATCH_NOT_FOUND)
 
@@ -93,7 +98,7 @@ def check_if_dev_release_branch(sender,pr_branch,pr_body,api_url,pr_head_repo):
 
     print("[INFO] check if PR is release branch on dev")
 
-    if not sender!=os.environ.get("BOT_NAME") and sender!=DEFAULT_BOT_NAME:
+    if sender!=os.environ.get("BOT_NAME") and sender!=DEFAULT_BOT_NAME:
         print(f"Sender indicates PR is not part of a release: {sender}")
         return False
 
@@ -124,7 +129,7 @@ def check_if_charts_release_branch(sender,pr_branch,pr_body,api_url,pr_head_repo
 
     print("[INFO] check if PR is release branch on charts")
 
-    if not sender!=os.environ.get("BOT_NAME") and sender!=DEFAULT_BOT_NAME:
+    if sender!=os.environ.get("BOT_NAME") and sender!=DEFAULT_BOT_NAME:
         print(f"Sender indicates PR is not part of a release: {sender}")
         return False
 

--- a/scripts/src/release/releaser.py
+++ b/scripts/src/release/releaser.py
@@ -31,8 +31,10 @@ from github import gitutils
 
 SCHEDULE_YAML_FILE=".github/workflows/schedule.yml"
 BUILD_YAML_FILE=".github/workflows/build.yml"
+DEV_PR_BRANCH_BODY_PREFIX="Charts workflow version"
 DEV_PR_BRANCH_NAME_PREFIX="Auto-Release-"
-DEV_PR_BRANCH_BODY_PREFIX="Workflow and script updates from development repository"
+CHARTS_PR_BRANCH_BODY_PREFIX="Workflow and script updates from development repository"
+CHARTS_PR_BRANCH_NAME_PREFIX="Release-"
 
 SCHEDULE_INSERT = [
     '  # Daily trigger to check updates',
@@ -138,7 +140,22 @@ def main():
                         help="Directory of pull request code.")
     parser.add_argument("-b", "--dev_pr_body", dest="dev_pr_body", type=str, required=True,
                         help="Body to use for the dev PR")
+    parser.add_argument("-t", "--target_branch", dest="target_branch", type=str, required=True,
+                        help="Target branch of the Pull Request" )
+    parser.add_argument("-r", "--target_repository", dest="target_repository", type=str, required=True,
+                        help="Repository which is the target of the pull request" )
+
     args = parser.parse_args()
+
+    print("[INFO] releaser inputs:")
+    print(f"[INFO] arg version : {args.version}")
+    print(f"[INFO] arg dev_dir : {args.dev_dir}")
+    print(f"[INFO] arg charts_dir : {args.charts_dir}")
+    print(f"[INFO] arg pr_dir : {args.pr_dir}")
+    print(f"[INFO] arg dev_pr_body : {args.dev_pr_body}")
+    print(f"[INFO] arg target_branch :  {args.target_branch}")
+    print(f"[INFO] arg target_repository :  {args.target_repository}")
+
 
     start_directory = os.getcwd()
     print(f"working directory: {start_directory}")
@@ -150,15 +167,18 @@ def main():
     os.chdir(args.charts_dir)
     update_workflow()
 
-    print(f"create charts pull request")
-    branch_name = f"Release-{args.version}"
-    message = f'Workflow and script updates from development repository {branch_name}'
-    outcome = gitutils.create_pr(branch_name,[],gitutils.CHARTS_REPO,message)
+    organization = args.target_repository.split("/")[0]
+    charts_repository=f"{organization}{gitutils.CHARTS_REPO}"
+    print(f"create charts pull request, repository: {charts_repository}, branch: {args.target_branch} ")
+    branch_name = f"{CHARTS_PR_BRANCH_NAME_PREFIX}{args.version}"
+    message = f'{CHARTS_PR_BRANCH_BODY_PREFIX} {branch_name}'
+    outcome = gitutils.create_pr(branch_name,[],charts_repository,message,args.target_branch)
     if outcome == gitutils.PR_CREATED:
         print(f'::set-output name=charts_pr_created::true')
     elif outcome == gitutils.PR_NOT_NEEDED:
         print(f'::set-output name=charts_pr_not_needed::true')
     else:
+        printf("[ERROR] error creating charts PR")
         print(f'::set-output name=charts_pr_error::true')
         os.chdir(start_directory)
         return
@@ -171,7 +191,7 @@ def main():
     os.chdir(args.dev_dir)
     print(f"create development pull request")
     branch_name = f"{DEV_PR_BRANCH_NAME_PREFIX}{args.version}"
-    outcome = gitutils.create_pr(branch_name,[release_info.RELEASE_INFO_FILE],gitutils.DEVELOPMENT_REPO,args.dev_pr_body)
+    outcome = gitutils.create_pr(branch_name,[release_info.RELEASE_INFO_FILE],args.target_repository,args.dev_pr_body,args.target_branch)
     if outcome == gitutils.PR_CREATED:
         print("Dev PR successfully created.")
         print(f'::set-output name=dev_pr_created::true')
@@ -179,7 +199,7 @@ def main():
         print("Dev PR not needed.")
         print(f'::set-output name=dev_pr_not_needed::true')
     else:
-        print("Dev PR errored.")
+        print("[ERROR] error creating development PR.")
         print(f'::set-output name=dev_pr_error::true')
 
     os.chdir(start_directory)


### PR DESCRIPTION
Updated the test workflow to look if the PR is a charts release PR and if it is, the PR is auto-merged.

Also made changes to remove the need to modify some files when testing. This is new behavior

The PR with a ```release-info.json``` file is targetted at a repository and a branch. 
1. The repository has to end with ```/development```  so, for example  ```mmulholla/development```  is good. The ```mmulholla``` part is the organization.  
2. The charts PR will be sent to the same organization and same branch but to "/charts"
3. The dev PR will be sent to the same repository and branch as the original PR was sent to.

Example: 
- I create a branch containing only the  ```release-info.json``` and create a PR to merge into branch ```test-branch``` on my fork ```mmulholla/development```.
- The charts PR is created to merge into branch ```test-branch``` on  ```mmulholla/charts``` .
- The dev PR is created ti merge into branch ```test-branch``` on  ```mmulholla/devlopment``` .


Also note for the next release the workflow change will not be in place to auto merge the charts PR, but will the following  release. 