### PR TITLE
Improve messages in error situations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -164,9 +164,18 @@ jobs:
         id: install-oc
         if: ${{ steps.sanity_check_pr_content.outputs.report-exists != 'true' && steps.cache.outputs.cache-hit != 'true' && steps.check_build_required.outputs.run-build == 'true' }}
         run: |
+          echo "::set-output name=install-oc::true"
           curl -sLO https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux.tar.gz
           tar zxvf openshift-client-linux.tar.gz oc
           echo "::set-output name=oc-installed::true"
+
+      - name: Check oc installed
+        id: check_oc_installed
+        if: ${{ always() && steps.install-oc.outputs.install-oc == 'true' && steps.install-oc.outputs.oc-installed != 'true' }}
+        run: |
+          # oc install failed so create failure
+          echo "::set-output name=oc-installed_failed::true"
+          exit 1
 
       - name: Get Repository
         if: ${{ steps.sanity_check_pr_content.outputs.report-exists != 'true' && steps.check_build_required.outputs.run-build == 'true' }}
@@ -218,6 +227,8 @@ jobs:
         env:
           SANITY_ERROR_MESSAGE: ${{ steps.sanity_check_pr_content.outputs.sanity-error-message }}
           OWNERS_ERROR_MESSAGE: ${{ steps.sanity_check_pr_content.outputs.owners-error-message }}
