### PR TITLE
tests: check lock before modifying git config

### DIFF
--- a/tests/functional/utils/chart_certification.py
+++ b/tests/functional/utils/chart_certification.py
@@ -51,8 +51,11 @@ vendor:
         username (str): git username to set
         email (str): git email to set
         """
-        repo.config_writer().set_value("user", "name", username).release()
-        repo.config_writer().set_value("user", "email", email).release()
+        git_path = repo.git.rev_parse("--show-toplevel")
+        # make sure only one process is modifying the git config
+        if not pathlib.Path(f'{git_path}/.git/config.lock').exists():
+            repo.config_writer().set_value("user", "name", username).release()
+            repo.config_writer().set_value("user", "email", email).release()
 
     def get_bot_name_and_token(self):
         bot_name = os.environ.get("BOT_NAME")

--- a/tests/functional/utils/chart_certification.py
+++ b/tests/functional/utils/chart_certification.py
@@ -51,11 +51,11 @@ vendor:
         username (str): git username to set
         email (str): git email to set
         """
-        git_path = repo.git.rev_parse("--show-toplevel")
+        git_path = self.repo.git.rev_parse("--show-toplevel")
         # make sure only one process is modifying the git config
         if not pathlib.Path(f'{git_path}/.git/config.lock').exists():
-            repo.config_writer().set_value("user", "name", username).release()
-            repo.config_writer().set_value("user", "email", email).release()
+            self.repo.config_writer().set_value("user", "name", username).release()
+            self.repo.config_writer().set_value("user", "email", email).release()
 
     def get_bot_name_and_token(self):
         bot_name = os.environ.get("BOT_NAME")


### PR DESCRIPTION
https://github.com/openshift-helm-charts/development/runs/4377741765?check_suite_focus=true
https://github.com/openshift-helm-charts/development/runs/4377834190?check_suite_focus=true
https://github.com/openshift-helm-charts/development/runs/4378053172?check_suite_focus=true

For reference, here's the error message after using multi-thread testing.
`
E   OSError: Lock for file '/home/runner/work/development/development/.git/config' did already exist, delete '/home/runner/work/development/development/.git/config.lock' in case the lock is illegal
`

Signed-off-by: Allen Bai <abai@redhat.com>