### PR TITLE
check OCP version support in index.yaml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,7 +118,7 @@ jobs:
 
       - name: Remove 'content-ok' label
         uses: actions/github-script@v3
-        if: ${{ steps.check_pr_content.outcome == 'failure'}}
+        if: ${{ steps.check_pr_content.outcome == 'failure' && contains( github.event.pull_request.labels.*.name, 'content-ok') }}
         continue-on-error: true
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
@@ -138,7 +138,7 @@ jobs:
 
       - name: Remove 'authorized-request' label from PR
         uses: actions/github-script@v3
-        if: ${{ steps.check_build_required.outputs.run-build == 'true' }}
+        if: ${{ steps.check_build_required.outputs.run-build == 'true' && contains( github.event.pull_request.labels.*.name, 'authorized-request') }}
         continue-on-error: true
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/src/indexfile/index.py
+++ b/scripts/src/indexfile/index.py
@@ -8,14 +8,10 @@ import sys
 sys.path.append('../')
 from chartrepomanager import indexannotations
 
-def _make_http_request(method, url, body=None, params={}, headers={}, verbose=False):
-    method_map = {"get": requests.get,
-                  "post": requests.post,
-                  "put": requests.put,
-                  "delete": requests.delete,
-                  "patch": requests.patch}
-    request_method = method_map[method]
-    response = request_method(url, params=params, headers=headers, json=body)
+INDEX_FILE = "https://charts.openshift.io/index.yaml"
+
+def _make_http_request(url, body=None, params={}, headers={}, verbose=False):
+    response = requests.get(url, params=params, headers=headers, json=body)
     if verbose:
         print(json.dumps(headers, indent=4, sort_keys=True))
         print(json.dumps(body, indent=4, sort_keys=True))
