### PR TITLE
Adding feature file for signed chart tests

### DIFF
--- a/tests/data/HC-10/signed_chart/report/partner/report.yaml
+++ b/tests/data/HC-10/signed_chart/report/partner/report.yaml
@@ -6,13 +6,13 @@ metadata:
         profile:
             VendorType: partner
             version: v1.2
-        reportDigest: uint64:16989833708667280020
+        reportDigest: uint64:5138098052618695524
         chart-uri: https://github.com/openshift-helm-charts/development/blob/main/tests/data/HC-10/signed_chart/vault-0.17.0.tgz?raw=true
         digests:
             chart: sha256:f01dd362d81fe4b1ef99bb7fa5be268fa94dc96f3009d28bc93a18517aa1ef7a
             package: df206272be1282a05af0576a054c9b35a8d2cebb836dc990d8b87dced82dcdb9
             publicKey: 662ba24b23e80f0b26a634f3c215e74d973943e32d0ee85868759365a5640995
-        lastCertifiedTimestamp: "2022-11-22T11:49:38.322793+05:30"
+        lastCertifiedTimestamp: "2023-01-17T14:39:57.760254+05:30"
         testedOpenShiftVersion: "4.11"
         supportedOpenShiftVersions: '>=4.2'
         providerControlledDelivery: false
@@ -48,15 +48,51 @@ metadata:
         type: ""
     chart-overrides: ""
 results:
-    - check: v1.0/contains-values-schema
+    - check: v1.0/contains-test
       type: Mandatory
       outcome: PASS
-      reason: Values schema file exist
+      reason: Chart test files exist
     - check: v1.0/helm-lint
       type: Mandatory
       outcome: PASS
       reason: Helm lint successful
-    - check: v1.0/images-are-certified
+    - check: v1.0/not-contains-crds
+      type: Mandatory
+      outcome: PASS
+      reason: Chart does not contain CRDs
+    - check: v1.0/contains-values
+      type: Mandatory
+      outcome: PASS
+      reason: Values file exist
+    - check: v1.0/not-contain-csi-objects
+      type: Mandatory
+      outcome: PASS
+      reason: CSI objects do not exist
+    - check: v1.0/required-annotations-present
+      type: Mandatory
+      outcome: PASS
+      reason: All required annotations present
+    - check: v1.0/chart-testing
+      type: Mandatory
+      outcome: PASS
+      reason: Chart tests have passed
+    - check: v1.1/has-kubeversion
+      type: Mandatory
+      outcome: PASS
+      reason: Kubernetes version specified
+    - check: v1.0/signature-is-valid
+      type: Mandatory
+      outcome: PASS
+      reason: 'Chart is signed : Signature verification passed'
+    - check: v1.0/contains-values-schema
+      type: Mandatory
+      outcome: PASS
+      reason: Values schema file exist
+    - check: v1.0/has-readme
+      type: Mandatory
+      outcome: PASS
+      reason: Chart has a README
+    - check: v1.1/images-are-certified
       type: Mandatory
       outcome: PASS
       reason: |-
@@ -66,40 +102,4 @@ results:
       type: Mandatory
       outcome: PASS
       reason: API version is V2, used in Helm 3
-    - check: v1.0/chart-testing
-      type: Mandatory
-      outcome: PASS
-      reason: Chart tests have passed
-    - check: v1.0/not-contains-crds
-      type: Mandatory
-      outcome: PASS
-      reason: Chart does not contain CRDs
-    - check: v1.0/has-readme
-      type: Mandatory
-      outcome: PASS
-      reason: Chart has a README
-    - check: v1.0/contains-test
-      type: Mandatory
-      outcome: PASS
-      reason: Chart test files exist
-    - check: v1.0/not-contain-csi-objects
-      type: Mandatory
-      outcome: PASS
-      reason: CSI objects do not exist
-    - check: v1.0/required-annotations-present
-      type: Mandatory
-      outcome: PASS
-      reason: All required annotations present
-    - check: v1.0/signature-is-valid
-      type: Mandatory
-      outcome: PASS
-      reason: 'Chart is signed : Signature verification passed'
-    - check: v1.0/contains-values
-      type: Mandatory
-      outcome: PASS
-      reason: Values file exist
-    - check: v1.1/has-kubeversion
-      type: Mandatory
-      outcome: PASS
-      reason: Kubernetes version specified
 

--- a/tests/data/HC-10/signed_chart/report/redhat/report.yaml
+++ b/tests/data/HC-10/signed_chart/report/redhat/report.yaml
@@ -6,13 +6,13 @@ metadata:
         profile:
             VendorType: redhat
             version: v1.2
-        reportDigest: uint64:16923642309854382860
+        reportDigest: uint64:18038370130181201778
         chart-uri: https://github.com/openshift-helm-charts/development/blob/main/tests/data/HC-10/signed_chart/vault-0.17.0.tgz?raw=true
         digests:
             chart: sha256:f01dd362d81fe4b1ef99bb7fa5be268fa94dc96f3009d28bc93a18517aa1ef7a
             package: df206272be1282a05af0576a054c9b35a8d2cebb836dc990d8b87dced82dcdb9
             publicKey: 662ba24b23e80f0b26a634f3c215e74d973943e32d0ee85868759365a5640995
