### PR TITLE
Check chart version is a valid semantic version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -205,6 +205,13 @@ jobs:
             report_type: all
             fail: false
 
+      - name: check-verifier-result
+        id: check-verifier-result
+        if: ${{ always() && steps.run-verifier.outcome == 'failure' }}
+        run: |
+          error_message="The chart verifier returned an error when trying to obtain a verification report for the chart."
+          echo "::set-output name=verifier_error_message::$error_message"
+
       - name: Check Report
         id: check_report
         if: ${{ steps.check_build_required.outputs.run-build == 'true' }}
@@ -241,8 +248,9 @@ jobs:
           OWNERS_ERROR_MESSAGE: ${{ steps.check_pr_content.outputs.owners-error-message }}
           COMMUNITY_MANUAL_REVIEW: ${{ steps.check_report.outputs.community_manual_review_required }}
           OC_INSTALL_RESULT: ${{ steps.install-oc.conclusion }}
+          VERIFIER_ERROR_MESSAGE: ${{ steps.check-verifier-result.outputs.verifier_error_message }}
         run: |
-          ve1/bin/pr-comment ${{ steps.check_pr_content.outcome }} ${{ steps.check_report.conclusion }} ${{ github.repository }}
+          ve1/bin/pr-comment ${{ steps.check_pr_content.outcome }} ${{ steps.run-verifier.outcome }} ${{ steps.check_report.conclusion }}
 
       - name: Comment on PR
         if: ${{ always() && steps.check_build_required.outputs.run-build == 'true' }}
@@ -261,7 +269,7 @@ jobs:
             });
 
       - name: Add 'authorized-request' label to PR
-        if: ${{ always() && steps.check_pr_content.outcome == 'success' && steps.check_build_required.outputs.run-build == 'true' }}
+        if: ${{ always() && steps.check_pr_content.outcome == 'success' && steps.run-verifier.outcome != 'failure' && steps.check_build_required.outputs.run-build == 'true' }}
         uses: actions/github-script@v3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/src/checkprcontent/checkpr.py
+++ b/scripts/src/checkprcontent/checkpr.py
@@ -144,7 +144,6 @@ def ensure_only_chart_is_modified(api_url, repository, branch):
                     print(f"[INFO] Report found: {file_path}")
                     print("::set-output name=report-exists::true")
                     report_found = True
-                    report_path = file_path
                 if matches_found == 1:
                     pattern_match = match
                 elif pattern_match.groups() != match.groups():

--- a/scripts/src/checkprcontent/checkpr.py
+++ b/scripts/src/checkprcontent/checkpr.py
@@ -4,6 +4,7 @@ import sys
 import argparse
 
 import requests
+import semver
 import yaml
 try:
     from yaml import CLoader as Loader, CDumper as Dumper
@@ -140,9 +141,10 @@ def ensure_only_chart_is_modified(api_url, repository, branch):
             else:
                 matches_found += 1
                 if reportpattern.match(file_path):
-                    print("[INFO] Report found")
+                    print(f"[INFO] Report found: {file_path}")
                     print("::set-output name=report-exists::true")
                     report_found = True
+                    report_path = file_path
                 if matches_found == 1:
                     pattern_match = match
                 elif pattern_match.groups() != match.groups():
@@ -183,6 +185,13 @@ def ensure_only_chart_is_modified(api_url, repository, branch):
         category, organization, chart, version = pattern_match.groups()
         print(f"::set-output name=category::{'partner' if category == 'partners' else category}")
         print(f"::set-output name=organization::{organization}")
+
+        if not semver.VersionInfo.isvalid(version):
+            msg = f"[ERROR] Helm chart version is not a valid semantic version: {version}"
+            print(msg)
+            print(f"::set-output name=pr-content-error-message::{msg}")
+            sys.exit(1)
+
         print("Downloading index.yaml", category, organization, chart, version)
         r = requests.get(f'https://raw.githubusercontent.com/{repository}/{branch}/index.yaml')
         if r.status_code == 200:
@@ -191,7 +200,6 @@ def ensure_only_chart_is_modified(api_url, repository, branch):
             data = {"apiVersion": "v1",
                 "entries": {}}
 
-        crtentries = []
         entry_name = f"{organization}-{chart}"
         d = data["entries"].get(entry_name, [])
         print(f"::set-output name=chart-entry-name::{entry_name}")

--- a/scripts/src/pullrequest/prepare_pr_comment.py
+++ b/scripts/src/pullrequest/prepare_pr_comment.py
@@ -20,12 +20,14 @@ def get_verifier_errors_trailer():
     return "Please run the [chart-verifier](https://github.com/redhat-certification/chart-verifier) \
 and ensure all mandatory checks pass."
 
