### PR TITLE
add PR metrics and update release metrics

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -209,6 +209,7 @@ jobs:
           ve1/bin/pr-artifact --directory=./pr --pr-number=${{ github.event.number }} --api-url=${{ github.event.pull_request._links.self.href }}
 
       - name: Prepare PR comment
+        id: pr_comment
         if: ${{ always() && steps.check_build_required.outputs.run-build == 'true' }}
         env:
           PR_CONTENT_ERROR_MESSAGE: ${{ steps.check_pr_content.outputs.pr-content-error-message }}
@@ -315,3 +316,33 @@ jobs:
           fail_on_unmatched_files: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Add metrics
+        if: always() && steps.check_build_required.outputs.run-build == 'true'
+        run: |
+          if [ $GITHUB_REPOSITORY == "openshift-helm-charts/charts" ]; then
+              WRITE_KEY=${{ secrets.SEGMENT_WRITE_KEY }}
+              echo "Use segment production write key"
+          else
+              WRITE_KEY=${{ secrets.SEGMENT_TEST_WRITE_KEY }}
+              echo "Use segment test write key"
+          fi
+
+          if [ "${WRITE_KEY}" != "" ]; then
+            if [ "${{steps.pr_comment.outputs.pr_passed}}" == "true" ]; then
+              echo "add PR run passed metric"
+              ve1/bin/metrics --write-key=${WRITE_KEY} \
+                              --metric-type=pull_request \
+                              --chart=${{ steps.check_pr_content.outputs.chart-name-with-version }} \
+                              --partner=${{ steps.check_pr_content.outputs.organization }}
+            else
+              echo "add PR run failed metric"
+              ve1/bin/metrics --write-key=${WRITE_KEY} \
+                              --metric-type=pull_request \
+                              --chart=${{ steps.check_pr_content.outputs.chart-name-with-version }} \
+                              --partner=${{ steps.check_pr_content.outputs.organization }} \
+                              --message="${{ steps.pr_comment.outputs.error-message }}"
+            fi
+          else
+              echo "Do not collect metrics, required segment write key is not set"
+          fi

--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -4,14 +4,21 @@ on:
   # * is a special character in YAML so you have to quote this string
   - cron:  '0 0 * * *'
   workflow_dispatch:
+    inputs:
+      # Production metrics require secret SEGMENT_WRITE_KEY
+      # Test metrics require secret SEGMENT_TEST_WRITE_KEY
+      production-data:
+        description: "Upload metrics to production data {true,false}"
+        required: true
+        default: "false"
 
 jobs:
   metrics:
     name: Collect and Send Metrics
-    if: github.repository == 'openshift-helm-charts/development'
     runs-on: ubuntu-20.04
     env:
       SEGMENT_WRITE_KEY: ${{ secrets.SEGMENT_WRITE_KEY }}