@@ -23,14 +19,13 @@ def _make_http_request(method, url, body=None, params={}, headers={}, verbose=Fa
         print(response.text)
     return response.text
 
-def _load_index_yaml(url):
-
-    yaml_text = _make_http_request('get', url)
+def _load_index_yaml():
+    yaml_text = _make_http_request(INDEX_FILE)
     dct = yaml.safe_load(yaml_text)
     return dct
 
 def get_chart_info(tar_name):
-    index_dct = _load_index_yaml("https://charts.openshift.io/index.yaml")
+    index_dct = _load_index_yaml()
     for entry, charts in index_dct["entries"].items():
         if tar_name.startswith(entry):
             for chart in charts:
@@ -46,7 +41,7 @@ def get_chart_info(tar_name):
 def get_charts_info():
     chart_info_list = []
 
-    index_dct = _load_index_yaml("https://charts.openshift.io/index.yaml")
+    index_dct = _load_index_yaml()
     for entry, charts in index_dct["entries"].items():
         for chart in charts:
             chart_info = {}

--- a/scripts/src/indexfile/index.py
+++ b/scripts/src/indexfile/index.py
@@ -2,6 +2,11 @@
 import json
 import requests
 import yaml
+import semantic_version
+import sys
+
+sys.path.append('../')
+from chartrepomanager import indexannotations
 
 def _make_http_request(method, url, body=None, params={}, headers={}, verbose=False):
     method_map = {"get": requests.get,
@@ -38,5 +43,97 @@ def get_chart_info(tar_name):
     print(f"[INFO] match not found: {tar_name}")
     return "","","",""
 
+def get_charts_info():
+    chart_info_list = []
+
+    index_dct = _load_index_yaml("https://charts.openshift.io/index.yaml")
+    for entry, charts in index_dct["entries"].items():
+        for chart in charts:
+            chart_info = {}
+            chart_info["name"] = chart['name']
+            chart_info["version"] = chart["version"]
+            chart_info["providerType"] = chart["annotations"]["charts.openshift.io/providerType"]
+            chart_info["provider"] =  entry.removesuffix(f'-{chart["name"]}')
+            #print(f'[INFO] found chart : {chart_info["provider"]} {chart["name"]} {chart["version"]} ')
+            if 'charts.openshift.io/supportedOpenShiftVersions' in chart["annotations"]:
+                chart_info["supportedOCP"] = chart["annotations"]["charts.openshift.io/supportedOpenShiftVersions"]
+            else:
+                chart_info["supportedOCP"] = ""
+            if "kubeVersion" in chart:
+                chart_info["kubeVersion"] = chart["kubeVersion"]
+            else:
+                chart_info["kubeVersion"] =""
+            chart_info_list.append(chart_info)
+
+    return chart_info_list
+
+def get_latest_charts():
+    chart_list = get_charts_info()
+
+    print(f"{len(chart_list)} charts found in Index file")
+
+    chart_in_process = {"name" : ""}
+    chart_latest_version = ""
+    latest_charts = []
+
+    for index,chart in enumerate(chart_list):
+        chart_name = chart["name"]
+        #print(f'[INFO] look for latest chart : {chart_name} {chart["version"]}')
+        if chart_name == chart_in_process["name"]:
+            new_version = semantic_version.Version.coerce(chart["version"])
+            #print(f'   [INFO] compare chart versions : {new_version}({chart["version"]}) : {chart_latest_version}')
+            if new_version > chart_latest_version:
+                #print(f'   [INFO] a new latest chart version : {new_version}')
+                chart_latest_version = new_version
+                chart_in_process = chart
+        else:
+            if chart_in_process["name"] != "":
+                #print(f'   [INFO] chart completed : {chart_in_process["name"]} {chart_in_process["version"]}')
+                latest_charts.append(chart_in_process)
+
+                #print(f'[INFO] new  chart found : {chart_name} {chart["version"]}')
+                chart_in_process = chart
+                chart_version = chart["version"]
+                if chart_version.startswith("v"):
+                    chart_version = chart_version[1:]
+                chart_latest_version = semantic_version.Version.coerce(chart_version)
+            else:
+                chart_in_process = chart
+
+        if index+1 == len(chart_list):
+            #print(f'   [INFO] last chart completed : {chart_in_process["name"]} {chart_in_process["version"]}')
+            latest_charts.append(chart_in_process)
+
+    return latest_charts
+
+
 if __name__ == "__main__":
     get_chart_info("redhat-dotnet-0.0.1")
+
+    chart_list = get_latest_charts()
+
+    for chart in chart_list:
+        print(f'[INFO] found latest chart : {chart["name"]} {chart["version"]}')
+
+
+    OCP_VERSION = semantic_version.Version.coerce("4.11")
+
+    for chart in chart_list:
+        if "supportedOCP" in chart and chart["supportedOCP"] != "N/A" and chart["supportedOCP"] != "":
+            if OCP_VERSION in semantic_version.NpmSpec(chart["supportedOCP"]):
+                print(f'PASS: Chart supported OCP version {chart["supportedOCP"]} includes: {OCP_VERSION}')
+            else:
+                print(f'   ERROR: Chart supported OCP version {chart["supportedOCP"]} does not include {OCP_VERSION}')
+        elif "kubeVersion" in chart and chart["kubeVersion"] != "":
+            supportedOCPVersion = indexannotations.getOCPVersions(chart["kubeVersion"])
+            if OCP_VERSION in semantic_version.NpmSpec(supportedOCPVersion):
+                print(f'PASS: Chart kubeVersion  {chart["kubeVersion"]} (OCP: {supportedOCPVersion}) includes OCP version: {OCP_VERSION}')
+            else:
+                print(f'   ERROR: Chart kubeVersion {chart["kubeVersion"]} (OCP: {supportedOCPVersion}) does not include {OCP_VERSION}')
+
+
+
+
+
+
+

--- a/tests/functional/utils/github.py
+++ b/tests/functional/utils/github.py
@@ -10,11 +10,8 @@ from functional.utils.setttings import *
 
 @retry(stop_max_delay=30_000, wait_fixed=1000)
 def get_run_id(secrets, pr_number=None):
-    pr_number = secrets.pr_number if pr_number is None else pr_number
-    r = github_api(
-        'post', f'repos/{secrets.test_repo}/pulls/{pr_number}', secrets.bot_token)
-    pr = json.loads(r.text)
 
+    pr = get_pr(secrets, pr_number)
     r = github_api(
         'get', f'repos/{secrets.test_repo}/actions/runs', secrets.bot_token)
     runs = json.loads(r.text)
@@ -61,6 +58,15 @@ def get_release_by_tag(secrets, release_tag):
         if release['tag_name'] == release_tag:
             return release
     raise Exception("Release not published")
+
+
+def get_pr(secrets, pr_number=None):
+    pr_number = secrets.pr_number if pr_number is None else pr_number
+    r = github_api(
+        'post', f'repos/{secrets.test_repo}/pulls/{pr_number}', secrets.bot_token)
+    pr = json.loads(r.text)
+    return pr
+
 
 def github_api_get(endpoint, bot_token, headers={}):
     if not headers:

--- a/tests/functional/utils/index.py
+++ b/tests/functional/utils/index.py
@@ -1,0 +1,43 @@
+
+import logging
+import semantic_version
+import sys
+
+sys.path.append('../../../scripts/src')
+from chartrepomanager import indexannotations
+from indexfile import index
+
+
+
+def check_index_entries(ocpVersion):
+
+    all_chart_list = index.get_latest_charts()
+    failed_chart_list = []
+
+    OCP_VERSION = semantic_version.Version.coerce(ocpVersion)
+
+    for chart in all_chart_list:
+        if "supportedOCP" in chart and chart["supportedOCP"] != "N/A" and chart["supportedOCP"] != "":
+            if OCP_VERSION in semantic_version.NpmSpec(chart["supportedOCP"]):
+                logging.info(f'PASS: Chart {chart["name"]} {chart["version"]} supported OCP version {chart["supportedOCP"]} includes: {OCP_VERSION}')
+            else:
+                chart["message"] = f'chart {chart["name"]} {chart["version"]} supported OCP version {chart["supportedOCP"]} does not include latest OCP version {OCP_VERSION}'
+                logging.info(f'   ERROR: Chart {chart["name"]} {chart["version"]} supported OCP version {chart["supportedOCP"]} does not include {OCP_VERSION}')
+                failed_chart_list.append(chart)
+        elif "kubeVersion" in chart and chart["kubeVersion"] != "":
+            supportedOCPVersion = indexannotations.getOCPVersions(chart["kubeVersion"])
+            if OCP_VERSION in semantic_version.NpmSpec(supportedOCPVersion):
+                logging.info(f'PASS: Chart {chart["name"]} {chart["version"]} kubeVersion  {chart["kubeVersion"]} (OCP: {supportedOCPVersion}) includes OCP version: {OCP_VERSION}')
+            else:
+                chart["message"] = f'chart {chart["name"]} {chart["version"]} kubeVersion {chart["kubeVersion"]} (OCP: {supportedOCPVersion}) does not include latest OCP version {OCP_VERSION}'
+                logging.info(f'   ERROR: Chart {chart["name"]} {chart["version"]} kubeVersion {chart["kubeVersion"]} (OCP: {supportedOCPVersion}) does not include {OCP_VERSION}')
+                failed_chart_list.append(chart)
+
+    return failed_chart_list
+
+
+
+
+
+
+

--- a/tests/functional/utils/notifier.py
+++ b/tests/functional/utils/notifier.py
@@ -11,6 +11,7 @@ from functional.utils.setttings import *
 
 endpoint_data = {}
 
+CHECKS_FAILED = "checks failed"
 
 def _set_endpoint_key(key, env_var):
     if key not in endpoint_data:
@@ -77,35 +78,39 @@ def _verify_endpoint(access_token):
         endpoint_data["access_token"] = access_token
 
 
-def create_verification_issue(chart_name, chart_owners, notify_developers, report_url, software_name, software_version, pass_verification, access_token=None, dry_run=False):
+def create_verification_issue(chart, chart_owners, failure_type, notify_developers, pr_url, report_url, software_name, software_version, access_token=None, dry_run=False):
     """Create and issue with chart-verifier findings after a version change trigger.
 
     chart_name -- Name of the chart that was verified. Include version for more verbose information\n
     chart_owners -- Github IDs of the chart owners\n
-    report_url -- URL or the report resulting from verification\n
+    failure_type - Indication of the type of failure
+    report_url -- URL or the report resulting from verification if applicable\n
+    kube-version -- The kubeVersion attribute of the chart if it is bade.\n
     software_name -- Name of the software dependency that changed e.g, OCP and Chart Verifier\n
     software_version -- The softwared dependency version used\n
-    pass_verification -- A boolean indicating whether the verification passed\n
-    access_token -- An optional github access token secret. If not passed will try to get from GITHUB_AUTH_TOKEN environment variable\n
+    access_token -- An optional github access token secret. If not passed will try to get from GITHUB_AUTH_TOKEN environment variable\
+    dry-run -- Set if the test run is a dry-run.
     """
 
 
-    if not pass_verification:
-        title = f"Chart {chart_name}"
-        if dry_run:
-            title = f"Dry Run: Chart {chart_name}"
+    title = f"Chart {chart}"
+    if dry_run:
+        title = f"Dry Run: Chart {chart}"
 
-
+    if failure_type == CHECKS_FAILED:
         title = f"{title} has failures with {software_name} version {software_version}"
         report_result = "some chart checks have failed. Please review the failures and, if required, consider submitting a new chart version with the appropriate additions/corrections."
+        body = (f"FYI @{' @'.join(notify_developers)}, in PR {pr_url} we triggered the chart certification workflow against chart {chart} because the workflow "
+                f"now supports {software_name} version {software_version}. We have found that {report_result}. Check details in the report: "
+                f"{report_url}, Chart owners are: {chart_owners}")
+    else:
+        title = f"{title} does not support {software_name} version {software_version}"
+        body = (f"FYI @{' @'.join(notify_developers)}, we checked the OCP versions supported by {chart} because the workflow "
+        f"now supports {software_name} version {software_version}. We have found that {failure_type}. Chart owners are: {chart_owners}")
 
-        body = (f"FYI @{' @'.join(notify_developers)}, we have triggered the chart certification workflow against chart {chart_name} because the workflow "
-            f"now supports {software_name} version {software_version}. We have found that {report_result}. Check details in the report: "
-            f"{report_url}, Chart owners are: {chart_owners}")
-
-        _set_endpoint()
-        _verify_endpoint(access_token)
-        create_an_issue(title, body)
+    _set_endpoint()
+    _verify_endpoint(access_token)
+    create_an_issue(title, body)
 
 
 


### PR DESCRIPTION
https://issues.redhat.com/browse/HELM-358

Updated version check workflow to check that the OCP Versions or kubeVersion of all charts  (latest version only) in index.yaml include the OCP version which caused the workflow to run.  

For this needed a mew message when opening a PR, for example:
```
FYI @mmulholla, we checked the OCP versions supported by ibm ibm-oms-ent-prod 6.0.2 because the workflow now supports OpenShift version 4.10.25. We have found that chart ibm-oms-ent-prod 6.0.2 kubeVersion 1.16.0-0 (OCP: 4.3) does not include latest OCP version 4.10.25. Chart owners are: ['ntinvo']
``` 

also improved other messages. 

Also a fix to read the OCP version to kubeVersion map from a chart verifier file so we have a single source.