### PR TITLE
Update provider delivery message to web catalog only

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -43,6 +43,7 @@ submit a chart and the report together.
       * [Chart name and version mismatch errors](#chart-name-and-version-mismatch-errors)
       * [Report failures](#report-failures)
       * [Signed chart failures](#signed-chart-failures)
+      * [Web catalog only delivery](#web-catalog-only-delivery)
    * [Frequently Asked Questions](#frequently-asked-questions)
       * [Can I test the pull request in my fork before submitting?](#can-i-test-the-pull-request-in-my-fork-before-submitting)
       * [Can I use any command-line interface to create pull request?](#can-i-use-any-command-line-interface-to-create-pull-request)
@@ -493,6 +494,28 @@ Error message(s):
 Chart is signed : Signature verification failed : openpgp: signature made by unknown entity
 ```
 This is because the key generated from the PGP key in the OWNERS file does not correspond to the secret key used to sign the chart. 
+
+### Web catalog only delivery
+
+Whenever there is a mismatch between provider delivery in the OWNERS file and the report, the following errors will show: 
+
+```
+[ERROR] Report indicates web catalog only delivery but OWNERS file does not. The distribution method web catalog only requires providerDelivery to be set to true in the OWNERS file.
+[ERROR] OWNERS file indicates web catalog only delivery but report does not. The distribution method web catalog only requires providerDelivery to be set to true in the OWNERS file.
+[ERROR] OWNERS file and/or report indicate web catalog only delivery but pull request is not report only. The distribution method web catalog only requires providerDelivery to be set to true in the OWNERS file.
+```
+
+The distribution method of web catalog only requires providerDelivery to be set to true within the OWNERS file.
+
+There are three methods of distribution for certified helm charts.
+- Publish your chart in the Red Hat Helm Chart repository
+  - Submissions should include either a chart or chart and report.
+- Publish you chart in your own Helm Chart repository
+  - Submissions should be report only using a publicly available chart URL.
+- Web catalog only
+  - This submission should be report only using a private chart URL.
+
+For more information on the different Helm Chart Distribution methods, see: [Creating a Helm Chart Certification Project](https://redhat-connect.gitbook.io/partner-guide-for-red-hat-openshift-and-container/helm-chart-certification/creating-a-helm-chart-certification-project)
 
 ## Frequently Asked Questions
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -500,9 +500,9 @@ This is because the key generated from the PGP key in the OWNERS file does not c
 Whenever there is a mismatch between provider delivery in the OWNERS file and the report, the following errors will show: 
 
 ```
-[ERROR] Report indicates web catalog only delivery but OWNERS file does not. The distribution method web catalog only requires providerDelivery to be set to true in the OWNERS file.
-[ERROR] OWNERS file indicates web catalog only delivery but report does not. The distribution method web catalog only requires providerDelivery to be set to true in the OWNERS file.
-[ERROR] OWNERS file and/or report indicate web catalog only delivery but pull request is not report only. The distribution method web catalog only requires providerDelivery to be set to true in the OWNERS file.
+[ERROR] Report indicates web catalog only but the distribution method set for the chart is not web catalog only.
+[ERROR] The web catalog distribution method is set for the chart but is not set in the report.
+[ERROR] The web catalog distribution method requires the pull request to be report only.
 ```
 
 The distribution method of web catalog only requires providerDelivery to be set to true within the OWNERS file.

--- a/scripts/src/checkprcontent/checkpr.py
+++ b/scripts/src/checkprcontent/checkpr.py
@@ -54,7 +54,7 @@ def check_provider_delivery(report_in_pr,num_files_in_pr,report_file_match):
     provider_delivery = False
     if report_in_pr and num_files_in_pr > 1:
         if report_provider_delivery or owner_provider_delivery:
-            msg = f"[ERROR] OWNERS file and/or report indicate web catalog only delivery but pull request is not report only. The distribution method web catalog only requires providerDelivery to be set to true in the OWNERS file."
+            msg = f"[ERROR] The web catalog distribution method requires the pull request to be report only."
             print(msg)
             print(f"::set-output name=pr-content-error-message::{msg}")
             sys.exit(1)
@@ -63,17 +63,17 @@ def check_provider_delivery(report_in_pr,num_files_in_pr,report_file_match):
             if verifier_report.get_package_digest(report_data):
                 provider_delivery = True
             else:
-                msg = f"[ERROR] Web catalog only delivery control requires a package digest in the report. The distribution method web catalog only requires providerDelivery to be set to true in the OWNERS file."
+                msg = f"[ERROR] The web catalog distribution method requires a package digest in the report."
                 print(msg)
                 print(f"::set-output name=pr-content-error-message::{msg}")
                 sys.exit(1)
         elif report_provider_delivery:
-            msg = f"[ERROR] Report indicates web catalog only delivery but OWNERS file does not. The distribution method web catalog only requires providerDelivery to be set to true in the OWNERS file."
+            msg = f"[ERROR] Report indicates web catalog only but the distribution method set for the chart is not web catalog only."
             print(msg)
             print(f"::set-output name=pr-content-error-message::{msg}")
             sys.exit(1)
         elif owner_provider_delivery:
-            msg = f"[ERROR] OWNERS file indicates web catalog only delivery but report does not. The distribution method web catalog only requires providerDelivery to be set to true in the OWNERS file."
+            msg = f"[ERROR] The web catalog distribution method is set for the chart but is not set in the report."
             print(msg)
             print(f"::set-output name=pr-content-error-message::{msg}")
             sys.exit(1)

--- a/scripts/src/checkprcontent/checkpr.py
+++ b/scripts/src/checkprcontent/checkpr.py
@@ -54,7 +54,7 @@ def check_provider_delivery(report_in_pr,num_files_in_pr,report_file_match):
     provider_delivery = False
     if report_in_pr and num_files_in_pr > 1:
         if report_provider_delivery or owner_provider_delivery:
-            msg = f"[ERROR] OWNERS file and/or report indicate provider controlled delivery but pull request is not report only."
+            msg = f"[ERROR] OWNERS file and/or report indicate web catalog only delivery but pull request is not report only. The distribution method web catalog only requires providerDelivery to be set to true in the OWNERS file."
             print(msg)
             print(f"::set-output name=pr-content-error-message::{msg}")
             sys.exit(1)
@@ -63,17 +63,17 @@ def check_provider_delivery(report_in_pr,num_files_in_pr,report_file_match):
             if verifier_report.get_package_digest(report_data):
                 provider_delivery = True
             else:
-                msg = f"[ERROR] Provider delivery control requires a package digest in the report."
+                msg = f"[ERROR] Web catalog only delivery control requires a package digest in the report. The distribution method web catalog only requires providerDelivery to be set to true in the OWNERS file."
                 print(msg)
                 print(f"::set-output name=pr-content-error-message::{msg}")
                 sys.exit(1)
         elif report_provider_delivery:
-            msg = f"[ERROR] Report indicates provider controlled delivery but OWNERS file does not."
+            msg = f"[ERROR] Report indicates web catalog only delivery but OWNERS file does not. The distribution method web catalog only requires providerDelivery to be set to true in the OWNERS file."
             print(msg)
             print(f"::set-output name=pr-content-error-message::{msg}")
             sys.exit(1)
         elif owner_provider_delivery:
-            msg = f"[ERROR] OWNERS file indicates provider controlled delivery but report does not."
+            msg = f"[ERROR] OWNERS file indicates web catalog only delivery but report does not. The distribution method web catalog only requires providerDelivery to be set to true in the OWNERS file."
             print(msg)
             print(f"::set-output name=pr-content-error-message::{msg}")
             sys.exit(1)

--- a/tests/functional/behave_features/HC-06_provider_delivery_control.feature
+++ b/tests/functional/behave_features/HC-06_provider_delivery_control.feature
@@ -29,7 +29,7 @@ Feature: Report only submission with provider control settings
     @partners @full
     Examples:
       | vendor_type  | vendor    | chart_path                  | report_path                          | provider_control_owners | message                                                                                              |
-      | partners     | hashicorp | tests/data/vault-0.17.0.tgz | tests/data/HC-06/partner/report.yaml | true                    | OWNERS file and/or report indicate web catalog only delivery but pull request is not report only. The distribution method web catalog only requires providerDelivery to be set to true in the OWNERS file. |
+      | partners     | hashicorp | tests/data/vault-0.17.0.tgz | tests/data/HC-06/partner/report.yaml | true                    | The web catalog distribution method requires the pull request to be report only. |
 
   @external-feedback
   Scenario Outline: [HC-06-003] A partner associate submits an error-free report with inconsistent provider controlled delivery setting
@@ -43,5 +43,5 @@ Feature: Report only submission with provider control settings
     @partners @full
     Examples:
       | vendor_type  | vendor    | report_path                            | provider_control_owners | message                                                                 |
-      | partners     | hashicorp | tests/data/common/partner/report.yaml  | true                    | OWNERS file indicates web catalog only delivery but report does not. The distribution method web catalog only requires providerDelivery to be set to true in the OWNERS file. |
-      | partners     | hashicorp | tests/data/HC-06/partner/report.yaml   | false                   | Report indicates web catalog only delivery but OWNERS file does not. The distribution method web catalog only requires providerDelivery to be set to true in the OWNERS file. |
+      | partners     | hashicorp | tests/data/common/partner/report.yaml  | true                    | The web catalog distribution method is set for the chart but is not set in the report. |
+      | partners     | hashicorp | tests/data/HC-06/partner/report.yaml   | false                   | Report indicates web catalog only but the distribution method set for the chart is not web catalog only. |

--- a/tests/functional/behave_features/HC-06_provider_delivery_control.feature
+++ b/tests/functional/behave_features/HC-06_provider_delivery_control.feature
@@ -29,7 +29,7 @@ Feature: Report only submission with provider control settings
     @partners @full
     Examples:
       | vendor_type  | vendor    | chart_path                  | report_path                          | provider_control_owners | message                                                                                              |
-      | partners     | hashicorp | tests/data/vault-0.17.0.tgz | tests/data/HC-06/partner/report.yaml | true                    | OWNERS file and/or report indicate provider controlled delivery but pull request is not report only. |
+      | partners     | hashicorp | tests/data/vault-0.17.0.tgz | tests/data/HC-06/partner/report.yaml | true                    | OWNERS file and/or report indicate web catalog only delivery but pull request is not report only. The distribution method web catalog only requires providerDelivery to be set to true in the OWNERS file. |
 
   @external-feedback
   Scenario Outline: [HC-06-003] A partner associate submits an error-free report with inconsistent provider controlled delivery setting
@@ -43,5 +43,5 @@ Feature: Report only submission with provider control settings
     @partners @full
     Examples:
       | vendor_type  | vendor    | report_path                            | provider_control_owners | message                                                                 |
-      | partners     | hashicorp | tests/data/common/partner/report.yaml  | true                    | OWNERS file indicates provider controlled delivery but report does not. |
-      | partners     | hashicorp | tests/data/HC-06/partner/report.yaml   | false                   | Report indicates provider controlled delivery but OWNERS file does not. |
+      | partners     | hashicorp | tests/data/common/partner/report.yaml  | true                    | OWNERS file indicates web catalog only delivery but report does not. The distribution method web catalog only requires providerDelivery to be set to true in the OWNERS file. |
+      | partners     | hashicorp | tests/data/HC-06/partner/report.yaml   | false                   | Report indicates web catalog only delivery but OWNERS file does not. The distribution method web catalog only requires providerDelivery to be set to true in the OWNERS file. |


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/HELM-462

Updates the error messages whenever there is an issue with provider delivery to now display web catalog only. 

The mention of provider controlled delivery in the error messages can lead to some confusions with users. This is due to the fact that the [Creating a Helm Chart Certification Project](https://redhat-connect.gitbook.io/partner-guide-for-red-hat-openshift-and-container/helm-chart-certification/creating-a-helm-chart-certification-project) article does not have any mentions of a provider delivery distribution method. In our case provider delivery is the same as the web catalog only distribution method. 