### PR TITLE
add support for signed charts

### DIFF
--- a/scripts/src/owners/owners_file.py
+++ b/scripts/src/owners/owners_file.py
@@ -37,7 +37,6 @@ def get_chart(owner_data):
         pass
     return chart
 
-
 def get_provider_delivery(owner_data):
     provider_delivery = False
     try:
@@ -56,5 +55,12 @@ def get_users_included(owner_data):
         pass
     return users_included
 
+def get_pgp_public_key(owner_data):
+    pgp_public_key = "null"
+    try:
+        pgp_public_key = owner_data["publicPgpKey"]
+    except Exception:
+        pass
+    return pgp_public_key
 
 

--- a/scripts/src/report/get_verify_params.py
+++ b/scripts/src/report/get_verify_params.py
@@ -5,6 +5,7 @@ import argparse
 
 sys.path.append('../')
 from chartprreview import chartprreview
+from signedchart import signedchart
 
 def generate_verify_options(directory,category, organization, chart, version):
     print("[INFO] Generate verify options. %s, %s, %s" % (organization,chart,version))
@@ -28,6 +29,12 @@ def generate_verify_options(directory,category, organization, chart, version):
         return flags,src,True, cluster_needed
     elif os.path.exists(tar) and not os.path.exists(src):
         print("[INFO] tarball included")
+        if not os.path.exists(report_path):
+            owners_file = os.path.join(os.getcwd(),"charts", category, organization, chart, "OWNERS")
+            signed_flags = signedchart.get_verifier_flags(tar,owners_file,directory)
+            if signed_flags:
+                print(f"[INFO] include flags for signed chart: {signed_flags}")
+                flags = f"{flags} {signed_flags}"
         return flags,tar,True, cluster_needed
     elif os.path.exists(tar) and os.path.exists(src):
         msg = "[ERROR] Both chart source directory and tarball should not exist"

--- a/scripts/src/report/verifier_report.py
+++ b/scripts/src/report/verifier_report.py
@@ -53,18 +53,23 @@ def get_report_data(report_path):
 
 def get_result(report_data,check_name):
     outcome = False
+    reason = "Not Found"
     for result in report_data["results"]:
         if result["check"].endswith(check_name):
+            reason = result["reason"]
             if result["outcome"] == "PASS":
                 outcome = True
             break
-    return outcome
+    return outcome,reason
 
 def get_chart_testing_result(report_data):
     return get_result(report_data,"/chart-testing")
 
 def get_has_kubeversion_result(report_data):
     return get_result(report_data,"/has-kubeversion")
+
+def get_signature_is_valid_result(report_data):
+    return get_result(report_data,"/signature-is-valid")
 
 def get_profile_version(report_data):
     profile_version = "1.1"
@@ -90,9 +95,21 @@ def get_package_digest(report_data):
         if "package" in digests:
             package_digest = digests["package"]
     except Exception as err:
-        print(f"Exception getting providerControlledDelivery {err=}, {type(err)=}")
+        print(f"Exception getting package digest {err=}, {type(err)=}")
         pass
     return package_digest
+
+def get_public_key_digest(report_data):
+    public_key_digest = None
+    try:
+        digests = report_data["metadata"]["tool"]["digests"]
+        if "publicKey" in digests:
+            public_key_digest = digests["publicKey"]
+    except Exception as err:
+        print(f"Exception getting publicKey digest {err=}, {type(err)=}")
+        pass
+    return public_key_digest
+
 
 def report_is_valid(report_data):
     outcome = True
@@ -129,7 +146,8 @@ def validate(report_path):
         return False,f"Report is incomplete and cannot be processed: {report_path}"
 
     ## No value in checking if chart testing failed
-    if get_chart_testing_result(report_data):
+    chart_testing_outcome,_ = get_chart_testing_result(report_data)
+    if chart_testing_outcome:
 
         profile_version_string = get_profile_version(report_data)
 
@@ -163,7 +181,8 @@ def validate(report_path):
         except ValueError:
             return False,f"{tested_version_annotation} {tested_version_string} is not a valid semantic version."
 
-        if get_has_kubeversion_result:
+        has_kubeversion_outcome,_ = get_chart_testing_result(report_data)
+        if has_kubeversion_outcome:
 
             chart = report_info.get_report_chart(report_path)
             if KUBE_VERSION_ATTRIBUTE in chart:

