### PR TITLE
Ensure worklfow works with new annotations

### DIFF
--- a/scripts/src/chartprreview/chartprreview.py
+++ b/scripts/src/chartprreview/chartprreview.py
@@ -216,11 +216,21 @@ def check_report_success(directory, api_url, report_path, version):
         write_error_log(directory, msg)
         sys.exit(1)
 
+    report_metadata = report_info.get_report_metadata(report_path)
+    profile_version = report_metadata["profileVersion"]
+
+    print(f"[INFO] Profile version:  {profile_version}")
     annotations = report_info.get_report_annotations(report_path)
 
     required_annotations = {"charts.openshift.io/lastCertifiedTimestamp",
-                            "charts.openshift.io/certifiedOpenShiftVersions",
+                            "charts.openshift.io/testedOpenShiftVersion",
+                            "charts.openshift.io/supportedOpenShiftVersions",
                             "charts.openshift.io/digest"}
+
+    if profile_version == "v1.0":
+        required_annotations = {"charts.openshift.io/lastCertifiedTimestamp",
+                                "charts.openshift.io/certifiedOpenShiftVersions",
+                                "charts.openshift.io/digest"}
 
     available_annotations = set(annotations.keys())
 
@@ -261,6 +271,13 @@ def check_report_success(directory, api_url, report_path, version):
 
     if failures_in_report or vendor_type == "community":
         return
+
+    if "charts.openshift.io/testedOpenShiftVersions" in annotations:
+        full_version = annotations["charts.openshift.io/testedOpenShiftVersions"]
+        if not semver.VersionInfo.isvalid(full_version):
+            msg = f"[ERROR] tested OpenShift version not conforming to SemVer spec: {full_version}"
+            write_error_log(directory, msg)
+            sys.exit(1)
 
     if "charts.openshift.io/certifiedOpenShiftVersions" in annotations:
         full_version = annotations["charts.openshift.io/certifiedOpenShiftVersions"]


### PR DESCRIPTION
DO NOT MERGE because it needs to be merged shortly after: https://github.com/redhat-certification/chart-verifier/pull/213

Add logic to recognize the new annotations added:
- charts.openshift.io/testedOpenShiftVersion
     - renamed from charts.openshift.io/certifiedOpenShiftVersions
- charts.openshift.io/supportedOpenShiftVersions
   -  new, based on content of kubeVersion in chart.yaml.