### PR TITLE
require a package digest for PDC

### DIFF
--- a/scripts/src/chartprreview/chartprreview.py
+++ b/scripts/src/chartprreview/chartprreview.py
@@ -156,6 +156,8 @@ def check_url(directory, report_path):
         msgs.append(str(err))
         write_error_log(directory, *msgs)
 
+    verify_package_digest(chart_url,report_path)
+
 def match_name_and_version(directory, category, organization, chart, version,generated_report_path):
     print("[INFO] Check chart has same name and version as directory structure. %s, %s, %s" % (organization, chart, version))
     submitted_report_path = os.path.join("charts", category, organization, chart, version, "report.yaml")
@@ -300,7 +302,23 @@ def check_report_success(directory, api_url, report_path, report_info_path, vers
             write_error_log(directory, msg)
             sys.exit(1)
 
+def verify_package_digest(url,report):
+    print("[INFO] check package digest.")
 
+    response = requests.get(url, allow_redirects=True)
+    target_digest = hashlib.sha256(response.content).hexdigest()
+
+    found,report_data = verifier_report.get_report_data(report)
+    if found:
+        pkg_digest = verifier_report.get_package_digest(report_data)
+
+    if target_digest:
+        if pkg_digest and pkg_digest != target_digest:
+            # Digest was passed and computed but differ
+            raise Exception("Found an integrity issue. SHA256 digest passed does not match SHA256 digest computed.")
+    elif not pkg_digest:
+        # Digest was not passed and could not be computed
+        raise Exception("Was unable to compute SHA256 digest, please ensure chart url points to a chart package.")
 
 
 def main():
@@ -331,6 +349,7 @@ def main():
     report_generated = os.environ.get("REPORT_GENERATED")
     generated_report_path = os.environ.get("GENERATED_REPORT_PATH")
     generated_report_info_path =  os.environ.get("REPORT_SUMMARY_PATH")
+    provider_delivery = os.environ.get("PROVIDER_DELIVERY")
 
     if os.path.exists(submitted_report_path):
         print("[INFO] Report exists: ", submitted_report_path)
@@ -339,7 +358,7 @@ def main():
         report_info_path = ""
         if report_generated and report_generated == "True":
             match_checksum(args.directory,generated_report_info_path, category, organization, chart, version)
-        else:
+        elif not provider_delivery or provider_delivery == "False":
             check_url(args.directory, report_path)
     else:
         print("[INFO] Report does not exist: ", submitted_report_path)

--- a/scripts/src/checkprcontent/checkpr.py
+++ b/scripts/src/checkprcontent/checkpr.py
@@ -58,8 +58,14 @@ def check_provider_delivery(report_in_pr,num_files_in_pr,report_file_match):
             sys.exit(1)
     elif report_in_pr:
         if report_provider_delivery and owner_provider_delivery:
-            print(f"[INFO] providerDelivery is a go")
-            print(f"::set-output name=providerDelivery::True")
+            if verifier_report.get_package_digest(report_data):
+                print(f"[INFO] providerDelivery is a go")
+                print(f"::set-output name=providerDelivery::True")
+            else:
+                msg = f"[ERROR] Provider delivery control requires a package digest in the report."
+                print(msg)
+                print(f"::set-output name=pr-content-error-message::{msg}")
+                sys.exit(1)
         elif report_provider_delivery:
             msg = f"[ERROR] Report indicates provider controlled delivery but OWNERS file does not."
             print(msg)

--- a/scripts/src/report/verifier_report.py
+++ b/scripts/src/report/verifier_report.py
@@ -84,6 +84,17 @@ def get_provider_delivery(report_data):
         pass
     return provider_delivery
 
+def get_package_digest(report_data):
+    package_digest = None
+    try:
+        digests = report_data["metadata"]["tool"]["digests"]
+        if "package" in digests:
+            package_digest = digests["package"]
+    except Exception as err:
+        print(f"Exception getting providerControlledDelivery {err=}, {type(err)=}")
+        pass
+    return package_digest
+
 def report_is_valid(report_data):
     outcome = True
 

--- a/tests/data/report.json
+++ b/tests/data/report.json
@@ -10,7 +10,8 @@
       },
       "chart-uri": "https://github.com/${repository}/raw/${branch}/tests/data/vault-0.17.0.tgz",
       "digests": {
-        "chart": "sha256:f01dd362d81fe4b1ef99bb7fa5be268fa94dc96f3009d28bc93a18517aa1ef7a"
+        "chart": "sha256:f01dd362d81fe4b1ef99bb7fa5be268fa94dc96f3009d28bc93a18517aa1ef7a",
+        "package" : "9cb7e3a5d82537f512319c754ccd6e9a4be08118b34849609d0fc261934d062a"
       },
       "lastCertifiedTimestamp": "2021-11-24T11:42:48.736244+05:30",
       "testedOpenShiftVersion": "4.9",

--- a/tests/data/report.yaml
+++ b/tests/data/report.yaml
@@ -9,6 +9,7 @@ metadata:
         chart-uri: https://github.com/${repository}/raw/${branch}/tests/data/vault-0.17.0.tgz
         digests:
             chart: sha256:f01dd362d81fe4b1ef99bb7fa5be268fa94dc96f3009d28bc93a18517aa1ef7a
+            package: 9cb7e3a5d82537f512319c754ccd6e9a4be08118b34849609d0fc261934d062a
         lastCertifiedTimestamp: "2021-11-24T11:42:48.736244+05:30"
         testedOpenShiftVersion: "4.9"
         supportedOpenShiftVersions: '>=4.2'