--- a/scripts/src/signedchart/signedchart.py
+++ b/scripts/src/signedchart/signedchart.py
@@ -1,0 +1,167 @@
+import requests
+import sys
+import subprocess
+import base64
+import filecmp
+import os
+
+import yaml
+try:
+    from yaml import CLoader as Loader, CDumper as Dumper
+except ImportError:
+    from yaml import Loader, Dumper
+
+sys.path.append('../')
+from report import verifier_report
+from owners import owners_file
+
+def check_and_prepare_signed_chart(api_url,report_path,owner_path,key_file_path):
+
+    signed_chart = is_chart_signed(api_url,report_path)
+    key_in_owners = False
+    keys_match = False
+    if signed_chart:
+        owners_pgp_key = get_pgp_key_from_owners(owner_path)
+        if owners_pgp_key:
+            key_in_owners = True
+            if report_path:
+                keys_match = check_pgp_public_key(owners_pgp_key,report_path)
+            elif key_file_path:
+                create_public_key_file(owners_pgp_key,key_file_path)
+
+    return signed_chart,key_in_owners,keys_match
+
+def get_verifier_flags(tar_file,owners_file,temp_dir):
+    prov_file = f"{tar_file}.prov"
+    if os.path.exists(prov_file):
+        gpg_key = get_pgp_key_from_owners(owners_file)
+        if gpg_key:
+            key_file = os.path.join(temp_dir,"pgp",f"{tar_file}.key")
+            create_public_key_file(gpg_key,key_file)
+            return f"--pgp-public-key {key_file}"
+    return ""
+
+
+def is_chart_signed(api_url,report_path):
+
+    if api_url:
+        files_api_url = f'{api_url}/files'
+        headers = {'Accept': 'application/vnd.github.v3+json'}
+        r = requests.get(files_api_url, headers=headers)
+        tgz_pattern = re.compile(r"charts/(\w+)/([\w-]+)/([\w-]+)/([\w\.-]+)/.*.tgz")
+        tgz_found = False
+        prov_pattern = re.compile(r"charts/(\w+)/([\w-]+)/([\w-]+)/([\w\.-]+)/.*.tgz.prov")
+        prov_found = False
+
+        for f in r.json():
+            if tgz_pattern.match(f["filename"]):
+                tgz_found = True
+            if prov_pattern.match(f["filename"]):
+                prov_found = True
+
+        if tgz_found and prov_found:
+            return True
+    elif report_path:
+        return check_report_for_signed_chart(report_path)
+
+    return False
+
+def key_in_owners_match_report(owner_path,report_path):
+    owner_key = get_pgp_key_from_owners(owner_path)
+    if not owner_key:
+        return True
+    return check_pgp_public_key(owner_key,report_path)
+
+def get_pgp_key_from_owners(owner_path):
+    found, owner_data = owners_file.get_owner_data_from_file(owner_path)
+    if found:
+        pgp_key = owners_file.get_pgp_public_key(owner_data)
+        if pgp_key == "null":
+            pgp_key = ""
+
+        return pgp_key
+    return ""
+
+
+def check_report_for_signed_chart(report_path):
+
+    found,report_data = verifier_report.get_report_data(report_path)
+    if found:
+        outcome,reason = verifier_report.get_signature_is_valid_result(report_data)
+        if "Chart is signed" in reason:
+            return True
+    return False
+
+
+def check_pgp_public_key(owner_pgp_key,report_path):
+
+    ## return True if one of:
+    #  - report not found
+    #  - report is not for a signed chart
+    #  - digests match
+    found,report_data = verifier_report.get_report_data(report_path)
+    if found:
+        pgp_public_key_digest_owners = subprocess.getoutput(f'echo {owner_pgp_key} | sha256sum').split(" ")[0]
+        print(f"[INFO] digest of PGP key from OWNERS :{pgp_public_key_digest_owners}:")
+        pgp_public_digest_report = verifier_report.get_public_key_digest(report_data)
+        print(f"[INFO] PGP key digest in report :{pgp_public_digest_report}:")
+        if pgp_public_digest_report:
+            return pgp_public_key_digest_owners == pgp_public_digest_report
+        else:
+            return not check_report_for_signed_chart(report_path)
+    return True
+
+
+def create_public_key_file(pgp_public_key_from_owners,key_file_path):
+
+    key_content = base64.b64decode(pgp_public_key_from_owners)
+
+    key_file = open(key_file_path, "w")
+    key_file.write(key_content.decode('utf-8'))
+    key_file.close()
+
+
+def main():
+
+    if not is_chart_signed("","./partner-report.yaml"):
+        print("ERROR chart is signed")
+    else:
+        print("PASS chart is signed")
+
+    if not check_report_for_signed_chart("./partner-report.yaml"):
+        print("ERROR report indicates chart is signed")
+    else:
+        print("PASS report is signed")
+
+
+    encoded_key_in_owners = get_pgp_key_from_owners("./OWNERS")
+    if not check_pgp_public_key(encoded_key_in_owners,"./partner-report.yaml"):
+        print("ERROR key digests do not match")
+    else:
+        print("PASS key digests match")
+
+
+    signed,key_in_owners,keys_match = check_and_prepare_signed_chart("","./partner-report.yaml","./OWNERS","./pgp.key")
+    if signed and key_in_owners and keys_match:
+        print("PASS all is good")
+    else:
+        print(f"ERROR, all true expected: signed = {signed}, key_in_owners = {key_in_owners}. keys_match = {keys_match}")
+
+    create_public_key_file(encoded_key_in_owners,"./pgp.key")
+    if os.path.exists("./pgp.key"):
+        if not filecmp.cmp("./psql-service-0.1.11.tgz.key","./pgp.key"):
+            print("ERROR public key files file do not match")
+        else:
+            print("PASS public key files do match")
+        os.remove("./pgp.key")
+    else:
+        print("ERROR pgp key file was not created")
+
+
+
+if __name__ == '__main__':
+    main()
+
+
+
+


### PR DESCRIPTION
This code correctly process signed charts and pgp key IN OWNERS for certification purposes but has not changed release processing asper the scope of the helm story: https://issues.redhat.com/browse/HELM-411.

I did a lot of manual testing to conform function. Automated test are also a different story.

Manual tests as follows:
- Pass as expected (PR merged):
  - No key in OWNERS, signed chart, no report
  - No Key in OWNERS, signed chart,  report not for signed chart
  - Key in OWNERS, signed chart, no report
  - Key in OWNERS, signed chart, report for signed chart
  - Key in OWNERS, no chart, report for signed chart
  - Key in OWNERS, not signed chart, signed chart in report
  - Key in OWNERS, no chart, report for a non signed chart
  - Key in OWNERS, non signed  chart, no report
- Failed as expected:
   - Bad key in OWNERS, no chart, report for signed report (workflow spots key mismatch and creates an error)
   - Bad key in OWNERS, signed chart, no report (new signature-is-valid check fails when report is generated)