### PR TITLE
chart-verifier: use GitHub Action to download cv binary

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,8 +8,6 @@ jobs:
   chart-certification:
     name: Chart Certification
     runs-on: ubuntu-20.04
-    env:
-      VERIFIER_IMAGE: quay.io/redhat-certification/chart-verifier:main
     if: |
       github.event.pull_request.draft == false &&
       (github.event.action != 'labeled' || github.event.label.name == 'force-publish')
@@ -162,6 +160,18 @@ jobs:
           curl -sLO https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux.tar.gz
           tar zxvf openshift-client-linux.tar.gz oc
 
+      - name: Install chart-verifier
+        id: install-chart-verifier
+        if: ${{ steps.check_build_required.outputs.run-build == 'true' }}
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          # Search through these projects' GitHub releases, instead of the OpenShift Mirror.
+          # https://docs.github.com/en/actions/reference/authentication-in-a-workflow
+          source: "github"
+          # Using GitHub token from the github context
+          github_pat: ${{ secrets.GITHUB_TOKEN }}
+          chart-verifier: "latest"
+
       - name: Get Repository
         if: ${{ steps.sanity_check_pr_content.outputs.report-exists != 'true' && steps.check_build_required.outputs.run-build == 'true' }}
         id: get-repository
@@ -176,11 +186,9 @@ jobs:
         env:
           KUBECONFIG: /tmp/ci-kubeconfig
           VENDOR_TYPE: ${{ steps.sanity_check_pr_content.outputs.category }}
+          OPENSHIFT_TOOLS_INSTALLER_OUTPUT: ${{ steps.install-chart-verifier.outputs.installed }}
         run: |
           API_SERVER=$( echo -n ${{ secrets.API_SERVER }} | base64 -d)
-          gpg --version
-          docker pull ${{ env.VERIFIER_IMAGE }}
-          curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
           if [ "${{steps.sanity_check_pr_content.outputs.report-exists}}" != "true" ]; then
             if [ $GITHUB_REPOSITORY == "openshift-helm-charts/charts" ]; then
               ./oc login --token=${{ secrets.CLUSTER_TOKEN }} --server=${API_SERVER}
@@ -293,6 +301,7 @@ jobs:
           CHART_ENTRY_NAME: ${{ steps.sanity_check_pr_content.outputs.chart-entry-name }}
           CHART_NAME_WITH_VERSION: ${{ steps.sanity_check_pr_content.outputs.chart-name-with-version }}
           REDHAT_TO_COMMUNITY: ${{ steps.verify_pr.outputs.redhat_to_community }}
+          OPENSHIFT_TOOLS_INSTALLER_OUTPUT: ${{ steps.install-chart-verifier.outputs.installed }}
         id: release-charts
         run: |
           tar zxvf ./scripts/dependencies/helm-chart-releaser/chart-releaser_1.2.0_linux_amd64.tar.gz

--- a/scripts/src/chartprreview/chartprreview.py
+++ b/scripts/src/chartprreview/chartprreview.py
@@ -319,22 +319,28 @@ def generate_verify_report(directory, category, organization, chart, version):
         write_error_log(directory, msg)
         sys.exit(1)
     vendor_type = get_vendor_type(directory)
+    openshift_tools_installer_output = json.loads(os.environ.get("OPENSHIFT_TOOLS_INSTALLER_OUTPUT"))
+    if "chart-verifier" not in openshift_tools_installer_output:
+        msg = "[ERROR] chartprereview: missing OPENSHIFT_TOOLS_INSTALLER_OUTPUT"
+        write_error_log(directory, msg)
+        sys.exit(1)
+    chart_verifier_binary_path = openshift_tools_installer_output['chart-verifier'].get("installedPath", None)
+    if not chart_verifier_binary_path:
+        msg = "[ERROR] chartprereview: missing 'chart-verifier' binary"
+        write_error_log(directory, msg)
+        sys.exit(1)
     if src_exists:
         if os.path.exists(report_path):
-            out = subprocess.run(["docker", "run", "-v", src+":/charts:z", "-v", kubeconfig+":/kubeconfig", "-e", "KUBECONFIG=/kubeconfig", "--rm",
-                                 os.environ.get("VERIFIER_IMAGE"), "verify", "--set", f"profile.vendortype={vendor_type}", "-e", "has-readme", "/charts"], capture_output=True)
+            out = subprocess.run([chart_verifier_binary_path, "verify", "--set", f"profile.vendortype={vendor_type}", "-e", "has-readme", src], capture_output=True)
         else:
