### PR TITLE
Fix tests - report sha message case

### DIFF
--- a/tests/functional/behave_features/HC-19_report_sha.feature
+++ b/tests/functional/behave_features/HC-19_report_sha.feature
@@ -26,9 +26,9 @@ Feature: Report sha value in report
     @partners @full @smoke @reportSha
     Examples:
       | vendor_type  | vendor    | report_path                                          | message                                         |
-      | partners     | hashicorp | tests/data/HC-19/report_sha_bad/report.yaml          | Digest in report did not match report content  |
+      | partners     | hashicorp | tests/data/HC-19/report_sha_bad/report.yaml          | digest in report did not match report content  |
 
     @partners @full @reportSha
     Examples:
       | vendor_type  | vendor    | report_path                                          | message                                         |
-      | partners     | hashicorp | tests/data/HC-19/report_edited_sha_bad/report.yaml   | Digest in report did not match report content  |
+      | partners     | hashicorp | tests/data/HC-19/report_edited_sha_bad/report.yaml   | digest in report did not match report content  |


### PR DESCRIPTION
Problem was cause by a change to the chart verifier where a message was changed from:
- Digest in report did not match report content 
to:
- digest in report did not match report content

so Digest -> digest

Unfortunately this broke the test,