### PR TITLE
Add flow4 mercury bot [DO NOT MERGE]

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,8 @@ jobs:
     runs-on: ubuntu-20.04
     if: |
       github.event.pull_request.draft == false &&
-      (github.event.action != 'labeled' || github.event.label.name == 'force-publish')
+      (github.event.action != 'labeled' || github.event.label.name == 'force-publish') &&
+      github.actor != 'redhat-mercury-bot'
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/mercury_bot.yml
+++ b/.github/workflows/mercury_bot.yml
@@ -1,0 +1,98 @@
+name: OWNERS PR Check
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, edited, ready_for_review, labeled]
+
+jobs:
+  owners-file-check:
+    name: OWNERS file PR checker
+    runs-on: ubuntu-20.04
+    if: github.event.pull_request.draft == false && github.actor == 'redhat-mercury-bot'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        
+      - name: Set up Python 3.x Part 1
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.9"
+
+      - name: Set up Python 3.x Part 2
+        run: |
+          # set up python
+          python3 -m venv ve1
+          cd scripts && ../ve1/bin/pip3 install -r requirements.txt && cd ..
+          cd scripts && ../ve1/bin/python3 setup.py install && cd ..
+
+      - name: get files changed
+        id: get_files_changed
+        run: |
+          # get files in PR
+          ./ve1/bin/pr-artifact --api-url=${{ github.event.pull_request._links.self.href }} \
+                                --get-files
+
+      - name: check if only an OWNERS file is pushed
+        id: check_for_owners
+        env:
+          pr_files_py: "${{ steps.get_files_changed.outputs.pr_files }}"
+        run: |
+          # check if PR contains just one partner OWNERS file
+          pr_files=($(echo "$pr_files_py" | tr -d '[],'))
+          echo "Files in PR: ${pr_files[@]}"
+          eval first_file=${pr_files[0]}
+          if [ ${#pr_files[@]} == 1 ]; then
+            eval first_file=${pr_files[0]}
+            if [[ $first_file == "charts/partners/"*/*"/OWNERS" ]] ; then
+                echo "An OWNERS file has been modified or added"
+                echo "merge_pr=true" >> $GITHUB_OUTPUT
+            else
+              echo "The file in the PR is not a partner OWNERS file"
+              echo "merge_pr=false" >> $GITHUB_OUTPUT
+              echo "msg=ERROR: PR does not include a partner OWNERS file." >> $GITHUB_OUTPUT
+            fi
+          else
+            echo "The PR contains multiple files."
+            echo "msg=ERROR: PR contains multiple files." >> $GITHUB_OUTPUT
+            echo "merge_pr=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Comment on PR
+        if: ${{ steps.check_for_owners.outputs.merge_pr == 'false' }}
+        uses: actions/github-script@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+              var issue_number = ${{ github.event.number }};
+              var comment = "${{ steps.check_for_owners.outputs.msg }}";
+              github.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: Number(issue_number),
+                body: comment
+              });
+
+      - name: Reflect on check for OWNERS file result
+        if: ${{ steps.check_for_owners.outputs.merge_pr == 'false' }}
+        run: |
+          # exit with failure if PR is not for a single partner OWNERS file
+          echo "The PR was not for a single partner OWNERS file."
+          exit 1
+
+      - name: Approve PR
+        id: approve_pr
+        if: ${{ steps.check_for_owners.outputs.merge_pr == 'true' }}
+        uses: hmarr/auto-approve-action@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Merge PR
+        id: merge_pr
+        if: ${{ steps.approve_pr.conclusion == 'success' }}
+        uses: pascalgn/automerge-action@v0.13.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MERGE_METHOD: squash
+          MERGE_LABELS: ""
+
+

--- a/.github/workflows/owners.yml
+++ b/.github/workflows/owners.yml
@@ -8,21 +8,13 @@ jobs:
   owners-metrics:
     name: Send Owner Metrics
     runs-on: ubuntu-20.04
+    if: github.actor == 'redhat-mercury-bot'
     env:
       SEGMENT_WRITE_KEY: ${{ secrets.SEGMENT_WRITE_KEY }}
       SEGMENT_TEST_WRITE_KEY: ${{ secrets.SEGMENT_TEST_WRITE_KEY }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-
-      - name: Exit if push is not from redhat-mercury-bot
-        id: check_push_by_bot
-        run: |
-          echo "${{ github.event.pusher.name}}"
-          if [ "${{ github.event.pusher.name}}" != "redhat-mercury-bot" ]; then
-            echo "The push is not from redhat mercury bot - do not continue."
-            exit 0
-          fi
 
       - name: Set up Python 3.x Part 1
         uses: actions/setup-python@v2
@@ -50,16 +42,19 @@ jobs:
           echo "${{ steps.filesChangedOrModified.outputs.modified }}"
 
       - name: Quit if owners files pushed are not
+        id: check_pr_content
         run: |
           SUB="/OWNERS"
           if [ "${{ steps.filesChangedOrModified.outputs.added[0] }}" == *"$SUB"* ] || [ "${{ steps.filesChangedOrModified.outputs.modified[0] }}" == *"$SUB"* ] ; then
-          echo "OWNERS files have been modified or added"
+              echo "OWNERS files have been modified or added"
+              echo "collect_metrics=true" >> $GITHUB_OUTPUT
           else
-          echo "OWNERS files not pushed"
-          exit 0
+              echo "OWNERS files not pushed"
+              echo "collect_metrics=false" >> $GITHUB_OUTPUT
           fi
 
       - name: Add owner metrics
+        if: ${{ steps.check_pr_content.outputs.collect_metrics == 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/scripts/src/pullrequest/prartifact.py
+++ b/scripts/src/pullrequest/prartifact.py
@@ -24,6 +24,16 @@ def get_modified_charts(api_url):
 
     return "", "", "", ""
 
+def get_modified_files(api_url):
+    files_api_url = f'{api_url}/files'
+    headers = {'Accept': 'application/vnd.github.v3+json'}
+    r = requests.get(files_api_url, headers=headers)
+    pr_files = []
+    print(f"[INFO] file info in PR {r.json()}")
+    for f in r.json():
+        if "filename" in f:
+            pr_files.append(f["filename"])
+    return pr_files
 
 def save_metadata(directory, vendor_label, chart, number):
     with open(os.path.join(directory, "vendor"), "w") as fd:
@@ -44,16 +54,23 @@ def save_metadata(directory, vendor_label, chart, number):
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("-d", "--directory", dest="directory", type=str, required=True,
+    parser.add_argument("-d", "--directory", dest="directory", type=str, required=False,
                                         help="artifact directory for archival")
-    parser.add_argument("-n", "--pr-number", dest="number", type=str, required=True,
+    parser.add_argument("-n", "--pr-number", dest="number", type=str, required=False,
                                         help="current pull request number")
     parser.add_argument("-u", "--api-url", dest="api_url", type=str, required=True,
                                         help="API URL for the pull request")
+    parser.add_argument("-f","--get-files", dest="get_files", default=False,action='store_true' )
+
     args = parser.parse_args()
-    os.makedirs(args.directory, exist_ok=True)
-    category, organization, chart, version = get_modified_charts(args.api_url)
-    save_metadata(args.directory, organization, chart, args.number)
+    if args.get_files:
+        pr_files = get_modified_files(args.api_url)
+        print(f"[INFO] files in pr: {pr_files}")
+        print(f"::set-output name=pr_files::{pr_files}")
+    else:
+        os.makedirs(args.directory, exist_ok=True)
+        category, organization, chart, version = get_modified_charts(args.api_url)
+        save_metadata(args.directory, organization, chart, args.number)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Created a new flow for redhat-mercury-bot PR's. The flow will auto-merge a redhat-mercury-bot PR only if it contains a single partner OWNERS file.  Any other PR content will not be merged.

Also stopped the certification workflow from running if submitter is redhat-mercury-bot. This allows a valid PR mercury bot. to complete without errors. 

Finally, fixed the OWNERS.yml which collects metrics for redhat-mercury-bot push requests. It was gathering metrics for all flows regardless of content.