--- a/tests/functional/features/HC-06_provider_delivery_control.feature
+++ b/tests/functional/features/HC-06_provider_delivery_control.feature
@@ -40,12 +40,13 @@ Feature: Report only submission with provider control settings
     Given the vendor <vendor> has a valid identity as <vendor_type>
     And provider delivery control is set to <provider_control_owners> in the OWNERS file
     And a <report_path> is provided
-    And provider delivery control is set to <provider_control_report> in the report
+    And provider delivery control is set to <provider_control_report> and a package digest is <package_digest_set> in the report
     When the user sends a pull request with the report
     Then the pull request is not merged
     And user gets the <message> in the pull request comment
 
     Examples:
-      | vendor_type  | vendor    | provider_control_owners | provider_control_report | message |
-      | partners     | hashicorp | true                    | false                   | OWNERS file indicates provider controlled delivery but report does not. |
-      | partners     | hashicorp | false                   | true                    | Report indicates provider controlled delivery but OWNERS file does not. |
+      | vendor_type  | vendor    | provider_control_owners | provider_control_report | package_digest_set | message |
+      | partners     | hashicorp | true                    | false                   | true               | OWNERS file indicates provider controlled delivery but report does not. |
+      | partners     | hashicorp | false                   | true                    | true               | Report indicates provider controlled delivery but OWNERS file does not. |
+      | partners     | hashicorp | true                    | true                    | false              | Provider delivery control requires a package digest in the report. |

--- a/tests/functional/step_defs/test_provider_delivery_control.py
+++ b/tests/functional/step_defs/test_provider_delivery_control.py
@@ -53,6 +53,20 @@ def provider_delivery_control_set_in_report(workflow_test,provider_control_repor
         print("[INFO] un-set provider delivery control_in report")
         workflow_test.process_report(update_provider_delivery=True,provider_delivery=False)
 
+@given(parsers.parse("provider delivery control is set to <provider_control_report> and a package digest is <package_digest_set> in the report"))
+def provider_delivery_control_and_package_digest_set_in_report(workflow_test,provider_control_report,package_digest_set=True):
+    if package_digest_set == "true":
+        no_package_digest = False
+    else:
+        no_package_digest = True
+
+    if provider_control_report == "true":
+        print("[INFO] set provider delivery control_in report")
+        workflow_test.process_report(update_provider_delivery=True,provider_delivery=True,unset_package_digest=no_package_digest)
+    else:
+        print("[INFO] un-set provider delivery control_in report")
+        workflow_test.process_report(update_provider_delivery=True,provider_delivery=False,unset_package_digest=no_package_digest)
+
 @then(parsers.parse("the <index_file> is updated with an entry for the submitted chart"))
 def index_file_is_updated(workflow_test,index_file):
     workflow_test.secrets.index_file = index_file

--- a/tests/functional/utils/chart_certification.py
+++ b/tests/functional/utils/chart_certification.py
@@ -318,6 +318,8 @@ class ChartCertificationE2ETestSingle(ChartCertificationE2ETest):
         self.secrets.chart_name = chart_name
         self.secrets.chart_version = chart_version
         self.secrets.index_file = "index.yaml"
+        self.secrets.provider_delivery = False
+
 
     def cleanup (self):
         # Cleanup releases and release tags
@@ -464,7 +466,7 @@ class ChartCertificationE2ETestSingle(ChartCertificationE2ETest):
 
     def process_report(self, update_chart_sha=False, update_url=False, url=None,
                        update_versions=False,supported_versions=None,tested_version=None,kube_version=None,
-                       update_provider_delivery=False, provider_delivery=False, missing_check=None):
+                       update_provider_delivery=False, provider_delivery=False, missing_check=None,unset_package_digest=False):
 
         with SetDirectory(Path(self.temp_dir.name)):
             # Copy report to temporary location and push to test_repo:pr_branch
@@ -486,7 +488,7 @@ class ChartCertificationE2ETestSingle(ChartCertificationE2ETest):
                 report["metadata"]["tool"]["profile"]["VendorType"] = self.secrets.vendor_type
                 logging.info(f'VendorType set to {report["metadata"]["tool"]["profile"]["VendorType"]} in report.yaml')
 
-            if update_chart_sha or update_url or update_versions or update_provider_delivery:
+            if update_chart_sha or update_url or update_versions or update_provider_delivery or unset_package_digest:
                 #For updating the report.yaml, for chart sha mismatch scenario
                 if update_chart_sha:
                     new_sha_value = 'sha256:5b85ae00b9ca2e61b2d70a59f98fd72136453b1a185676b29d4eb862981c1xyz'
@@ -510,6 +512,9 @@ class ChartCertificationE2ETestSingle(ChartCertificationE2ETest):
 
                 if update_provider_delivery:
                     report['metadata']['tool']['providerControlledDelivery'] = provider_delivery
+
+                if unset_package_digest:
+                    del report['metadata']['tool']['digests']['package']
 
             with open(report_path, 'w') as fd:
                 try:


### PR DESCRIPTION
Changes made:

if submission is for provider deliver control and package digest is not set , fail the PR
if provider delivery control is set do not check the chart uri in the report.
include a check of the digest as part of checking the chart uri so if there is an issue fail before merge.

added a test for provider deliver control when the report  does not include a package digest.
added package digest to reports used in tests.