### PR TITLE
modify annotations for 1.0 report in index.yaml

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -26,3 +26,4 @@ toml==0.10.2
 urllib3==1.26.5
 docker==5.0.0
 six==1.16.0
+semantic_version==2.8.5

--- a/scripts/src/chartprreview/chartprreview.py
+++ b/scripts/src/chartprreview/chartprreview.py
@@ -8,6 +8,7 @@ import hashlib
 import tempfile
 
 import semver
+import semantic_version
 import requests
 import yaml
 try:
@@ -272,9 +273,11 @@ def check_report_success(directory, api_url, report_path, version):
     if failures_in_report or vendor_type == "community":
         return
 
-    if "charts.openshift.io/testedOpenShiftVersions" in annotations:
-        full_version = annotations["charts.openshift.io/testedOpenShiftVersions"]
-        if not semver.VersionInfo.isvalid(full_version):
+    if "charts.openshift.io/testedOpenShiftVersion" in annotations:
+        full_version = annotations["charts.openshift.io/testedOpenShiftVersion"]
+        try:
+            semantic_version.Version.coerce(full_version)
+        except ValueError:
             msg = f"[ERROR] tested OpenShift version not conforming to SemVer spec: {full_version}"
             write_error_log(directory, msg)
             sys.exit(1)
@@ -282,7 +285,7 @@ def check_report_success(directory, api_url, report_path, version):
     if "charts.openshift.io/certifiedOpenShiftVersions" in annotations:
         full_version = annotations["charts.openshift.io/certifiedOpenShiftVersions"]
         if not semver.VersionInfo.isvalid(full_version):
-            msg = f"[ERROR] OpenShift version not conforming to SemVer spec: {full_version}"
+            msg = f"[ERROR] certified OpenShift version not conforming to SemVer spec: {full_version}"
             write_error_log(directory, msg)
             sys.exit(1)
 

--- a/scripts/src/chartrepomanager/chartrepomanager.py
+++ b/scripts/src/chartrepomanager/chartrepomanager.py
@@ -19,6 +19,7 @@ except ImportError:
 
 sys.path.append('../')
 from report import report_info
+from chartrepomanager import indexannotations
 
 def get_modified_charts(api_url):
     files_api_url = f'{api_url}/files'
