### PR TITLE
fix bug in ProviderDelivery

### DIFF
--- a/scripts/src/chartrepomanager/chartrepomanager.py
+++ b/scripts/src/chartrepomanager/chartrepomanager.py
@@ -332,7 +332,7 @@ def main():
     indexdir = create_worktree_for_index(branch)
 
     print(f'[INFO] os.environ["PROVIDER_DELIVERY"] {os.environ["PROVIDER_DELIVERY"]}')
-    if os.environ["PROVIDER_DELIVERY"] and os.environ["PROVIDER_DELIVERY"] == True:
+    if os.environ["PROVIDER_DELIVERY"] and os.environ["PROVIDER_DELIVERY"] == "True":
         indexfile = "unpublished-certified-charts.yaml"
     else:
         indexfile = "index.yaml"

--- a/tests/functional/step_defs/test_provider_delivery_control.py
+++ b/tests/functional/step_defs/test_provider_delivery_control.py
@@ -56,3 +56,4 @@ def provider_delivery_control_set_in_report(workflow_test,provider_control_repor
 @then(parsers.parse("the <index_file> is updated with an entry for the submitted chart"))
 def index_file_is_updated(workflow_test,index_file):
     workflow_test.secrets.index_file = index_file
+    workflow_test.check_index_yaml(True)


### PR DESCRIPTION
Two issues.
1. When deciding which index file to use the test checked for ```os.environ["PROVIDER_DELIVERY"]``` as a binary, but it is a string. As a result everything went to Index.yaml.
2. The test case missed out the call to check the content of the new index file.