### PR TITLE
disable the nightly workflow in forks

### DIFF
--- a/.github/workflows/nightly_test.yml
+++ b/.github/workflows/nightly_test.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   nightly-test:
     name: Nightly Test
+    if: github.repository == 'openshift-helm-charts/development'
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout


### PR DESCRIPTION
This PR will disable the workflow run the forks, since the nightly test is only intended for 'openshift-helm-charts/development' repo.