@@ -140,7 +141,7 @@ def create_index_from_chart(indexdir, repository, branch, category, organization
 def create_index_from_report(category, report_path):
     print("[INFO] create index from report. %s, %s" % (category, report_path))
 
-    annotations = report_info.get_report_annotations(report_path)
+    annotations = indexannotations.getIndexAnnotations(report_path)
 
     print("category:", category)
     redhat_to_community = bool(os.environ.get("REDHAT_TO_COMMUNITY"))
@@ -272,7 +273,7 @@ def update_chart_annotation(category, organization, chart_file_name, chart, repo
     print("[INFO] Update chart annotation. %s, %s, %s, %s" % (category, organization, chart_file_name, chart))
     dr = tempfile.mkdtemp(prefix="annotations-")
 
-    annotations = report_info.get_report_annotations(report_path)
+    annotations = indexannotations.getIndexAnnotations(report_path)
 
     print("category:", category)
     redhat_to_community = bool(os.environ.get("REDHAT_TO_COMMUNITY"))
@@ -288,14 +289,6 @@ def update_chart_annotation(category, organization, chart_file_name, chart, repo
         out = yaml.load(data, Loader=Loader)
         vendor_name = out["vendor"]["name"]
         annotations["charts.openshift.io/provider"] = vendor_name
-
-    if "charts.openshift.io/certifiedOpenShiftVersions" in annotations:
-        full_version = annotations["charts.openshift.io/certifiedOpenShiftVersions"]
-        if full_version == "N/A":
-            annotations["charts.openshift.io/certifiedOpenShiftVersions"] = "N/A"
-        else:
-            ver = semver.VersionInfo.parse(full_version)
-            annotations["charts.openshift.io/certifiedOpenShiftVersions"] = f"{ver.major}.{ver.minor}"
 
     out = subprocess.run(["tar", "zxvf", os.path.join(".cr-release-packages", f"{organization}-{chart_file_name}"), "-C", dr], capture_output=True)
     print(out.stdout.decode("utf-8"))

--- a/scripts/src/chartrepomanager/indexannotations.py
+++ b/scripts/src/chartrepomanager/indexannotations.py
@@ -1,0 +1,112 @@
+import sys
+import semantic_version
+
+sys.path.append('../')
+from report import report_info
+
+kubeOpenShiftVersionMap = {"1.13": "4.1",
+                           "1.14": "4.2",
+                           "1.16": "4.3",
+                           "1.17": "4.4",
+                           "1.18": "4.5",
+                           "1.19": "4.6",
+                           "1.20": "4.7",
+                           "1.21": "4.8",
+                           "1.22": "4.9"}
+
+
+def getOCPVersions(kubeVersion):
+
+    if kubeVersion == "":
+        return "N/A"
+
+    checkKubeVersion = kubeVersion
+
+    try:
+        semantic_version.NpmSpec(kubeVersion)
+    except ValueError:
+        print(f"Value error with kubeVersion -  NpmSpec : {kubeVersion}, see if it fixable")
+
+        try:
+            # Kubversion is bad, see if we can fix it
+            separator = checkKubeVersion.find(" - ")
+            if separator != -1:
+                lowVersion = checkKubeVersion[:separator].strip()
+                highVersion = checkKubeVersion[separator+3:].strip()
+                #print(f"Low Version in range: {lowVersion}, high Version in range : {highVersion}")
+                #print(f"New Low Version in range: {semantic_version.Version.coerce(lowVersion)}, new high Version in range : {semantic_version.Version.coerce(highVersion)}")
+                checkKubeVersion = f"{semantic_version.Version.coerce(lowVersion)} - {semantic_version.Version.coerce(highVersion)}"
+            else:
+                firstDigit = -1
+                for i, c in enumerate(checkKubeVersion):
+                    if c.isdigit():
+                        firstDigit = i
+                        break
+                if firstDigit != -1:
+                    versionInRange = checkKubeVersion[firstDigit:].strip()
+                    preVersion = checkKubeVersion[:firstDigit].strip()
+                    #print(f"Version in range: {versionInRange}, pre Version : {preVersion}")
+                    checkKubeVersion = f"{preVersion}{semantic_version.Version.coerce(versionInRange)}"
+
+            # see if the updates have helped
+            semantic_version.NpmSpec(checkKubeVersion)
+            print(f"Fixed value error in kubeVersion : {checkKubeVersion}")
+
+        except ValueError:
+            print(f"Unable to fix value error in kubeVersion : {kubeVersion}")
+            return "N/A"
+
+
+    minOCP = ""
+    maxOCP = ""
+    for kubeVersionKey in kubeOpenShiftVersionMap :
+        coercedKubeVersionKey = semantic_version.Version.coerce(kubeVersionKey)
+        if minOCP == "" and coercedKubeVersionKey in semantic_version.NpmSpec(checkKubeVersion):
+            minOCP = kubeOpenShiftVersionMap[kubeVersionKey]
+            print(f"   Found min : {kubeVersion}: {minOCP}")
+        elif coercedKubeVersionKey in semantic_version.NpmSpec(checkKubeVersion):
+            maxOCP = kubeOpenShiftVersionMap[kubeVersionKey]
+            print(f"   Found new Max : {kubeVersion}: {maxOCP}")
+
+    # check if minOCP is open ended
+    if minOCP != "" and semantic_version.Version("1.999.999") in semantic_version.NpmSpec(checkKubeVersion):
+        ocp_versions = f">={minOCP}"
+    elif minOCP == "":
+        ocp_versions = "N/A"
+    elif maxOCP == "":
+        ocp_versions = minOCP
+    else:
+        ocp_versions = f"{minOCP} - {maxOCP}"
+
+    return ocp_versions
+
+
+def getIndexAnnotations(report_path):
+
+    annotations = report_info.get_report_annotations(report_path)
+
+    set_annotations = {}
+    OCPSupportedSet = False
+    for annotation in annotations:
+        #print(f"annotation : {annotation} = {annotations[annotation]}")
+        if annotation == "charts.openshift.io/certifiedOpenShiftVersions":
+            full_version = annotations[annotation]
+            if full_version != "N/A" and semantic_version.validate(full_version):
+                ver = semantic_version.Version(full_version)
+                set_annotations["charts.openshift.io/testedOpenShiftVersion"] = f"{ver.major}.{ver.minor}"
+            else:
+                set_annotations["charts.openshift.io/testedOpenShiftVersion"] = annotations[annotation]
+        else:
+            if annotation == "charts.openshift.io/supportedOpenShiftVersions":
+                OCPSupportedSet = True
+            set_annotations[annotation] = annotations[annotation]
+
+    if not OCPSupportedSet:
+        chart = report_info.get_report_chart(report_path)
+        kubeVersion = chart["kubeVersion"]
+        OCPVersions = "N/A"
+        if kubeVersion != "":
+            OCPVersions = getOCPVersions(kubeVersion)
+        set_annotations["charts.openshift.io/supportedOpenShiftVersions"] = OCPVersions
+
+    return set_annotations

--- a/scripts/src/chartrepomanager/indexannotations.py
+++ b/scripts/src/chartrepomanager/indexannotations.py
@@ -33,8 +33,6 @@ def getOCPVersions(kubeVersion):
             if separator != -1:
                 lowVersion = checkKubeVersion[:separator].strip()
                 highVersion = checkKubeVersion[separator+3:].strip()
-                #print(f"Low Version in range: {lowVersion}, high Version in range : {highVersion}")
-                #print(f"New Low Version in range: {semantic_version.Version.coerce(lowVersion)}, new high Version in range : {semantic_version.Version.coerce(highVersion)}")
                 checkKubeVersion = f"{semantic_version.Version.coerce(lowVersion)} - {semantic_version.Version.coerce(highVersion)}"
             else:
                 firstDigit = -1
@@ -45,7 +43,6 @@ def getOCPVersions(kubeVersion):
                 if firstDigit != -1:
                     versionInRange = checkKubeVersion[firstDigit:].strip()
                     preVersion = checkKubeVersion[:firstDigit].strip()
-                    #print(f"Version in range: {versionInRange}, pre Version : {preVersion}")
                     checkKubeVersion = f"{preVersion}{semantic_version.Version.coerce(versionInRange)}"
 
             # see if the updates have helped
@@ -88,7 +85,6 @@ def getIndexAnnotations(report_path):
     set_annotations = {}
     OCPSupportedSet = False
     for annotation in annotations:
-        #print(f"annotation : {annotation} = {annotations[annotation]}")
         if annotation == "charts.openshift.io/certifiedOpenShiftVersions":
             full_version = annotations[annotation]
             if full_version != "N/A" and semantic_version.validate(full_version):


### PR DESCRIPTION
If chart submission is a 1.0 report:

1. rename certifiedOpenShiftVersions annotation to testedOpenShiftVersion
2. Add a supportedOpenShiftVersions based on the kubeVersion in the chart. If kubeVersion is not recognizable as a version set this to N/A,

Tested with a new and old report (report only submissions:
new report: https://github.com/mmulholla/development/pull/174
old report: https://github.com/mmulholla/development/pull/175

resulting Index:
https://github.com/mmulholla/development/blob/gh-pages/index.yaml