### PR TITLE
Add slack notification if tests are run

### DIFF
--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -159,6 +159,7 @@ jobs:
           ve1/bin/pytest tests/functional/step_defs/test_submitted_charts.py --log-cli-level=WARNING --tb=short
 
       - name: (Schedule) Run tests on existing charts
+        id: run-schedule-tests
         if: |
           github.event_name == 'schedule' && steps.compare_ocp_versions.outputs.run_tests == 'true'
         env:
@@ -179,6 +180,19 @@ jobs:
           printf "[INFO] Software Name: '%s'\n" "${{ env.SOFTWARE_NAME }}"
           printf "[INFO] Software Version: '%s'\n" "${{ env.SOFTWARE_VERSION }}"
           ve1/bin/pytest tests/functional/step_defs/test_submitted_charts.py --log-cli-level=WARNING --tb=short
+
+      - name: Send message to slack channel
+        id: notify
+        if: always() && github.event_name == 'schedule' && steps.compare_cv_versions.outputs.run_tests == 'true'
+        uses: archive/github-actions-slack@v2.0.0
+        with:
+          slack-bot-user-oauth-access-token: ${{ secrets.SLACK_BOT_USER_OAUTH_ACCESS_TOKEN }}
+          slack-channel: C02979BDUPL
+          slack-text: ${{ steps.run-schedule-tests.conclusion }}! Nightly run after OCP version update detected. See '${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}'
+
+      - name: Result from "Send Message to slack channel"
+        run: echo "The result was ${{ steps.notify.outputs.slack-result }}"
+
 
   check-chart-verifier:
     name: Check Chart Verifier Version
@@ -249,7 +263,7 @@ jobs:
           steps.compare_cv_versions.outputs.run_tests == 'true' &&
           (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.dry-run != 'true'))
         run: |
-          COMMIT_MESSAGE=$(printf "software-version.yaml: Update OpenShift version from '%s' to '%s'" "${{ steps.get_prev_ocp_version.outputs.result }}" "${{ steps.get_curr_cv_version.outputs.current_cv_digest }}")
+          COMMIT_MESSAGE=$(printf "software-version.yaml: Update chart-verifier version from '%s' to '%s'" "${{ steps.get_prev_ocp_version.outputs.result }}" "${{ steps.get_curr_cv_version.outputs.current_cv_digest }}")
           git remote -v
           git branch -vv
 
@@ -305,6 +319,7 @@ jobs:
           ve1/bin/pytest tests/functional/step_defs/test_submitted_charts.py --log-cli-level=WARNING --tb=short
 
       - name: (Schedule) Run tests on existing charts
+        id: run-schedule-tests
         if: |
           github.event_name == 'schedule' && steps.compare_cv_versions.outputs.run_tests == 'true'
         env:
@@ -325,3 +340,16 @@ jobs:
           printf "[INFO] Software Name: '%s'\n" "${{ env.SOFTWARE_NAME }}"
           printf "[INFO] Software Version: '%s'\n" "${{ env.SOFTWARE_VERSION }}"
           ve1/bin/pytest tests/functional/step_defs/test_submitted_charts.py --log-cli-level=WARNING --tb=short
+
+      - name: Send message to slack channel
+        id: notify
+        if: always() && github.event_name == 'schedule' && steps.compare_cv_versions.outputs.run_tests == 'true'
+        uses: archive/github-actions-slack@v2.0.0
+        with:
+          slack-bot-user-oauth-access-token: ${{ secrets.SLACK_BOT_USER_OAUTH_ACCESS_TOKEN }}
+          slack-channel: C02979BDUPL
+          slack-text: ${{ steps.run-schedule-tests.conclusion }}! Nightly run after chartverifier version update detected. See '${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}'
+
+      - name: Result from "Send Message to slack channel"
+        run: echo "The result was ${{ steps.notify.outputs.slack-result }}"
+


### PR DESCRIPTION
Add slack notification if a test is run either due to a OCP version update or chart verifier version update.