### PR TITLE
.github: fix unmatched quotes in workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,10 +43,15 @@ jobs:
           BOT_NAME: ${{ secrets.BOT_NAME }}
         run: |
           # check if PR was created as part of release processing
+          # mitigate unmatched quote error in bash
+          pr_body=$(cat <<EOF | xargs -0 printf '%q'
+          ${{ github.event.pull_request.body }}
+          EOF
+          )
           ./ve1/bin/release-checker --api-url=${{ github.event.pull_request._links.self.href }} \
                                     --sender='${{ github.event.sender.login }}' \
                                     --pr_branch='${{ github.event.pull_request.head.ref }}' \
-                                    --pr_body='${{ github.event.pull_request.body }}' \
+                                    --pr_body="${pr_body}" \
                                     --pr_base_repo='${{ github.event.pull_request.base.repo.full_name }}' \
                                     --pr_head_repo='${{ github.event.pull_request.head.repo.full_name }}'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,10 +53,15 @@ jobs:
           BOT_NAME: ${{ secrets.BOT_NAME }}
         run: |
           # check if PR was created as part of release processing
+          # mitigate unmatched quote error in bash
+          pr_body=$(cat <<EOF | xargs -0 printf '%q'
+          ${{ github.event.pull_request.body }}
+          EOF
+          )
           ./ve1/bin/release-checker --api-url=${{ github.event.pull_request._links.self.href }} \
                                   --sender='${{ github.event.sender.login }}' \
                                   --pr_branch='${{ github.event.pull_request.head.ref }}' \
-                                  --pr_body='${{ github.event.pull_request.body }}' \
+                                  --pr_body="${pr_body}" \
                                   --pr_base_repo='${{ github.event.pull_request.base.repo.full_name }}' \
                                   --pr_head_repo='${{ github.event.pull_request.head.repo.full_name }}'
 
@@ -126,11 +131,16 @@ jobs:
           BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
         run: |
           # sync the repositories
+          # mitigate unmatched quote error in bash
+          dev_pr_body=$(cat <<EOF | xargs -0 printf '%q'
+          ${{ steps.check_only_version_in_PR_and_authorized.outputs.PR_release_body }}
+          EOF
+          )
           ./ve1/bin/releaser --version=${{ steps.check_only_version_in_PR_and_authorized.outputs.PR_version }}\
                              --pr_dir="./pr-branch" \
                              --development_dir="./dev-repo" \
                              --charts_dir="./charts-repo" \
-                             --dev_pr_body="${{ steps.check_only_version_in_PR_and_authorized.outputs.PR_release_body }}" \
+                             --dev_pr_body="${dev_pr_body}" \
                              --target_branch="${{ github.event.pull_request.base.ref }}" \
                              --target_repository="${{ github.event.pull_request.base.repo.full_name }}"
 
@@ -144,6 +154,15 @@ jobs:
           DEV_PR_FOR_RELEASE: ${{ steps.check_created_release_pr.outputs.dev_release_branch }}
         run: |
           # determine what should be done next
+          # mitigate unmatched quote error in bash
+          dev_pr_body=$(cat <<EOF | xargs -0 printf '%q'
+          ${{ steps.check_only_version_in_PR_and_authorized.outputs.PR_release_body }}
+          EOF
+          )
+          pr_body=$(cat <<EOF | xargs -0 printf '%q'
+          ${{ github.event.pull_request.body }}
+          EOF
+          )
           if [ ${REPOSITORIES_SYNCED} == 'true' ]; then
               if [ ${CHART_PR_ERROR} == 'true' ]; then
                   echo "Error creating charts pull request"
@@ -157,13 +176,13 @@ jobs:
               fi
               if [ ${DEV_PR_NOT_NEEDED} == 'true' ]; then
                   echo "No dev PR so create release"
-                  echo '::set-output name=release_body::${{ steps.check_only_version_in_PR_and_authorized.outputs.PR_release_body }}'
+                  echo "::set-output name=release_body::${dev_pr_body}"
                   echo '::set-output name=release_tag::${{ steps.check_only_version_in_PR_and_authorized.outputs.PR_version }}'
               fi
           elif [ ${DEV_PR_FOR_RELEASE} == 'true' ]; then
               echo "Dev PR so create release"
               echo '::set-output name=merge::true'
-              echo '::set-output name=release_body::${{ github.event.pull_request.body }}'
+              echo "::set-output name=release_body::${pr_body}"
               echo '::set-output name=release_tag::${{ steps.check_created_release_pr.outputs.PR_version }}'
           fi
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -113,10 +113,15 @@ jobs:
           BOT_NAME: ${{ secrets.BOT_NAME }}
         run: |
           # check if PR was created as part of release processing
+          # mitigate unmatched quote error in bash
+          pr_body=$(cat <<EOF | xargs -0 printf '%q'
+          ${{ github.event.pull_request.body }}
+          EOF
+          )
           ./ve1/bin/release-checker --api-url=${{ github.event.pull_request._links.self.href }} \
                                 --sender='${{ github.event.sender.login }}' \
                                 --pr_branch='${{ github.event.pull_request.head.ref }}' \
-                                --pr_body='${{ github.event.pull_request.body }}' \
+                                --pr_body="${pr_body}" \
                                 --pr_base_repo='${{ github.event.pull_request.base.repo.full_name }}' \
                                 --pr_head_repo='${{ github.event.pull_request.head.repo.full_name }}'
 


### PR DESCRIPTION
Caused by unpredicted single(')/double(") quotes in PR body, shell strings in
workflow produce unmatched quotes error. This change ensures we parse
the string correctly before passing as arguments.

Refer: https://github.com/openshift-helm-charts/development/runs/4266289403?check_suite_focus=true#step:7:14
Signed-off-by: Allen Bai <abai@redhat.com>