### PR TITLE
metrics: add job to collect and send metrics

### DIFF
--- a/.github/workflows/metrics.yaml
+++ b/.github/workflows/metrics.yaml
@@ -1,0 +1,21 @@
+name: Scheduled Metrics
+on:
+  schedule:
+  # * is a special character in YAML so you have to quote this string
+  - cron:  '0 0 * * *'
+
+jobs:
+  metrics:
+    name: Collect and Send Metrics
+    runs-on: ubuntu-20.04
+    env:
+      SEGMENT_WRITE_KEY: ${{ secrets.SEGMENT_WRITE_KEY }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Python 3.x Part 1
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.9"
+      - name: Release Metrics
+        run: python3 scripts/src/metrics/metrics.py

--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   metrics:
     name: Collect and Send Metrics
+    if: github.repository == 'openshift-helm-charts/development'
     runs-on: ubuntu-20.04
     env:
       SEGMENT_WRITE_KEY: ${{ secrets.SEGMENT_WRITE_KEY }}
@@ -18,4 +19,14 @@ jobs:
         with:
           python-version: "3.9"
       - name: Release Metrics
+        id: release_metrics
         run: python3 scripts/src/metrics/metrics.py
+      - name: Send message to slack channel
+        id: notify
+        if: always()
+        uses: archive/github-actions-slack@v2.0.0
+        with:
+          slack-bot-user-oauth-access-token: ${{ secrets.SLACK_BOT_USER_OAUTH_ACCESS_TOKEN }}
+          slack-channel: C02979BDUPL
+          slack-text: ${{ steps.release_metrics.conclusion }}! Nightly collection of metrics. See '${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}'
+

--- a/release/release_info.json
+++ b/release/release_info.json
@@ -16,6 +16,8 @@
       "docs",
       "tests"
     ],
-    "ignore" : [".github/workflows/release.yml", ".github/workflows/nightly_test.yml"]
+    "ignore" : [".github/workflows/release.yml",
+                ".github/workflows/nightly_test.yml",
+                ".github/workflows/metrics.yml"]
   }
 }

--- a/scripts/src/metrics/metrics.py
+++ b/scripts/src/metrics/metrics.py
@@ -1,0 +1,60 @@
+import os
+import re
+import requests
+import logging
+import sys
+import itertools
+
+logging.basicConfig(level=logging.INFO)
+
+
+def parse_response(response):
+    result = []
+    for obj in response:
+        if 'name' in obj and len(obj.get('assets', [])) > 0:
+            release = {
+                'name': obj['name'],
+                'assets': list(map(lambda asset: (asset.get('name', 'unknown'), asset.get('download_count', 0)), obj['assets']))
+            }
+            result.append(release)
+    return result
+
+
+def get_metrics():
+    result = []
+    for i in itertools.count(start=1):
+        response = requests.get(
+            f'https://api.github.com/repos/openshift-helm-charts/charts/releases?per_page=100&page={i}')
+        if response.status_code != 200:
+            logging.error(f"expect reponse 200, got {response.status_code}")
+            sys.exit(1)
+        response_json = response.json()
+        if len(response_json) == 0:
+            break
+        result.extend(response_json)
+    return parse_response(result)
+
+
+def send_metrics(metrics: dict):
+    for release in metrics:
+        headers = {
+            'Authorization': os.getenv('SEGMENT_WRITE_KEY')}
+        json = {
+            "userId": release['name'],
+            "event": "Chart Certification Metrics",
+            "properties": dict(release['assets']),
+        }
+        response = requests.post(
+            url='https://api.segment.io/v1/track', headers=headers, json=json)
+        if response.status_code != 200:
+            logging.error(f"expect reponse 200, got {response.status_code}")
+            sys.exit(1)
+        logging.info(f'POST {json["userId"]}\nRESPONSE {response}')
+
+
+def main():
+    send_metrics(get_metrics())
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/src/metrics/metrics.py
+++ b/scripts/src/metrics/metrics.py
@@ -25,8 +25,8 @@ def get_metrics():
     for i in itertools.count(start=1):
         response = requests.get(
             f'https://api.github.com/repos/openshift-helm-charts/charts/releases?per_page=100&page={i}')
-        if response.status_code != 200:
-            logging.error(f"expect reponse 200, got {response.status_code}")
+        if not 200 <= response.status_code < 300:
+            logging.error(f"unexpected response getting release data : {response.status_code} : {response.reason}")
             sys.exit(1)
         response_json = response.json()
         if len(response_json) == 0:
@@ -46,8 +46,8 @@ def send_metrics(metrics: dict):
         }
         response = requests.post(
             url='https://api.segment.io/v1/track', headers=headers, json=json)
-        if response.status_code != 200:
-            logging.error(f"expect reponse 200, got {response.status_code}")
+        if not 200 <= response.status_code < 300:
+            logging.error(f"unexpected response sending data to segment : {response.status_code} : {response.reason}")
             sys.exit(1)
         logging.info(f'POST {json["userId"]}\nRESPONSE {response}')
 


### PR DESCRIPTION
Adds a github cron job that runs a python script that will collect the
accumulated download count from release artifacts and send over to
Segment. Eventually the metrics will land in Woopra for analytics.

Closes: https://issues.redhat.com/browse/HELM-193
Signed-off-by: Allen Bai <carpe.diem.allen@gmail.com>

@mmulholla added changes:
- only run cron job on development branch
- do not copy metrics.yml to charts repository as part of a release
- accept any 2xx return code from request for release info or posting info to segment 
- added slack channel message with outcome.