-        lastCertifiedTimestamp: "2022-11-22T11:51:58.909069+05:30"
+        lastCertifiedTimestamp: "2023-01-17T14:49:46.03165+05:30"
         testedOpenShiftVersion: "4.11"
         supportedOpenShiftVersions: '>=4.2'
         providerControlledDelivery: false
@@ -48,32 +48,40 @@ metadata:
         type: ""
     chart-overrides: ""
 results:
-    - check: v1.0/contains-values-schema
+    - check: v1.0/is-helm-v3
       type: Mandatory
       outcome: PASS
-      reason: Values schema file exist
-    - check: v1.0/images-are-certified
+      reason: API version is V2, used in Helm 3
+    - check: v1.0/not-contain-csi-objects
+      type: Mandatory
+      outcome: PASS
+      reason: CSI objects do not exist
+    - check: v1.0/has-readme
+      type: Mandatory
+      outcome: PASS
+      reason: Chart has a README
+    - check: v1.1/images-are-certified
       type: Mandatory
       outcome: PASS
       reason: |-
         Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault-k8s:0.14.0-ubi
         Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault:1.8.4-ubi
-    - check: v1.0/required-annotations-present
-      type: Mandatory
-      outcome: PASS
-      reason: All required annotations present
-    - check: v1.0/is-helm-v3
-      type: Mandatory
-      outcome: PASS
-      reason: API version is V2, used in Helm 3
-    - check: v1.0/chart-testing
-      type: Mandatory
-      outcome: PASS
-      reason: Chart tests have passed
     - check: v1.0/not-contains-crds
       type: Mandatory
       outcome: PASS
       reason: Chart does not contain CRDs
+    - check: v1.0/required-annotations-present
+      type: Mandatory
+      outcome: PASS
+      reason: All required annotations present
+    - check: v1.0/chart-testing
+      type: Mandatory
+      outcome: PASS
+      reason: Chart tests have passed
+    - check: v1.0/contains-values-schema
+      type: Mandatory
+      outcome: PASS
+      reason: Values schema file exist
     - check: v1.0/contains-test
       type: Mandatory
       outcome: PASS
@@ -82,6 +90,10 @@ results:
       type: Mandatory
       outcome: PASS
       reason: Kubernetes version specified
+    - check: v1.0/helm-lint
+      type: Mandatory
+      outcome: PASS
+      reason: Helm lint successful
     - check: v1.0/signature-is-valid
       type: Mandatory
       outcome: PASS
@@ -90,16 +102,4 @@ results:
       type: Mandatory
       outcome: PASS
       reason: Values file exist
-    - check: v1.0/has-readme
-      type: Mandatory
-      outcome: PASS
-      reason: Chart has a README
-    - check: v1.0/helm-lint
-      type: Mandatory
-      outcome: PASS
-      reason: Helm lint successful
-    - check: v1.0/not-contain-csi-objects
-      type: Mandatory
-      outcome: PASS
-      reason: CSI objects do not exist
 