+def get_look_at_job_output_comment():
+    return f"""To see the console output with the error messages, click the "Details" \
+link next to "CI / Chart Certification" job status towards the end of this page."""
+
 def prepare_failure_comment():
     msg = f"""\
 {get_failure_comment()}
-To see the console output with the error messages, click the "Details"
-link next to "CI / Chart Certification" job status towards the end of this page.
-"""
+{get_look_at_job_output_comment()}"""
     if os.path.exists("./pr/errors"):
         errors = open("./pr/errors").read()
         msg += f"""
@@ -55,6 +57,17 @@ def prepare_pr_content_failure_comment():
         msg += f"{owners_error_msg}\n\n"
     return msg
 
+def prepare_run_verifier_failure_comment():
+    verifier_error_msg = os.environ.get("VERIFIER_ERROR_MESSAGE", "")
+    print(f"::set-output name=error-message::{verifier_error_msg}")
+    msg = f"""   
+{verifier_error_msg}
+
+{get_look_at_job_output_comment()}
+"""
+    return msg
+
+
 def prepare_community_comment():
     msg = f"{get_community_review_message()}\n\n"
     if os.path.exists("./pr/errors"):
@@ -82,8 +95,8 @@ def get_comment_footer(vendor_label, chart_name):
 
 def main():
     pr_content_result = sys.argv[1]
-    verify_result = sys.argv[2]
-    repository = sys.argv[3]
+    run_verifier_result = sys.argv[2]
+    verify_result = sys.argv[3]
     issue_number = open("./pr/NR").read().strip()
     vendor_label = open("./pr/vendor").read().strip()
     chart_name = open("./pr/chart").read().strip()
@@ -91,6 +104,9 @@ def main():
     oc_install_result = os.environ.get("OC_INSTALL_RESULT", False)
     if pr_content_result == "failure":
         msg += prepare_pr_content_failure_comment()
+        print(f"::set-output name=pr_passed::false")
+    elif run_verifier_result == "failure":
+        msg += prepare_run_verifier_failure_comment()
         print(f"::set-output name=pr_passed::false")
     elif verify_result == "failure":
         community_manual_review = os.environ.get("COMMUNITY_MANUAL_REVIEW",False)

--- a/scripts/src/report/verifier_report.py
+++ b/scripts/src/report/verifier_report.py
@@ -84,6 +84,15 @@ def get_provider_delivery(report_data):
         pass
     return provider_delivery
 
+def get_chart_version(report_data):
+    chart_version = ""
+    try:
+        chart_version = report_data["metadata"]["chart"]["version"]
+    except Exception as err:
+        print(f"Exception getting chart version {err=}, {type(err)=}")
+        pass
+    return chart_version
+
 def get_package_digest(report_data):
     package_digest = None
     try:

--- a/scripts/src/report/verifier_report.py
+++ b/scripts/src/report/verifier_report.py
@@ -24,7 +24,6 @@ These are not comprehensive lists - other certification checks will preform furt
 """
 
 import sys
-import os
 import semantic_version
 
 import yaml
@@ -83,15 +82,6 @@ def get_provider_delivery(report_data):
         print(f"Exception getting providerControlledDelivery {err=}, {type(err)=}")
         pass
     return provider_delivery
-
-def get_chart_version(report_data):
-    chart_version = ""
-    try:
-        chart_version = report_data["metadata"]["chart"]["version"]
-    except Exception as err:
-        print(f"Exception getting chart version {err=}, {type(err)=}")
-        pass
-    return chart_version
 
 def get_package_digest(report_data):
     package_digest = None

--- a/tests/functional/behave_features/HC-14_user_submits_chart_with_errors.feature
+++ b/tests/functional/behave_features/HC-14_user_submits_chart_with_errors.feature
@@ -37,7 +37,8 @@ Feature: Chart submission with errors
     Examples:
       | vendor_type  | vendor    | chart_path                     | message                               | bad_version | 
       | partners     | hashicorp | tests/data/vault-0.17.0.tgz    | doesn't match the directory structure | 9.9.9       |
-    
+      | partners     | hashicorp | tests/data/vault-0.17.0.tgz    | The chart verifier returned an error  | abc-9.9.9       |
+
     @redhat @full
     Examples:
       | vendor_type  | vendor    | chart_path                     | message                               | bad_version |


### PR DESCRIPTION
Added an early check for the version based on the directory structure to be valid semantic version and error if it is not. Current test suite does not support creating a chart in a directory with an invalid semantic version so have opened a jira story to add this: https://issues.redhat.com/browse/HELM-409
A manual test can be seen here: https://github.com/mmulholla/development/pull/309

Also added code to handle the chart verifier step ending in an error and not producing a report. This could happen, for example, if the directory structure uses a valid chart version but the chart itself includes a version which is not a valid semantic version. Added a  test for this as it was a simple addition. Note: without this fix, certification would fail but the message added to the PR said the chart had been certified.