-            out = subprocess.run(["docker", "run", "-v", src+":/charts:z", "-v", kubeconfig+":/kubeconfig", "-e", "KUBECONFIG=/kubeconfig", "--rm",
-                                 os.environ.get("VERIFIER_IMAGE"), "verify", "--set", f"profile.vendortype={vendor_type}", "/charts"], capture_output=True)
+            out = subprocess.run([chart_verifier_binary_path, "verify", "--set", f"profile.vendortype={vendor_type}", src], capture_output=True)
     elif tar_exists:
         dn = os.path.join(os.getcwd(), "charts", category,
                           organization, chart, version)
         if os.path.exists(report_path):
-            out = subprocess.run(["docker", "run", "-v", dn+":/charts:z", "-v", kubeconfig+":/kubeconfig", "-e", "KUBECONFIG=/kubeconfig", "--rm", os.environ.get("VERIFIER_IMAGE"),
-                                 "verify", "--set", f"profile.vendortype={vendor_type}", "-e", "has-readme", f"/charts/{chart}-{version}.tgz"], capture_output=True)
+            out = subprocess.run([chart_verifier_binary_path, "verify", "--set", f"profile.vendortype={vendor_type}", "-e", "has-readme", f"{dn}/{chart}-{version}.tgz"], capture_output=True)
         else:
-            out = subprocess.run(["docker", "run", "-v", dn+":/charts:z", "-v", kubeconfig+":/kubeconfig", "-e", "KUBECONFIG=/kubeconfig", "--rm",
-                                 os.environ.get("VERIFIER_IMAGE"), "verify", "--set", f"profile.vendortype={vendor_type}", f"/charts/{chart}-{version}.tgz"], capture_output=True)
+            out = subprocess.run([chart_verifier_binary_path, "verify", "--set", f"profile.vendortype={vendor_type}", f"{dn}/{chart}-{version}.tgz"], capture_output=True)
     else:
         return
 

--- a/scripts/src/report/report_info.py
+++ b/scripts/src/report/report_info.py
@@ -1,8 +1,8 @@
 
 import os
 import sys
-import docker
 import json
+import subprocess
 
 REPORT_ANNOTATIONS = "annotations"
 REPORT_RESULTS = "results"
@@ -10,8 +10,16 @@ REPORT_DIGESTS = "digests"
 REPORT_METADATA = "metadata"
 
 def _get_report_info(report_path, info_type, profile_type, profile_version):
+    openshift_tools_installer_output = json.loads(os.environ.get("OPENSHIFT_TOOLS_INSTALLER_OUTPUT"))
+    if "chart-verifier" not in openshift_tools_installer_output:
+        print("[ERROR] report_info: missing OPENSHIFT_TOOLS_INSTALLER_OUTPUT")
+        sys.exit(1)
+    chart_verifier_binary_path = openshift_tools_installer_output['chart-verifier'].get("installedPath", None)
+    if not chart_verifier_binary_path:
+        print("[ERROR] report_info: missing 'chart-verifier' binary")
+        sys.exit(1)
 
-    docker_command = "report " + info_type + " /charts/"+os.path.basename(report_path)
+    command = [chart_verifier_binary_path, "report", info_type, report_path]
 
     set_values = ""
     if profile_type:
@@ -23,13 +31,11 @@ def _get_report_info(report_path, info_type, profile_type, profile_version):
             set_values = "profile.version=%s" % profile_version
 
     if set_values:
-        docker_command = "%s --set %s" % (docker_command, set_values)
+        command.extend(["--set", set_values])
 
-    client = docker.from_env()
-    report_directory = os.path.dirname(os.path.abspath(report_path))
-    print(f'Call docker using imcge: {os.environ.get("VERIFIER_IMAGE")}, docker command: {docker_command}, report directory: {report_directory}')
-    output = client.containers.run(os.environ.get("VERIFIER_IMAGE"),docker_command,stdin_open=True,tty=True,stdout=True,volumes={report_directory: {'bind': '/charts/', 'mode': 'rw'}})
-    report_out = json.loads(output)
+    print(f'[INFO] calling chart-verifier: {command}, report path: {report_path}')
+    output = subprocess.run(command, capture_output=True)
+    report_out = json.loads(output.stdout.decode("utf-8"))
 
     if not info_type in report_out:
         print(f"Error extracting {info_type} from the report:", report_out.strip())


### PR DESCRIPTION
Uses https://github.com/redhat-actions/openshift-tools-installer to
download and chart-verifier binary. Also removes dependencies to docker
binaries.

Closes: https://issues.redhat.com/browse/HELM-273
Signed-off-by: Allen Bai <abai@redhat.com>