--- a/tests/functional/behave_features/HC-10_signed_chart.feature
+++ b/tests/functional/behave_features/HC-10_signed_chart.feature
@@ -1,0 +1,111 @@
+Feature: Signed chart submission
+    Partners or redhat users can publish their signed chart
+
+    Scenario Outline: [HC-10-001] A partner or redhat associate submits a signed chart tarball without report
+        Given the vendor "<vendor>" has a valid identity as "<vendor_type>"
+        And a signed chart tarball is used in "<chart_path>" and public key in "<public_key_file>"
+        When the user sends a pull request with the chart
+        Then the user sees the pull request is merged
+        And the index.yaml file is updated with an entry for the submitted chart
+        And a release is published with corresponding report, tarball, prov and key
+
+        @partners @smoke @full
+        Examples:
+            | vendor_type  | vendor    | chart_path                                     | public_key_file                                   |
+            | partners     | hashicorp | tests/data/HC-10/signed_chart/vault-0.17.0.tgz | tests/data/HC-10/signed_chart/public_key_good.asc |
+        
+        @redhat @full
+        Examples:
+            | vendor_type  | vendor    | chart_path                                     | public_key_file                                   |
+            | redhat       | redhat    | tests/data/HC-10/signed_chart/vault-0.17.0.tgz | tests/data/HC-10/signed_chart/public_key_good.asc |
+
+    Scenario Outline: [HC-10-002] A partner or redhat associate submits a signed chart tarball with report
+        Given the vendor "<vendor>" has a valid identity as "<vendor_type>"
+        And a signed chart tar is used in "<chart_path>", report in "<report_path>" and public key in "<public_key_file>"
+        When the user sends a pull request with the chart
+        Then the user sees the pull request is merged
+        And the index.yaml file is updated with an entry for the submitted chart
+        And a release is published with corresponding report, tarball, prov and key
+
+        @partners @full
+        Examples:
+            | vendor_type  | vendor    | chart_path                                     | report_path                                              | public_key_file                                   |
+            | partners     | hashicorp | tests/data/HC-10/signed_chart/vault-0.17.0.tgz | tests/data/HC-10/signed_chart/report/partner/report.yaml | tests/data/HC-10/signed_chart/public_key_good.asc |
+        
+        @redhat @full
+        Examples:
+            | vendor_type  | vendor    | chart_path                                     | report_path                                             | public_key_file                                   |
+            | redhat       | redhat    | tests/data/HC-10/signed_chart/vault-0.17.0.tgz | tests/data/HC-10/signed_chart/report/redhat/report.yaml | tests/data/HC-10/signed_chart/public_key_good.asc |
+    
+    Scenario Outline: [HC-10-003] A partner or redhat associate submits a signed chart report
+        Given the vendor "<vendor>" has a valid identity as "<vendor_type>"
+        And signed chart report used in "<report_path>" and public key in "<public_key_file>"
+        When the user sends a pull request with the report
+        Then the user sees the pull request is merged
+        And the index.yaml file is updated with an entry for the submitted chart
+        And a release is published with corresponding report and key
+
+        @partners @smoke @full
+        Examples:
+            | vendor_type  | vendor    | report_path                                              | public_key_file                                   |
+            | partners     | hashicorp | tests/data/HC-10/signed_chart/report/partner/report.yaml | tests/data/HC-10/signed_chart/public_key_good.asc |
+        
+        @redhat @full
+        Examples:
+            | vendor_type  | vendor    | report_path                                             | public_key_file                                   |
+            | redhat       | redhat    | tests/data/HC-10/signed_chart/report/redhat/report.yaml | tests/data/HC-10/signed_chart/public_key_good.asc |
+    
+    Scenario Outline: [HC-10-004] A partner or redhat associate submits an unsigned chart tarball
+        Given the vendor "<vendor>" has a valid identity as "<vendor_type>"
+        And unsigned chart tarball is used in "<chart_path>" and public key used "<public_key_file>" in owners
+        When the user sends a pull request with the chart
+        Then the user sees the pull request is merged
+        And the index.yaml file is updated with an entry for the submitted chart
+        And a release is published with corresponding report and chart tarball
+
+        @partners @full
+        Examples:
+            | vendor_type  | vendor    | chart_path                  | public_key_file                                   |
+            | partners     | hashicorp | tests/data/vault-0.17.0.tgz | tests/data/HC-10/signed_chart/public_key_good.asc |
+        
+        @redhat @full
+        Examples:
+            | vendor_type  | vendor    | chart_path                  | public_key_file                                   |
+            | redhat       | redhat    | tests/data/vault-0.17.0.tgz | tests/data/HC-10/signed_chart/public_key_good.asc |
+    
+    Scenario Outline: [HC-10-005] A partner or redhat associate submits a signed chart tarball when public key is not in owners
+        Given the vendor "<vendor>" has a valid identity as "<vendor_type>"
+        And signed chart tar used in "<chart_path>"
+        When the user sends a pull request with the chart
+        Then the user sees the pull request is merged
+        And the index.yaml file is updated with an entry for the submitted chart
+        And a release is published with corresponding report, chart tar and prov file
+
+        @partners @full
+        Examples:
+            | vendor_type  | vendor    | chart_path                                     | 
+            | partners     | hashicorp | tests/data/HC-10/signed_chart/vault-0.17.0.tgz | 
+        
+        @redhat @full
+        Examples:
+            | vendor_type  | vendor    | chart_path                                     | 
+            | redhat       | redhat    | tests/data/HC-10/signed_chart/vault-0.17.0.tgz |
+    
+    Scenario Outline: [HC-10-006] A partner or redhat associate submits a signed chart tarball with wrong key in OWNERS file
+        Given the vendor "<vendor>" has a valid identity as "<vendor_type>"
+        And a signed chart tarball is used in "<chart_path>" and public key in "<public_key_file>"
+        When the user sends a pull request with the chart
+        Then the pull request is not merged
+        And user gets the "<message>" in the pull request comment
+
+        @partners @smoke @full
+        Examples:
+            | vendor_type  | vendor    | chart_path                                     | public_key_file                                  | message                       |
+            | partners     | hashicorp | tests/data/HC-10/signed_chart/vault-0.17.0.tgz | tests/data/HC-10/signed_chart/public_key_bad.asc | Signature verification failed |
+        
+        # @redhat @full
+        # Examples:
+        #     | vendor_type  | vendor    | chart_path                                     | public_key_file                                  | message                       | 
+        #     | redhat       | redhat    | tests/data/HC-10/signed_chart/vault-0.17.0.tgz | tests/data/HC-10/signed_chart/public_key_bad.asc | Signature verification failed |
+
+


### PR DESCRIPTION
Commented one scenario, while testing signed chart with wrong key in OWNERS file for vendorProfile: redhat, PR got successfully merged here https://github.com/openshift-helm-charts/sandbox/pull/44260
Expecting it to fail with error: Signature verification failed.