### PR TITLE
version_check changes needed for release

### DIFF
--- a/.github/workflows/version_check.yml
+++ b/.github/workflows/version_check.yml
@@ -1,9 +1,5 @@
 name: Check Software Version
 on:
-  # Daily trigger to check updates
-  schedule:
-    - cron: "0 0 * * *"
-  # manual dispatch
   workflow_dispatch:
     inputs:
       # XXX: dry-run has side effects:

--- a/scripts/src/release/releaser.py
+++ b/scripts/src/release/releaser.py
@@ -29,7 +29,7 @@ from release import release_info
 sys.path.append('../')
 from tools import gitutils
 
-SCHEDULE_YAML_FILE=".github/workflows/schedule.yml"
+VERSION_CHECK_YAML_FILE=".github/workflows/version_check.yml"
 BUILD_YAML_FILE=".github/workflows/build.yml"
 DEV_PR_BRANCH_BODY_PREFIX="Charts workflow version"
 DEV_PR_BRANCH_NAME_PREFIX="Auto-Release-"
@@ -45,7 +45,7 @@ SCHEDULE_INSERT = [
 def update_workflow():
 
     lines=[]
-    with open(SCHEDULE_YAML_FILE,'r') as schedule_file:
+    with open(VERSION_CHECK_YAML_FILE,'r') as schedule_file:
 
         lines = schedule_file.readlines()
 
@@ -59,7 +59,7 @@ def update_workflow():
                     lines.insert(insert_location+2,f"{SCHEDULE_INSERT[2]}\n")
                     break
 
-    with open(SCHEDULE_YAML_FILE,'w') as schedule_file:
+    with open(VERSION_CHECK_YAML_FILE,'w') as schedule_file:
         schedule_file.write("".join(lines))
 
 def make_required_changes(release_info_dir,origin,destination):

--- a/tests/functional/step_defs/test_smoke_scenarios.py
+++ b/tests/functional/step_defs/test_smoke_scenarios.py
@@ -8,7 +8,8 @@ from functional.utils.chart_certification import ChartCertificationE2ETestSingle
 def workflow_test():
     test_name = 'Smoke Test'
     test_chart = 'tests/data/vault-0.17.0.tgz'
-    workflow_test = ChartCertificationE2ETestSingle(test_name=test_name, test_chart=test_chart)
+    test_report = 'tests/data/report.yaml'
+    workflow_test = ChartCertificationE2ETestSingle(test_name=test_name, test_chart=test_chart, test_report=test_report)
     yield workflow_test
     workflow_test.cleanup()
 


### PR DESCRIPTION
The release build failed because the script was expecting to update file schedule.yml which is now renamed to version_check.yml. Further even with the correct name it would have failed because the cron job invocation was incorrectly in the development version of version_check.yml so it is now removed. '

Also added a quick fix for the smoke tests to fix the provider delivery control failure (test problem)