+      SEGMENT_TEST_WRITE_KEY: ${{ secrets.SEGMENT_TEST_WRITE_KEY }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -30,11 +37,38 @@ jobs:
 
       - name: Release Metrics
         id: release_metrics
-        run: ve1/bin/metrics --metric-type=release
+        run: |
+          if [[ "${{github.event_name}}" == "workflow_dispatch" ]]; then
+              if ${{github.event.inputs.production-data}}; then
+                  echo "Workflow dispatch using production write key"
+                  WRITE_KEY=${SEGMENT_WRITE_KEY}
+              else
+                  echo "Workflow dispatch using test write key"
+                  WRITE_KEY=${SEGMENT_TEST_WRITE_KEY}
+              fi
+          elif [[ "${{github.repository}}" == "openshift-helm-charts/development" ]]; then
+              echo "Scheduled dispatch using production write key"
+              WRITE_KEY=${SEGMENT_WRITE_KEY}
+              if [ "${SEGMENT_WRITE_KEY}" != "" ]; then
+                  WRITE_KEY=${SEGMENT_WRITE_KEY}
+              else
+                  echo "Error: Scheduled dispatch is missing write key"
+                  exit 1
+              fi
+          else
+              echo "Scheduled dispatch not on valid repo, do not set write key"
+              WRITE_KEY=""
+          fi
+
+          if [ "${WRITE_KEY}" != "" ]; then
+              ve1/bin/metrics --write-key=${WRITE_KEY} --metric-type=release
+          else
+              echo "Do not collect metrics, required segment write key is not set"
+          fi
 
       - name: Send message to slack channel
         id: notify
-        if: always()
+        if: always() && github.event_name == 'schedule' && github.repository == 'openshift-helm-charts/development'
         uses: archive/github-actions-slack@v2.0.0
         with:
           slack-bot-user-oauth-access-token: ${{ secrets.SLACK_BOT_USER_OAUTH_ACCESS_TOKEN }}

--- a/scripts/prepare_pr_comment.py
+++ b/scripts/prepare_pr_comment.py
@@ -18,6 +18,7 @@ Please run the [chart-verifier](https://github.com/redhat-certification/chart-ve
 and ensure all mandatory checks pass.
 
 """
+    print(f"::set-output name=error-message::{errors}")
     return msg
 
 def prepare_success_comment():
@@ -29,8 +30,10 @@ def prepare_pr_content_failure_comment():
     pr_content_error_msg = os.environ.get("PR_CONTENT_ERROR_MESSAGE", "")
     owners_error_msg = os.environ.get("OWNERS_ERROR_MESSAGE", "")
     if pr_content_error_msg:
+        print(f"::set-output name=error-message::{pr_content_error_msg}")
         msg += f"{pr_content_error_msg}\n\n"
     if owners_error_msg:
+        print(f"::set-output name=error-message::{owners_error_msg}")
         msg += f"{owners_error_msg}\n\n"
     return msg
 
@@ -70,15 +73,20 @@ def main():
     oc_install_result = os.environ.get("OC_INSTALL_RESULT", False)
     if pr_content_result == "failure":
         msg += prepare_pr_content_failure_comment()
+        print(f"::set-output name=pr_passed::false")
     elif verify_result == "failure":
         community_manual_review = os.environ.get("COMMUNITY_MANUAL_REVIEW",False)
         if community_manual_review:
             msg += prepare_community_comment()
+            print(f"::set-output name=pr_passed::true")
         else:
             msg += prepare_failure_comment()
+            print(f"::set-output name=pr_passed::false")
     elif oc_install_result == "failure":
         msg += prepare_oc_install_fail_comment()
+        print(f"::set-output name=pr_passed::false")
     else:
+        print(f"::set-output name=pr_passed::true")
         msg += prepare_success_comment()
 
     msg += get_comment_footer(vendor_label, chart_name)

--- a/scripts/src/checkprcontent/checkpr.py
+++ b/scripts/src/checkprcontent/checkpr.py
@@ -156,6 +156,7 @@ def ensure_only_chart_is_modified(api_url, repository, branch):
     if matches_found>0:
         category, organization, chart, version = pattern_match.groups()
         print(f"::set-output name=category::{'partner' if category == 'partners' else category}")
+        print(f"::set-output name=organization::{organization}")
         print("Downloading index.yaml", category, organization, chart, version)
         r = requests.get(f'https://raw.githubusercontent.com/{repository}/{branch}/index.yaml')
         if r.status_code == 200:

--- a/scripts/src/metrics/metrics.py
+++ b/scripts/src/metrics/metrics.py
@@ -37,24 +37,36 @@ def get_release_metrics():
         result.extend(response_json)
     return parse_response(result)
 
-
-def send_release_metrics(metrics):
-    for release in metrics:
+def send_release_metrics(write_key, downloads):
+    metrics={}
+    for release in downloads:
         _,provider,chart,_ = index.get_chart_info(release.get('name'))
         if len(provider)>0:
-            send_metric(provider,f"{chart} downloads", release.get('asset'))
+            if provider not in metrics:
+                metrics[provider] = {}
+            if chart not in metrics[provider]:
+                metrics[provider][chart] = {}
 
-def send_fail_metric(partner,chart,message):
+            for key in release.get('asset'):
+                metrics[provider][chart][key] = release.get('asset')[key]
+
+
+    for provider in metrics:
+        for chart in metrics[provider]:
+            send_metric(write_key,provider,f"{chart} downloads", metrics[provider][chart])
+
+
+def send_fail_metric(write_key,partner,chart,message):
 
     properties = { "chart" : chart, "message" : message }
 
-    send_metric(partner,"PR run Failed",properties)
+    send_metric(write_key,partner,"PR run Failed",properties)
 
-def send_pass_metric(partner,chart):
+def send_pass_metric(write_key,partner,chart):
 
     properties = { "chart" : chart }
 
-    send_metric(partner,"PR Success",properties)
+    send_metric(write_key,partner,"PR Success",properties)
 
 
 def on_error(error,items):
@@ -63,18 +75,21 @@ def on_error(error,items):
     sys.exit(1)
 
 
-def send_metric(partner,event,properties):
+def send_metric(write_key,partner,event,properties):
 
-    analytics.write_key = os.getenv('SEGMENT_WRITE_KEY')
+    analytics.write_key = write_key
     analytics.on_error = on_error
+
+    logging.info(f'Add track:  user: {partner},  event:{event},  properties:{properties}')
 
     analytics.track(partner, event, properties)
 
-    logging.info(f'Add track:  user: {partner},  event:{event},  properties:{properties}')
 
 
 def main():
     parser = argparse.ArgumentParser()
+    parser.add_argument("-k", "--write-key", dest="write_key", type=str, required=True,
+                        help="segment write key")
     parser.add_argument("-t", "--metric-type", dest="type", type=str, required=True,
                         help="metric type, releases or pull_request")
     parser.add_argument("-c", "--chart", dest="chart", type=str, required=False,
@@ -85,17 +100,17 @@ def main():
                         help="message for metric")
     args = parser.parse_args()
 
-    if not os.getenv('SEGMENT_WRITE_KEY'):
-        print("Error SEGMENT_WRITE_KEY not found")
+    if not args.write_key:
+        print("Error: Segment write key not set")
         sys.exit(1)
 
     if args.type == "pull_request":
         if args.message:
-            send_fail_metric(args.partner,args.chart,args.message)
+            send_fail_metric(args.write_key,args.partner,args.chart,args.message)
         else:
-            send_pass_metric(args.partner,args.chart)
+            send_pass_metric(args.write_key,args.partner,args.chart)
     else:
-        send_release_metrics(get_release_metrics())
+        send_release_metrics(args.write_key,get_release_metrics())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- Added metrics each time a chart PR runs. Added at then end of the workflow so does not affect merge if it fails for any reason.
- Modified release metrics to log a single metric for all versions of the same chart. This should prevent woopra showing lots of zeros.
- Added the concept of a test segment write key and  production write key read from secrets
    - SEGMENT_WRITE_KEY - production key
    - SEGMENT_TEST_WRITE_KEY - test key
- Added a workflow-dispatch for the metrics workflow, takes a single boolean input to se which segment write key to use.
     - dispatch workflow can be run form forks.

This PR was created for: https://issues.redhat.com/browse/HELM-302 