### PR TITLE
Update version checking workflow

### DIFF
--- a/.github/workflows/version_check.yml
+++ b/.github/workflows/version_check.yml
@@ -1,15 +1,17 @@
 name: Check Software Version
 on:
+  # Daily trigger to check updates
+  schedule:
+    - cron: "0 0 * * *"
+  # manual dispatch
   workflow_dispatch:
     inputs:
-      # XXX: dry-run has two side effects:
-      # 1. Don't launch github issues for notifications
-      # 2. Run this workflow but don't update the software-version.yaml,
-      #     used to re-run the cron job when there's version difference.
-      # Can lift this input when we feel comfortable to run this workflow once
-      # for each software version change and send notifications (no backdoor).
+      # XXX: dry-run has side effects:
+      # 1. Opens issue in openshift-helm-chart/sandbox if failures are detected.
+      # 2. Runs this workflow whether or not a version change has occurred
+      # 3. By default dperaza and mmulholla are tagged in any issues raised.
       dry-run:
-        description: "Run tests but do not create issues {true,false}"
+        description: "Dry Run? (Run tests but create issues in sandbox) {true,false}"
         required: true
         default: "true"
       vendor-type:
@@ -66,6 +68,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           ref: "software-version"
+          repository: "openshift-helm-charts/charts"
 
       - name: Read previous OpenShift version
         id: get_prev_ocp_version
@@ -81,9 +84,13 @@ jobs:
           if [ "${{ steps.check_repo.outputs.run-job }}" != "true" ]; then
             echo "::set-output name=run_tests::false"
           elif [ "${{ steps.get_curr_ocp_version.outputs.curr_ocp_version }}" = "${{ steps.get_prev_ocp_version.outputs.result }}" ]; then
-            # No change in the OpenShift version
-            printf "OpenShift version has not changed since last run: '%s' -> '%s'\n" "${{ steps.get_prev_ocp_version.outputs.result }}" "${{ steps.get_curr_ocp_version.outputs.curr_ocp_version }}"
-            echo "::set-output name=run_tests::false"
+            # No change in the OpenShift version on run tests if a dry-run
+            if [ "${{ github.event_name }}" == 'schedule' || "${{ github.event.inputs.dry-run }}" != 'true']; then
+              printf "OpenShift version has not changed since last run: '%s' -> '%s'\n" "${{ steps.get_prev_ocp_version.outputs.result }}" "${{ steps.get_curr_ocp_version.outputs.curr_ocp_version }}"
+              echo "::set-output name=run_tests::false"
+            else
+              echo "::set-output name=run_tests::true"
+            fi
           else
             # New OpenShift version is set
             printf "OpenShift version has changed since last run: '%s' -> '%s'\n" "${{ steps.get_prev_ocp_version.outputs.result }}" "${{ steps.get_curr_ocp_version.outputs.curr_ocp_version }}"
@@ -117,7 +124,7 @@ jobs:
           steps.compare_ocp_versions.outputs.run_tests == 'true'
         uses: actions/checkout@v2
         with:
-          ref: ${{ github.event.workflow_dispatch.ref }}
+          ref: "main"
           token: ${{ secrets.BOT_TOKEN }}
           fetch-depth: 0
 
@@ -156,7 +163,7 @@ jobs:
           printf "[INFO] Notify ID: '%s'\n" "${{ env.NOTIFY_ID }}"
           printf "[INFO] Software Name: '%s'\n" "${{ env.SOFTWARE_NAME }}"
           printf "[INFO] Software Version: '%s'\n" "${{ env.SOFTWARE_VERSION }}"
-          ve1/bin/pytest tests/functional/step_defs/test_submitted_charts.py --log-cli-level=WARNING --tb=short
+          ve1/bin/pytest tests/functional/step_defs/test_submitted_charts.py --log-cli-level=INFO --tb=short
 
       - name: (Schedule) Run tests on existing charts
         id: run-schedule-tests
@@ -179,7 +186,7 @@ jobs:
           printf "[INFO] Notify ID: '%s'\n" "${{ env.NOTIFY_ID }}"
           printf "[INFO] Software Name: '%s'\n" "${{ env.SOFTWARE_NAME }}"
           printf "[INFO] Software Version: '%s'\n" "${{ env.SOFTWARE_VERSION }}"
-          ve1/bin/pytest tests/functional/step_defs/test_submitted_charts.py --log-cli-level=WARNING --tb=short
+          ve1/bin/pytest tests/functional/step_defs/test_submitted_charts.py --log-cli-level=INFO --tb=short
 
       - name: Send message to slack channel
         id: notify
