### PR TITLE
Smoke fail fix

### DIFF
--- a/tests/functional/behave_features/common/utils/chart_certification.py
+++ b/tests/functional/behave_features/common/utils/chart_certification.py
@@ -304,7 +304,7 @@ class ChartCertificationE2ETestSingle(ChartCertificationE2ETest):
         test_repo = TEST_REPO
 
         #Storing current branch to checkout after scenario execution
-        if os.environ.get('WORKFLOW_DEVELOPMENT'):
+        if os.environ.get('LOCAL_RUN'):
             self.secrets.active_branch = self.repo.active_branch.name
             logging.debug(f"Active branch name : {self.secrets.active_branch}")
 
@@ -380,7 +380,7 @@ class ChartCertificationE2ETestSingle(ChartCertificationE2ETest):
 
         logging.info(f"Delete local '{current_branch}'")
         try:
-            if os.environ.get('WORKFLOW_DEVELOPMENT'):
+            if os.environ.get('LOCAL_RUN'):
                 self.repo.git.checkout(f'{self.secrets.active_branch}')
             self.repo.git.branch('-D', current_branch)
         except git.exc.GitCommandError:

--- a/tests/functional/behave_features/common/utils/chart_certification.py
+++ b/tests/functional/behave_features/common/utils/chart_certification.py
@@ -304,8 +304,9 @@ class ChartCertificationE2ETestSingle(ChartCertificationE2ETest):
         test_repo = TEST_REPO
 
         #Storing current branch to checkout after scenario execution
-        self.secrets.active_branch = self.repo.active_branch.name
-        logging.debug(f"Active branch name : {self.secrets.active_branch}")
+        if os.environ.get('WORKFLOW_DEVELOPMENT'):
+            self.secrets.active_branch = self.repo.active_branch.name
+            logging.debug(f"Active branch name : {self.secrets.active_branch}")
 
         # Create a new branch locally from detached HEAD
         head_sha = self.repo.git.rev_parse('--short', 'HEAD')
@@ -379,7 +380,8 @@ class ChartCertificationE2ETestSingle(ChartCertificationE2ETest):
 
         logging.info(f"Delete local '{current_branch}'")
         try:
-            self.repo.git.checkout(f'{self.secrets.active_branch}')
+            if os.environ.get('WORKFLOW_DEVELOPMENT'):
+                self.repo.git.checkout(f'{self.secrets.active_branch}')
             self.repo.git.branch('-D', current_branch)
         except git.exc.GitCommandError:
             logging.info(f"Local '{current_branch}' does not exist")


### PR DESCRIPTION
Fixes the current smoke test run failure on PR.

https://github.com/openshift-helm-charts/development/runs/7631696491?check_suite_focus=true

It was failing due to we were trying to get the branch name from a detached HEAD state. This part of the code helps us to move back to the current branch when running locally. We now need to set LOCAL_RUN environment, if we are running test locally.

Tested the change on my fork here https://github.com/tisutisu/development/runs/7646415155?check_suite_focus=true