+          COMMUNITY_MANUAL_REVIEW: ${{ steps.verify_pr.outputs.community_manual_review_required }}
+          OC_INSTALL_FAIL: ${{ steps.check_oc_installed.outputs.oc-installed_failed }}
         run: |
           python3 scripts/prepare_pr_comment.py ${{ steps.sanity_check_pr_content.outcome }} ${{ steps.verify_pr.conclusion }} ${{ github.repository }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -164,18 +164,8 @@ jobs:
         id: install-oc
         if: ${{ steps.sanity_check_pr_content.outputs.report-exists != 'true' && steps.cache.outputs.cache-hit != 'true' && steps.check_build_required.outputs.run-build == 'true' }}
         run: |
-          echo "::set-output name=install-oc::true"
           curl -sLO https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux.tar.gz
           tar zxvf openshift-client-linux.tar.gz oc
-          echo "::set-output name=oc-installed::true"
-
-      - name: Check oc installed
-        id: check_oc_installed
-        if: ${{ always() && steps.install-oc.outputs.install-oc == 'true' && steps.install-oc.outputs.oc-installed != 'true' }}
-        run: |
-          # oc install failed so create failure
-          echo "::set-output name=oc-installed_failed::true"
-          exit 1
 
       - name: Get Repository
         if: ${{ steps.sanity_check_pr_content.outputs.report-exists != 'true' && steps.check_build_required.outputs.run-build == 'true' }}
@@ -228,7 +218,7 @@ jobs:
           SANITY_ERROR_MESSAGE: ${{ steps.sanity_check_pr_content.outputs.sanity-error-message }}
           OWNERS_ERROR_MESSAGE: ${{ steps.sanity_check_pr_content.outputs.owners-error-message }}
           COMMUNITY_MANUAL_REVIEW: ${{ steps.verify_pr.outputs.community_manual_review_required }}
-          OC_INSTALL_FAIL: ${{ steps.check_oc_installed.outputs.oc-installed_failed }}
+          OC_INSTALL_RESULT: ${{ steps.install-oc.conclusion }}
         run: |
           python3 scripts/prepare_pr_comment.py ${{ steps.sanity_check_pr_content.outcome }} ${{ steps.verify_pr.conclusion }} ${{ github.repository }}
 

--- a/scripts/prepare_pr_comment.py
+++ b/scripts/prepare_pr_comment.py
@@ -67,7 +67,7 @@ def main():
     vendor_label = open("./pr/vendor").read().strip()
     chart_name = open("./pr/chart").read().strip()
     msg = get_comment_header(issue_number)
-    oc_install_fail = os.environ.get("OC_INSTALL_FAIL", False)
+    oc_install_result = os.environ.get("OC_INSTALL_RESULT", False)
     if sanity_result == "failure":
         msg += prepare_sanity_failure_comment()
     elif verify_result == "failure":
@@ -76,7 +76,7 @@ def main():
             msg += prepare_community_comment()
         else:
             msg += prepare_failure_comment()
-    elif oc_install_fail:
+    elif oc_install_result == "failure":
         msg += prepare_oc_install_fail_comment()
     else:
         msg += prepare_success_comment()

--- a/scripts/prepare_pr_comment.py
+++ b/scripts/prepare_pr_comment.py
@@ -1,10 +1,8 @@
 import os
 import sys
 
-def prepare_failure_comment(repository, issue_number, vendor_label, chart_name):
+def prepare_failure_comment():
     msg = f"""\
-Thank you for submitting pull request #{issue_number} for Helm Chart Certification!
-
 There were one or more errors while building and verifying your pull request.
 To see the console output with the error messages, click the "Details"
 link next to "CI / Chart Certification" job status towards the end of this page.
@@ -18,31 +16,46 @@ link next to "CI / Chart Certification" job status towards the end of this page.
 
 Please run the [chart-verifier](https://github.com/redhat-certification/chart-verifier) \
 and ensure all mandatory checks pass.
-"""
 
-    msg += f"""
----
-/metadata {{"vendor_label": "{vendor_label}", "chart_name": "{chart_name}"}}
-
-For support, connect with our [Technology Partner Success Desk](https://redhat-connect.gitbook.io/red-hat-partner-connect-general-guide/managing-your-account/getting-help/technology-partner-success-desk).
 """
     return msg
 
-def prepare_success_comment(issue_number, vendor_label, chart_name):
-    msg = f"Thank you for submitting PR #{issue_number} for Helm Chart Certification!\n\n"
-    msg += f"Congratulations! Your chart has been certified and will be published shortly.\n\n"
-    msg += f'/metadata {{"vendor_label": "{vendor_label}", "chart_name": "{chart_name}"}}\n\n'
+def prepare_success_comment():
+    msg = f"Congratulations! Your chart has been certified and will be published shortly.\n\n"
     return msg
 
-def prepare_sanity_failure_comment(issue_number, vendor_label, chart_name):
-    msg = f"Thank you for submitting PR #{issue_number} for Helm Chart Certification!\n\n"
-    msg += f"One or more errors were found with the pull request: \n"
+def prepare_sanity_failure_comment():
+    msg = f"One or more errors were found with the pull request: \n"
     sanity_error_msg = os.environ.get("SANITY_ERROR_MESSAGE", "")
     owners_error_msg = os.environ.get("OWNERS_ERROR_MESSAGE", "")
     if sanity_error_msg:
         msg += f"{sanity_error_msg}\n\n"
     if owners_error_msg:
         msg += f"{owners_error_msg}\n\n"
+    return msg
+
+def prepare_community_comment():
+    msg = f"Community charts require maintainer review and approval, a review will be conducted shortly.\n\n"
+    if os.path.exists("./pr/errors"):
+        errors = open("./pr/errors").read()
+        msg += "However, please note that one or more errors were found while building and verifying your pull request:\n\n"
+        msg += f"{errors}\n\n"
+    return msg
+
+def prepare_oc_install_fail_comment():
+    msg = "Unfortunately the certification process failed to install OpenShift and could not complete.\n\n"
+    msg += "This problem will be addressed by maintainers and no further action is required from the submitter at this time.\n\n"
+    return msg
+
+def get_comment_header(issue_number):
+    msg = f"Thank you for submitting PR #{issue_number} for Helm Chart Certification!\n\n"
+    return msg
+
+def get_comment_footer(vendor_label, chart_name):
+    msg = "\n---\n\n"
+    msg += "For information on the certification process see:\n"
+    msg += "- [Red Hat certification requirements and process for Kubernetes applications that are deployed using Helm charts.](https://redhat-connect.gitbook.io/partner-guide-for-red-hat-openshift-and-container/helm-chart-certification/overview).\n\n"
+    msg += "For support, connect with our [Technology Partner Success Desk](https://redhat-connect.gitbook.io/red-hat-partner-connect-general-guide/managing-your-account/getting-help/technology-partner-success-desk).\n\n"
     msg += f'/metadata {{"vendor_label": "{vendor_label}", "chart_name": "{chart_name}"}}\n\n'
     return msg
 
@@ -53,12 +66,22 @@ def main():
     issue_number = open("./pr/NR").read().strip()
     vendor_label = open("./pr/vendor").read().strip()
     chart_name = open("./pr/chart").read().strip()
+    msg = get_comment_header(issue_number)
+    oc_install_fail = os.environ.get("OC_INSTALL_FAIL", False)
     if sanity_result == "failure":
-        msg = prepare_sanity_failure_comment(issue_number, vendor_label, chart_name)
+        msg += prepare_sanity_failure_comment()
     elif verify_result == "failure":
-        msg = prepare_failure_comment(repository, issue_number, vendor_label, chart_name)
+        community_manual_review = os.environ.get("COMMUNITY_MANUAL_REVIEW",False)
+        if community_manual_review:
+            msg += prepare_community_comment()
+        else:
+            msg += prepare_failure_comment()
+    elif oc_install_fail:
+        msg += prepare_oc_install_fail_comment()
     else:
-        msg = prepare_success_comment(issue_number, vendor_label, chart_name)
+        msg += prepare_success_comment()
+
+    msg += get_comment_footer(vendor_label, chart_name)
 
     with open("./pr/comment", "w") as fd:
         fd.write(msg)

--- a/scripts/src/chartprreview/chartprreview.py
+++ b/scripts/src/chartprreview/chartprreview.py
@@ -310,7 +310,7 @@ def generate_verify_report(directory, category, organization, chart, version):
         sys.exit(1)
     if not os.path.exists(report_path):
         if not src_exists and not tar_exists:
-            msg = '[ERROR] One of these must be modified: report, chart source, or a tarball created with "helm package"'
+            msg = '[ERROR] One of these must be modified: report, chart source, or tarball"'
             write_error_log(directory, msg)
             sys.exit(1)
     kubeconfig = os.environ.get("KUBECONFIG")

--- a/scripts/src/chartprreview/chartprreview.py
+++ b/scripts/src/chartprreview/chartprreview.py
@@ -263,12 +263,14 @@ def check_report_success(directory, api_url, report_path, version):
         if vendor_type == "redhat":
             print(f"::set-output name=redhat_to_community::True")
         if vendor_type != "redhat" and "force-publish" not in label_names:
+            if vendor_type == "community":
+                # requires manual review and approval
+                print(f"::set-output name=community_manual_review_required::True")
             sys.exit(1)
-        
+
     if vendor_type == "community" and "force-publish" not in label_names:
         # requires manual review and approval
-        msg = "[INFO] Community charts require manual review and approval from maintainers"
-        write_error_log(directory, msg)
+        print(f"::set-output name=community_manual_review_required::True")
         sys.exit(1)
 
     if failures_in_report or vendor_type == "community":
@@ -308,7 +310,7 @@ def generate_verify_report(directory, category, organization, chart, version):
         sys.exit(1)
     if not os.path.exists(report_path):
         if not src_exists and not tar_exists:
-            msg = "[ERROR] One of these must be modified: report, chart source, or tarball"
+            msg = '[ERROR] One of these must be modified: report, chart source, or a tarball created with "helm package"'
             write_error_log(directory, msg)
             sys.exit(1)
     kubeconfig = os.environ.get("KUBECONFIG")

--- a/tests/functional/features/chart_src_without_report.feature
+++ b/tests/functional/features/chart_src_without_report.feature
@@ -27,5 +27,5 @@ Feature: Chart source submission without report
         And user gets the <message> in the pull request comment
 
         Examples:
-            | vendor_type   | vendor    | message                                                               |
-            | community     | redhat    | Community charts require manual review and approval from maintainers  |
+            | vendor_type   | vendor    | message                                                                                     |
+            | community     | redhat    | Community charts require maintainer review and approval, a review will be conducted shortly |

--- a/tests/functional/features/chart_tar_without_report.feature
+++ b/tests/functional/features/chart_tar_without_report.feature
@@ -18,7 +18,7 @@ Feature: Chart tarball submission without report
             | vendor_type  | vendor    |
             | partners     | hashicorp |
             | redhat       | redhat    |
-    
+
     Scenario Outline: A community user submits an error-free chart tarball without report
         Given the vendor <vendor> has a valid identity as <vendor_type>
         And an error-free chart tarball is used in <chart_path>
@@ -27,5 +27,5 @@ Feature: Chart tarball submission without report
         And user gets the <message> in the pull request comment
 
         Examples:
-            | vendor_type   | vendor    | message                                                               |
-            | community     | redhat    | Community charts require manual review and approval from maintainers  |
+            | vendor_type   | vendor    | message                                                                                     |
+            | community     | redhat    | Community charts require maintainer review and approval, a review will be conducted shortly |

--- a/tests/functional/features/chart_verifier_comes_back_with_failures.feature
+++ b/tests/functional/features/chart_verifier_comes_back_with_failures.feature
@@ -14,9 +14,9 @@ Feature: Chart verifier comes back with a failure
     And user gets the <message> in the pull request comment
 
     Examples:
-        | vendor_type  | vendor    | message                                  |
-        | partners     | hashicorp | Chart does not have a README             |
-        | community    | redhat    | submitted chart has failed certification |
+        | vendor_type  | vendor    | message                                                 |
+        | partners     | hashicorp | Chart does not have a README                            |
+        | community    | redhat    | Community charts require maintainer review and approval |
 
   Scenario Outline: A redhat user submits a chart which does not contain a readme file
     Given the vendor <vendor> has a valid identity as <vendor_type>

--- a/tests/functional/features/report_and_chart_src.feature
+++ b/tests/functional/features/report_and_chart_src.feature
@@ -27,5 +27,5 @@ Feature: Chart source submission with report
         And user gets the <message> in the pull request comment
 
         Examples:
-            | vendor_type   | vendor    | message                                                               |
-            | community     | redhat    | Community charts require manual review and approval from maintainers  |
+            | vendor_type   | vendor    | message                                                                                     |
+            | community     | redhat    | Community charts require maintainer review and approval, a review will be conducted shortly |

--- a/tests/functional/features/report_and_chart_tar.feature
+++ b/tests/functional/features/report_and_chart_tar.feature
@@ -27,5 +27,5 @@ Feature: Chart tarball submission with report
         And user gets the <message> in the pull request comment
 
         Examples:
-            | vendor_type   | vendor    | message                                                               |
-            | community     | redhat    | Community charts require manual review and approval from maintainers  |
+            | vendor_type   | vendor    | message                                                                                     |
+            | community     | redhat    | Community charts require maintainer review and approval, a review will be conducted shortly |

--- a/tests/functional/features/report_without_chart.feature
+++ b/tests/functional/features/report_without_chart.feature
@@ -27,5 +27,5 @@ Feature: Report only submission
         And user gets the <message> in the pull request comment
 
         Examples:
-            | vendor_type   | vendor    | message                                                               |
-            | community     | redhat    | Community charts require manual review and approval from maintainers  |
+            | vendor_type   | vendor    | message                                                                                     |
+            | community     | redhat    | Community charts require maintainer review and approval, a review will be conducted shortly |


### PR DESCRIPTION
PR messages have been updated:

A new footer was added for all messages (e.g.: https://github.com/openshift-helm-charts/sandbox/pull/8335) to address:
https://issues.redhat.com/browse/HELM-239

---
```
For information on the certification process see:
- [Red Hat certification requirements and process for Kubernetes applications that are deployed using Helm charts.](https://redhat-connect.gitbook.io/partner-guide-for-red-hat-openshift-and-container/helm-chart-certification/overview).

For support, connect with our [Technology Partner Success Desk](https://redhat-connect.gitbook.io/red-hat-partner-connect-general-guide/managing-your-account/getting-help/technology-partner-success-desk).

/metadata {"vendor_label": "hashicorp-2d80e8b8b4ca4474993740175807f747-93", "chart_name": "vault"}
```


Community messages were modified to address https://issues.redhat.com/browse/HELM-257: 

Community pass (e..g: https://github.com/openshift-helm-charts/sandbox/pull/8337)
```
Community charts require maintainer review and approval, a review will be conducted shortly.
```

Community check fail (https://github.com/openshift-helm-charts/sandbox/pull/8378):
```
Community charts require maintainer review and approval, a review will be conducted shortly.

However, please note that one or more errors were found while building and verifying your pull request:

[ERROR] Chart verifier report includes failures:

Number of checks passed: 0
Number of checks failed: 1
Error message(s):
Missing mandatory check : v1.0/helm-lint
```

Code updated and message added for oc install failure e.g.: https://github.com/openshift-helm-charts/sandbox/pull/8184) to address https://issues.redhat.com/browse/HELM-255

```
Unfortunately the certification process failed to install OpenShift and could not complete.

This problem will be addressed by maintainers and no further action is required from the submitter at this time.
```

Finally, as part of https://issues.redhat.com/browse/HELM-223, in addition to a charts repo readme update (https://github.com/openshift-helm-charts/charts/pull/388) , the associated message was improved:

```
[ERROR] One of these must be modified: report, chart source, or a tarball created with "helm package"
```