@@ -205,15 +212,18 @@ jobs:
           echo "GITHUB_REPOSITORY : $GITHUB_REPOSITORY"
           if [ $GITHUB_EVENT_NAME == 'workflow_dispatch' ]; then
             echo '::set-output name=run-job::true'
+            echo "workflow_dispatch: set run-job to true"
           elif [ $GITHUB_REPOSITORY == "openshift-helm-charts/charts" ]; then
             echo '::set-output name=run-job::true'
+            echo "charts repo: set run-job to true"
           else
             echo '::set-output name=run-job::false'
+            echo "set run-job to false"
           fi
 
       - name: Get current Chart Verifier version
         id: get_curr_cv_version
-        if: steps.check-repo.outputs.run-job == 'true'
+        if: steps.check_repo.outputs.run-job == 'true'
         run: |
           QUAY_API='https://quay.io/api/v1/repository/redhat-certification/chart-verifier/tag/'
           CV_DIGEST=$(curl ${QUAY_API} | jq '[.tags[] | select(.name == "latest")] | .[0].manifest_digest')
@@ -222,13 +232,14 @@ jobs:
         shell: bash
 
       - name: Checkout software-version branch
-        if: steps.check-repo.outputs.run-job == 'true'
+        if: steps.check_repo.outputs.run-job == 'true'
         uses: actions/checkout@v2
         with:
           ref: "software-version"
+          repository: "openshift-helm-charts/charts"
 
       - name: Read previous Chart Verifier digest
-        if: steps.check-repo.outputs.run-job == 'true'
+        if: steps.check_repo.outputs.run-job == 'true'
         id: get_prev_cv_digest
         uses: mikefarah/yq@master
         with:
@@ -240,10 +251,14 @@ jobs:
           set -euo pipefail
           if [ "${{ steps.check_repo.outputs.run-job }}" != "true" ]; then
             echo "::set-output name=run_tests::false"
-          elif [ "${{ steps.get_curr_cv_version.outputs.current_cv_digest }}" = "${{ steps.get_prev_cv_digest.outputs.result }}" ]; then
-            # No change in the Chart Verifier image
-            printf "Chart Verifier has not changed since last run: '%s' -> '%s'\n" "${{ steps.get_prev_cv_digest.outputs.result }}" "${{ steps.get_curr_cv_version.outputs.current_cv_digest }}"
-            echo "::set-output name=run_tests::false"
+          elif [ "${{ steps.get_curr_cv_version.outputs.current_cv_digest }}" == "${{ steps.get_prev_cv_digest.outputs.result }}" ]; then
+            # No change in the Chart Verifier image only run tests if dry-run is set
+            if [ "${{ github.event_name }}" == 'schedule' || "${{ github.event.inputs.dry-run }}" != 'true']; then
+              printf "Chart Verifier has not changed since last run: '%s' -> '%s'\n" "${{ steps.get_prev_cv_digest.outputs.result }}" "${{ steps.get_curr_cv_version.outputs.current_cv_digest }}"
+              echo "::set-output name=run_tests::false"
+            else
+              echo "::set-output name=run_tests::true"
+            fi
           else
             # New Chart Verifier image is found
             printf "Chart Verifier has changed since last run: '%s' -> '%s'\n" "${{ steps.get_prev_cv_digest.outputs.result }}" "${{ steps.get_curr_cv_version.outputs.current_cv_digest }}"
@@ -272,12 +287,12 @@ jobs:
           git commit -am "${COMMIT_MESSAGE}"
           git push
 
-      - name: Checkout main branch
+      - name: Checkout charts main branch
         if: |
           steps.compare_cv_versions.outputs.run_tests == 'true'
         uses: actions/checkout@v2
         with:
-          ref: ${{ github.event.workflow_dispatch.ref }}
+          ref: "main"
           token: ${{ secrets.BOT_TOKEN }}
           fetch-depth: 0
 
@@ -293,13 +308,14 @@ jobs:
           steps.compare_cv_versions.outputs.run_tests == 'true'
         run: |
           # set up python
+          pwd
           python3 -m venv ve1
           cd scripts && ../ve1/bin/pip3 install -r requirements.txt && cd ..
           cd scripts && ../ve1/bin/python3 setup.py install && cd ..
 
       - name: (Manual) Run tests on existing charts
         if: |
