### PR TITLE
Fix bash error in metrics workflow

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -39,7 +39,7 @@ jobs:
         id: release_metrics
         run: |
           if [[ "${{github.event_name}}" == "workflow_dispatch" ]]; then
-              if ${{github.event.inputs.production-data}}; then
+              if [[ "${{github.event.inputs.production-data}}" == "true" ]]; then
                   echo "Workflow dispatch using production write key"
                   WRITE_KEY=${SEGMENT_WRITE_KEY}
               else


### PR DESCRIPTION
Fixed the workflow bash to prevent error in schedule metrics. 