-          github.event_name == 'workflow_dispatch' && steps.compare_cv_versions.outputs.run_tests == 'true'
+          github.event_name == 'workflow_dispatch'
         env:
           CLUSTER_TOKEN: ${{ secrets.CLUSTER_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -308,7 +324,7 @@ jobs:
           NOTIFY_ID: ${{ github.event.inputs.notify-id }}
           BOT_NAME: ${{ secrets.BOT_NAME }}
           BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
-          SOFTWARE_NAME: "OpenShift"
+          SOFTWARE_NAME: "chart-verifier"
           SOFTWARE_VERSION: ${{ steps.get_curr_cv_version.outputs.current_cv_digest }}
         run: |
           printf "[INFO] Dry run: '%s'\n" "${{ env.DRY_RUN }}"
@@ -316,7 +332,8 @@ jobs:
           printf "[INFO] Notify ID: '%s'\n" "${{ env.NOTIFY_ID }}"
           printf "[INFO] Software Name: '%s'\n" "${{ env.SOFTWARE_NAME }}"
           printf "[INFO] Software Version: '%s'\n" "${{ env.SOFTWARE_VERSION }}"
-          ve1/bin/pytest tests/functional/step_defs/test_submitted_charts.py --log-cli-level=WARNING --tb=short
+          pwd
+          ve1/bin/pytest tests/functional/step_defs/test_submitted_charts.py --log-cli-level=INFO --tb=short
 
       - name: (Schedule) Run tests on existing charts
         id: run-schedule-tests
@@ -331,7 +348,7 @@ jobs:
           DRY_RUN: "true"
           VENDOR_TYPE: "all"
           NOTIFY_ID: ""
-          SOFTWARE_NAME: "OpenShift"
+          SOFTWARE_NAME: "chart-verifier"
           SOFTWARE_VERSION: ${{ steps.get_curr_cv_version.outputs.current_cv_digest }}
         run: |
           printf "[INFO] Dry run: '%s'\n" "${{ env.DRY_RUN }}"
@@ -339,7 +356,7 @@ jobs:
           printf "[INFO] Notify ID: '%s'\n" "${{ env.NOTIFY_ID }}"
           printf "[INFO] Software Name: '%s'\n" "${{ env.SOFTWARE_NAME }}"
           printf "[INFO] Software Version: '%s'\n" "${{ env.SOFTWARE_VERSION }}"
-          ve1/bin/pytest tests/functional/step_defs/test_submitted_charts.py --log-cli-level=WARNING --tb=short
+          ve1/bin/pytest tests/functional/step_defs/test_submitted_charts.py --log-cli-level=INFO --tb=short
 
       - name: Send message to slack channel
         id: notify

--- a/.github/workflows/version_check.yml
+++ b/.github/workflows/version_check.yml
@@ -84,7 +84,7 @@ jobs:
           if [ "${{ steps.check_repo.outputs.run-job }}" != "true" ]; then
             echo "::set-output name=run_tests::false"
           elif [ "${{ steps.get_curr_ocp_version.outputs.curr_ocp_version }}" = "${{ steps.get_prev_ocp_version.outputs.result }}" ]; then
-            # No change in the OpenShift version on run tests if a dry-run
+            # No change in the OpenShift version - do not run tests if a scheduled run or dry-run is not set
             if [ "${{ github.event_name }}" == 'schedule' || "${{ github.event.inputs.dry-run }}" != 'true']; then
               printf "OpenShift version has not changed since last run: '%s' -> '%s'\n" "${{ steps.get_prev_ocp_version.outputs.result }}" "${{ steps.get_curr_ocp_version.outputs.curr_ocp_version }}"
               echo "::set-output name=run_tests::false"
@@ -252,7 +252,7 @@ jobs:
           if [ "${{ steps.check_repo.outputs.run-job }}" != "true" ]; then
             echo "::set-output name=run_tests::false"
           elif [ "${{ steps.get_curr_cv_version.outputs.current_cv_digest }}" == "${{ steps.get_prev_cv_digest.outputs.result }}" ]; then
-            # No change in the Chart Verifier image only run tests if dry-run is set
+            # No change in the Chart Verifier image - do not run tests if a scheduled run or dry-run is not set
             if [ "${{ github.event_name }}" == 'schedule' || "${{ github.event.inputs.dry-run }}" != 'true']; then
               printf "Chart Verifier has not changed since last run: '%s' -> '%s'\n" "${{ steps.get_prev_cv_digest.outputs.result }}" "${{ steps.get_curr_cv_version.outputs.current_cv_digest }}"
               echo "::set-output name=run_tests::false"
@@ -332,7 +332,6 @@ jobs:
           printf "[INFO] Notify ID: '%s'\n" "${{ env.NOTIFY_ID }}"
           printf "[INFO] Software Name: '%s'\n" "${{ env.SOFTWARE_NAME }}"
           printf "[INFO] Software Version: '%s'\n" "${{ env.SOFTWARE_VERSION }}"
-          pwd
           ve1/bin/pytest tests/functional/step_defs/test_submitted_charts.py --log-cli-level=INFO --tb=short
 
       - name: (Schedule) Run tests on existing charts

--- a/tests/functional/utils/chart_certification.py
+++ b/tests/functional/utils/chart_certification.py
@@ -6,6 +6,7 @@ import json
 import pathlib
 import shutil
 import logging
+import time
 import uuid
 from tempfile import TemporaryDirectory
 from dataclasses import dataclass
@@ -111,6 +112,8 @@ vendor:
         r = github_api(
             'post', f'repos/{remote_repo}/git/refs', bot_token, json=data)
 
+        logging.info(f'gh-pages branch created: {base_branch}-gh-pages')
+
     def setup_git_context(self, repo: git.Repo):
         self.set_git_username_email(repo, self.secrets.bot_name, GITHUB_ACTIONS_BOT_EMAIL)
         if os.environ.get('WORKFLOW_DEVELOPMENT'):
@@ -154,7 +157,9 @@ vendor:
         old_branch = self.repo.active_branch.name
         self.repo.git.fetch(f'https://github.com/{self.secrets.test_repo}.git',
                     '{0}:{0}'.format(f'{base_branch}-gh-pages'), '-f')
+
         self.repo.git.checkout(f'{base_branch}-gh-pages')
+
         with open(index_file, 'r') as fd:
             try:
                 index = yaml.safe_load(fd)
@@ -162,30 +167,33 @@ vendor:
                 logger(f"error parsing index.yaml: {err}")
                 return False
 
-        entry = vendor + '-' + chart_name
-        if entry not in index['entries']:
-            logger(
-                f"{entry} not added in entries to {index_file}")
+        if index:
+            entry = f"{vendor}-{chart_name}"
+            if "entries" not in index or entry not in index['entries']:
+                logger(f"{entry} not added in entries to {index_file}")
+                logger(f"Index.yaml entries: {index['entries']}")
+                return False
+
+            version_list = [release['version'] for release in index['entries'][entry]]
+            if chart_version not in version_list:
+                logger(f"{chart_version} not added to {index_file}")
+                logger(f"Index.yaml entry content: {index['entries'][entry]}")
+                return False
+
+            #This check is applicable for charts submitted in redhat path when one of the chart-verifier check fails
+            #Check whether providerType annotations is community in index.yaml when vendor_type is redhat
+            if check_provider_type and self.secrets.vendor_type == 'redhat':
+                provider_type_in_index_yaml = index['entries'][entry][0]['annotations']['charts.openshift.io/providerType']
+                if provider_type_in_index_yaml != 'community':
+                    logger(f"{provider_type_in_index_yaml} is not correct as providerType in index.yaml")
+
+
+            logging.info("Index updated correctly, cleaning up local branch")
+            self.repo.git.checkout(old_branch)
+            self.repo.git.branch('-D', f'{base_branch}-gh-pages')
+            return True
+        else:
             return False
-
-        version_list = [release['version'] for release in index['entries'][entry]]
-        if chart_version not in version_list:
-            logger(
-                f"{chart_version} not added to {index_file}")
-            return False
-
-        #This check is applicable for charts submitted in redhat path when one of the chart-verifier check fails
-        #Check whether providerType annotations is community in index.yaml when vendor_type is redhat
-        if check_provider_type and self.secrets.vendor_type == 'redhat':
-            provider_type_in_index_yaml = index['entries'][entry][0]['annotations']['charts.openshift.io/providerType']
-            if provider_type_in_index_yaml != 'community':
-                logger(f"{provider_type_in_index_yaml} is not correct as providerType in index.yaml")
-
-
-        logging.info("Index updated correctly, cleaning up local branch")
-        self.repo.git.checkout(old_branch)
-        self.repo.git.branch('-D', f'{base_branch}-gh-pages')
-        return True
 
     def check_release_result(self, vendor, chart_name, chart_version, chart_tgz, logger=pytest.fail):
         expected_tag = f'{vendor}-{chart_name}-{chart_version}'
@@ -218,34 +226,35 @@ vendor:
             run_id = get_run_id(self.secrets, pr_number)
             conclusion = get_run_result(self.secrets, run_id)
             if conclusion == expect_result:
-                logging.info(f"Workflow run was '{expect_result}' which is expected")
+                logging.info(f"PR{pr_number} Workflow run was '{expect_result}' which is expected")
             else:
                 logger(
-                    f"Workflow run was '{conclusion}' which is unexpected, run id: {run_id}, pr number: {pr_number if pr_number else self.secrets.pr_number}")
+                    f"PR{pr_number if pr_number else self.secrets.pr_number} Workflow run was '{conclusion}' which is unexpected, run id: {run_id}")
             return run_id, conclusion
         except Exception as e:
             logger(e)
-            return run_id, conclusion
+            return None, None
 
     # expect_merged: boolean representing whether the PR should be merged
     def check_pull_request_result(self, pr_number, expect_merged: bool, logger=pytest.fail):
         # Check if PR merged
         r = github_api(
             'get', f'repos/{self.secrets.test_repo}/pulls/{pr_number}/merge', self.secrets.bot_token)
+        logging.info(f"PR{pr_number} result status_code : {r.status_code}")
         if r.status_code == 204 and expect_merged:
-            logging.info("PR merged sucessfully as expected")
+            logging.info(f"PR{pr_number} merged sucessfully as expected")
             return True
         elif r.status_code == 404 and not expect_merged:
-            logging.info("PR not merged, which is expected")
+            logging.info(f"PR{pr_number} not merged, which is expected")
             return True
         elif r.status_code == 204 and not expect_merged:
-            logger("Expecting PR not merged but PR was merged")
+            logger(f"PR{pr_number} Expecting not merged but PR was merged")
             return False
         elif r.status_code == 404 and expect_merged:
-            logger("Expecting PR merged but PR was not merged")
+            logger(f"PR{pr_number} Expecting PR merged but PR was not merged")
             return False
         else:
-            logger(f"Got unexpected status code from PR: {r.status_code}")
+            logger(f"PR{pr_number} Got unexpected status code from PR: {r.status_code}")
             return False
 
     def cleanup_release(self, expected_tag):
@@ -560,7 +569,7 @@ class ChartCertificationE2ETestSingle(ChartCertificationE2ETest):
 
     def send_pull_request(self):
         self.secrets.pr_number = super().send_pull_request(self.secrets.test_repo, self.secrets.base_branch, self.secrets.pr_branch, self.secrets.bot_token)
-        print(f"[INFO] PR number: {self.secrets.pr_number}")
+        logging.info(f"[INFO] PR number: {self.secrets.pr_number}")
 
     # expect_result: a string representation of expected result, e.g. 'success'
     def check_workflow_conclusion(self, expect_result: str):
@@ -686,8 +695,7 @@ class ChartCertificationE2ETestMultiple(ChartCertificationE2ETest):
         if notify_id:
             notify_id = [vt.strip() for vt in notify_id.split(',')]
         else:
-            # Default to not override, i.e. use chart owners
-            notify_id = []
+            notify_id = ["dperaza","mmulholla"]
         return notify_id
 
     def get_software_name_version(self):
@@ -695,9 +703,11 @@ class ChartCertificationE2ETestMultiple(ChartCertificationE2ETest):
         if not software_name:
             raise Exception("SOFTWARE_NAME environment variable not defined")
 
-        software_version = os.environ.get("SOFTWARE_VERSION")
+        software_version = os.environ.get("SOFTWARE_VERSION").strip('\"')
         if not software_version:
             raise Exception("SOFTWARE_VERSION environment variable not defined")
+        elif software_version.startswith("sha256"):
+            software_version = software_version[-8:]
 
         return software_name, software_version
 
@@ -719,8 +729,6 @@ class ChartCertificationE2ETestMultiple(ChartCertificationE2ETest):
 
             # Run submission flow test with charts in PROD_REPO:PROD_BRANCH
             self.set_git_username_email(self.temp_repo, self.secrets.bot_name, GITHUB_ACTIONS_BOT_EMAIL)
-            self.temp_repo.git.fetch(
-                f'https://github.com/{PROD_REPO}.git', f'{PROD_BRANCH}:{PROD_BRANCH}', '-f')
             self.temp_repo.git.checkout(PROD_BRANCH, 'charts')
             self.temp_repo.git.restore('--staged', 'charts')
             self.secrets.submitted_charts = get_all_charts(
@@ -730,20 +738,16 @@ class ChartCertificationE2ETestMultiple(ChartCertificationE2ETest):
             self.temp_repo.git.checkout('-b', 'tmp')
 
     def get_owner_ids(self, chart_directory, owners_table):
-        # Don't send notifications on dry runs
-        if not self.secrets.dry_run:
-            if len(self.secrets.notify_id) == 0:
-                with open(f'{chart_directory}/OWNERS', 'r') as fd:
-                    try:
-                        owners = yaml.safe_load(fd)
-                        # Pick owner ids for notification
-                        owners_table[chart_directory] = [
-                            owner.get(['githubUsername'], '') for owner in owners['users']]
-                    except yaml.YAMLError as err:
-                        logging.warning(
-                            f"Error parsing OWNERS of {chart_directory}: {err}")
-            else:
-                owners_table[chart_directory] = self.secrets.notify_id
+
+        with open(f'{chart_directory}/OWNERS', 'r') as fd:
+            try:
+                owners = yaml.safe_load(fd)
+                # Pick owner ids for notification
+                owners_table[chart_directory] = [
+                    owner.get('githubUsername', '') for owner in owners['users']]
+            except yaml.YAMLError as err:
+                logging.warning(
+                    f"Error parsing OWNERS of {chart_directory}: {err}")
 
     def push_chart(self, chart_directory, chart_name, chart_version, vendor_name, vendor_type, pr_branch):
         # Push chart files to test_repo:pr_branch
@@ -760,42 +764,64 @@ class ChartCertificationE2ETestMultiple(ChartCertificationE2ETest):
         chart = f'{vendor_type} {vendor_name} {chart_name} {chart_version}'
         run_id, conclusion = super().check_workflow_conclusion(pr_number, 'success', logging.warning)
 
-        # Send notification to owner through GitHub issues
-        if not self.secrets.dry_run and run_id and conclusion:
+        if conclusion and run_id:
+            # Send notification to owner through GitHub issues
             r = github_api(
                 'get', f'repos/{self.secrets.test_repo}/actions/runs/{run_id}', self.secrets.bot_token)
             run = r.json()
             run_html_url = run['html_url']
             chart_directory = f'charts/{vendor_type}/{vendor_name}/{chart_name}'
-            chart_owners = owners_table[chart_directory]
             pass_verification = conclusion == 'success'
-            os.environ['GITHUB_ORGANIZATION'] = PROD_REPO.split('/')[0]
             os.environ['GITHUB_REPO'] = PROD_REPO.split('/')[1]
             os.environ['GITHUB_AUTH_TOKEN'] = self.secrets.bot_token
-            logging.info(
-                f"Send notification to '{chart_owners}' about verification result of '{chart}'")
-            create_verification_issue(chart_name, chart_owners, run_html_url, self.secrets.software_name,
-                                    self.secrets.software_version, pass_verification, self.secrets.bot_token)
+            if not self.secrets.dry_run:
+                chart_owners = owners_table[chart_directory]
+                os.environ['GITHUB_REPO'] = PROD_REPO.split('/')[1]
+                os.environ['GITHUB_AUTH_TOKEN'] = self.secrets.bot_token
+                os.environ['GITHUB_ORGANIZATION'] = PROD_REPO.split('/')[0]
+                logging.info(f"PR{pr_number} Send notification to '{self.secrets.notify_id}' about verification result of '{chart}'")
+                create_verification_issue(f"charts/{vendor_name}/{chart_name}/{chart_version}",  chart_owners, self.secrets.notify_id, run_html_url, self.secrets.software_name,
+                                    self.secrets.software_version, pass_verification, self.secrets.bot_token, self.secrets.dry_run)
+            else:
+                chart_owners = owners_table[chart_directory]
+                os.environ['GITHUB_ORGANIZATION'] = PROD_REPO.split('/')[0]
+                os.environ['GITHUB_REPO'] = "sandbox"
+                os.environ['GITHUB_AUTH_TOKEN'] = self.secrets.bot_token
+                logging.info(f"Send notification to '{self.secrets.notify_id}' about dry run verification result of '{chart}'")
+                create_verification_issue(f"charts/{vendor_name}/{chart_name}/{chart_version}", chart_owners, self.secrets.notify_id, run_html_url, self.secrets.software_name,
+                                      self.secrets.software_version, pass_verification, self.secrets.bot_token, self.secrets.dry_run)
+                logging.info(f"PR{pr_number} Dry Run - send sandbox notification to '{chart_owners}' about verification result of '{chart}'")
 
-        # Early return on workflow failures
+
         if conclusion != 'success':
+                logging.warning(f"PR{pr_number} workflow failed: {vendor_name}, {chart_name}, {chart_version}")
+                return
+        else:
+            logging.warning(f"PR{pr_number} workflow did not complete: {vendor_name}, {chart_name}, {chart_version}")
             return
+
+        logging.info(f"PR{pr_number} workflow passed: {vendor_name}, {chart_name}, {chart_version}")
 
         # Check PRs are merged
         if not super().check_pull_request_result(pr_number, True, logging.warning):
+            logging.warning(f"PR{pr_number} pull request was not merged: {vendor_name}, {chart_name}, {chart_version}")
             return
+        logging.info(f"PR{pr_number} pull request was merged: {vendor_name}, {chart_name}, {chart_version}")
 
         # Check index.yaml is updated
-        if not super().check_index_yaml(base_branch, vendor_name, chart_name, chart_version, False, logging.warning):
-            return
+        if not super().check_index_yaml(base_branch, vendor_name, chart_name, chart_version, check_provider_type=False, logger=logging.warning):
+            logging.warning(f"PR{pr_number} - Chart was not found in Index file: {vendor_name}, {chart_name}, {chart_version}")
+        logging.info(f"PR{pr_number} - Chart was found in Index file: {vendor_name}, {chart_name}, {chart_version}")
 
         # Check release is published
         chart_tgz = f'{chart_name}-{chart_version}.tgz'
         if not super().check_release_result(vendor_name, chart_name, chart_version, chart_tgz, logging.warning):
-            return
+            logging.warning(f"PR{pr_number} - Release was not created: {vendor_name}, {chart_name}, {chart_version}")
+        logging.info(f"PR{pr_number} - Release was created: {vendor_name}, {chart_name}, {chart_version}")
 
     def process_single_chart(self, vendor_type, vendor_name, chart_name, chart_version, pr_number_list, owners_table):
         # Get SHA from 'pr_base_branch' branch
+        logging.info(f"Process chart: {vendor_type}/{vendor_name}/{chart_name}/{chart_version}")
         r = github_api(
             'get', f'repos/{self.secrets.test_repo}/git/ref/heads/{self.secrets.pr_base_branch}', self.secrets.bot_token)
         j = json.loads(r.text)
@@ -803,6 +829,7 @@ class ChartCertificationE2ETestMultiple(ChartCertificationE2ETest):
 
         chart_directory = f'charts/{vendor_type}/{vendor_name}/{chart_name}'
         base_branch = f'{self.secrets.software_name}-{self.secrets.software_version}-{self.secrets.pr_base_branch}-{vendor_type}-{vendor_name}-{chart_name}-{chart_version}'
+        base_branch = base_branch.replace(":","-")
         pr_branch = f'{base_branch}-pr-branch'
 
         self.secrets.base_branches.append(base_branch)
@@ -843,8 +870,11 @@ class ChartCertificationE2ETestMultiple(ChartCertificationE2ETest):
         self.push_chart(chart_directory, chart_name, chart_version, vendor_name, vendor_type, pr_branch)
 
         # Create PR from pr_branch to base_branch
+        logging.info("sleep for 5 seconds to avoid secondary api limit")
+        time.sleep(5)
         pr_number = super().send_pull_request(self.secrets.test_repo, base_branch, pr_branch, self.secrets.bot_token)
         pr_number_list.append((vendor_type, vendor_name, chart_name, chart_version, pr_number))
+        logging.info(f"PR{pr_number} created in {self.secrets.test_repo} into {base_branch} from {pr_branch}")
 
         # Record expected release tags
         self.secrets.release_tags.append(f'{vendor_name}-{chart_name}-{chart_version}')
@@ -859,7 +889,12 @@ class ChartCertificationE2ETestMultiple(ChartCertificationE2ETest):
         # Process test charts and send PRs from temporary directory
         with SetDirectory(Path(self.temp_dir.name)):
             for vendor_type, vendor_name, chart_name, chart_version in self.secrets.submitted_charts:
+                logging.info(f"Process chart: {vendor_type}, {vendor_name}, {chart_name}, {chart_version}")
                 self.process_single_chart(vendor_type, vendor_name, chart_name, chart_version, pr_number_list, owners_table)
+                logging.info("sleep for 5 seconds  to avoid secondary api limit")
+                time.sleep(5)
 
         for vendor_type, vendor_name, chart_name, chart_version, pr_number in pr_number_list:
+            logging.info(f"PR{pr_number} Check result: {vendor_type}, {vendor_name}, {chart_name}, {chart_version}")
             self.check_single_chart_result(vendor_type, vendor_name, chart_name, chart_version, pr_number, owners_table)
+

--- a/tests/functional/utils/github.py
+++ b/tests/functional/utils/github.py
@@ -33,7 +33,7 @@ def get_run_result(secrets, run_id):
     run = json.loads(r.text)
 
     if run['conclusion'] is None:
-        raise Exception("Workflow is still running.")
+        raise Exception(f"Workflow {run_id} is still running, PR: {secrets.pr_number} ")
 
     return run['conclusion']
 

--- a/tests/functional/utils/notifier.py
+++ b/tests/functional/utils/notifier.py
@@ -77,7 +77,7 @@ def _verify_endpoint(access_token):
         endpoint_data["access_token"] = access_token
 
 
-def create_verification_issue(chart_name, chart_owners, report_url, software_name, software_version, pass_verification, access_token=None):
+def create_verification_issue(chart_name, chart_owners, notify_developers, report_url, software_name, software_version, pass_verification, access_token=None, dry_run=False):
     """Create and issue with chart-verifier findings after a version change trigger.
 
     chart_name -- Name of the chart that was verified. Include version for more verbose information\n
@@ -89,21 +89,32 @@ def create_verification_issue(chart_name, chart_owners, report_url, software_nam
     access_token -- An optional github access token secret. If not passed will try to get from GITHUB_AUTH_TOKEN environment variable\n
     """
 
-    title = f"Action needed for {chart_name} after a certification dependency change"
 
-    report_result = "some chart checks have failed. Consider submiting a new chart version with the appropiate corrections"
-    if pass_verification:
-        report_result = ("all chart checks have passed. With your approval, we could automatically "
-                         "update your chart annotations in index.yaml. Use this issue to communicate "
+    if not pass_verification:
+        title = f"Chart {chart_name}"
+        if dry_run:
+            title = f"Dry Run: Chart {chart_name}"
+
+        if not pass_verification:
+            title = f"{title} has failures with {software_name} version {software_version}"
+
+            report_result = "some chart checks have failed. Please review the failures and, if required, consider submitting a new chart version with the appropriate additions/corrections."
+        else:
+            title = f"{title} passed with new {software_name} version {software_version}"
+
+            report_result = (f"all chart checks have passed. If your chart does not already include support for {software_name} version {software_version},"
+                         "with your approval, we could update your chart annotations in index.yaml. Please use this issue to communicate "
                          "your response")
 
-    body = (f"FYI @{' @'.join(chart_owners)}, we have triggered chart-verifier against chart {chart_name} because the certification flow "
-            f"now supports {software_name} {software_version}. We have found that {report_result}. Check details in the report: "
-            f"{report_url}")
+        body = (f"FYI @{' @'.join(notify_developers)}, we have triggered the chart certification workflow against chart {chart_name} because the workflow "
+            f"now supports {software_name} version {software_version}. We have found that {report_result}. Check details in the report: "
+            f"{report_url}, Chart owners are: {chart_owners}")
 
-    _set_endpoint()
-    _verify_endpoint(access_token)
-    create_an_issue(title, body)
+        _set_endpoint()
+        _verify_endpoint(access_token)
+        create_an_issue(title, body)
+
+
 
 
 def create_version_change_issue(chart_name, chart_owners, software_name, software_version, access_token=None):

--- a/tests/functional/utils/notifier.py
+++ b/tests/functional/utils/notifier.py
@@ -95,16 +95,9 @@ def create_verification_issue(chart_name, chart_owners, notify_developers, repor
         if dry_run:
             title = f"Dry Run: Chart {chart_name}"
 
-        if not pass_verification:
-            title = f"{title} has failures with {software_name} version {software_version}"
 
-            report_result = "some chart checks have failed. Please review the failures and, if required, consider submitting a new chart version with the appropriate additions/corrections."
-        else:
-            title = f"{title} passed with new {software_name} version {software_version}"
-
-            report_result = (f"all chart checks have passed. If your chart does not already include support for {software_name} version {software_version},"
-                         "with your approval, we could update your chart annotations in index.yaml. Please use this issue to communicate "
-                         "your response")
+        title = f"{title} has failures with {software_name} version {software_version}"
+        report_result = "some chart checks have failed. Please review the failures and, if required, consider submitting a new chart version with the appropriate additions/corrections."
 
         body = (f"FYI @{' @'.join(notify_developers)}, we have triggered the chart certification workflow against chart {chart_name} because the workflow "
             f"now supports {software_name} version {software_version}. We have found that {report_result}. Check details in the report: "


### PR DESCRIPTION
Fixes:
- https://issues.redhat.com/browse/HELM-337
- https://issues.redhat.com/browse/HELM-338

Made quite a few changes:

- Fixed the flows so they actually work.
- Issues are only opened if a chart has a failure.
   - In the issues dperaza and mmulholla are tagged not the chart owners.
   - The issue should then be reviewed to ensure it is correct before tagging the owners.
- Updated the content of any issues opened.
- Issues are also opened for a dry run but in openshift-helm-charts/sandbox, the issue titles start ```Dry Run:```
- Dry run will run the checks whether or not version changes are detected.
- Dry run will work from a fork.
- Added a bunch of logging for easier diagnosis of failures.
- Testing hit some issues with the secondary api rate limit from github which happens when a workflow is creating github content too quickly. To resolve this I added a couple of 5 second sleeps which fixed the issue for each chart tested (note: 3 seconds sleeps did not fix the issue).
- Re-enabled the cron job now the flows work.
- renamed the workflow yaml file to be more descriptive
   - was schedule.yaml, now check_version.yaml

Testing:

- Have tested extensively - you can see a clean dry-run here: https://github.com/mmulholla/development/actions/runs/2386105542
- Dry run opens issue in sandbox - you can see a sample here: https://github.com/openshift-helm-charts/sandbox/issues/21423