### PR TITLE
Deprecation of set-output

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,7 +73,7 @@ jobs:
           elif [ "${CHART_PR_FOR_RELEASE}" == "true" ]; then
             echo "The PR is part of release processing for the charts repository - do not continue."
           else
-            echo "::set-output name=run-build::true"
+            echo "run-build=true" >> $GITHUB_OUTPUT
           fi
 
       - name: Set Environment
@@ -82,12 +82,12 @@ jobs:
           #set environemnt based on repository
           if [ $GITHUB_REPOSITORY == "openshift-helm-charts/charts" ]; then
             echo "Use latest verifier image"
-            echo "::set-output name=insecure_skip_tls_verify::false"
-            echo "::set-output name=verifier-action-image::latest"
+            echo "insecure_skip_tls_verify=false" >> $GITHUB_OUTPUT
+            echo "verifier-action-image=latest" >> $GITHUB_OUTPUT
           else
             echo "Use dev verifier image"
-            echo "::set-output name=insecure_skip_tls_verify::true"
-            echo "::set-output name=verifier-action-image::0.1.0"
+            echo "insecure_skip_tls_verify=true" >> $GITHUB_OUTPUT
+            echo "verifier-action-image=0.1.0" >> $GITHUB_OUTPUT
           fi
 
       - name: Checkout
@@ -186,7 +186,7 @@ jobs:
         run: |
           #calculate cluster params
           API_SERVER=$( echo -n ${{ secrets.API_SERVER }} | base64 -d)
-          echo "::set-output name=API_SERVER::${API_SERVER}"
+          echo "API_SERVER=${API_SERVER}" >> $GITHUB_OUTPUT
 
       - uses: redhat-actions/oc-login@v1
         id: oc_login
@@ -204,7 +204,7 @@ jobs:
           BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
         run: |
           ve1/bin/sa-for-chart-testing --create charts-${{ github.event.number }} --token token.txt --server ${API_SERVER}
-          echo "::set-output name=delete_namespace::true"
+          echo "delete_namespace=true" >> $GITHUB_OUTPUT
           echo $KUBECONFIG
 
       - uses: redhat-actions/chart-verifier@v1.1
@@ -221,7 +221,7 @@ jobs:
         if: ${{ always() && steps.run-verifier.outcome == 'failure' }}
         run: |
           error_message="The chart verifier returned an error when trying to obtain a verification report for the chart."
-          echo "::set-output name=verifier_error_message::$error_message"
+          echo "verifier_error_message=$error_message" >> $GITHUB_OUTPUT
 
       - name: Check Report
         id: check_report

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,7 @@ jobs:
               exit 1
           elif [ "${RELEASE_INFO_ONLY}" == 'true' ]; then
              echo "PR contains only release_info file"
-             echo '::set-output name=create_pull_requests::true'
+             echo "create_pull_requests=true" >> $GITHUB_OUTPUT
           elif [ "${DEV_PR_FOR_RELEASE}" != 'true' ]; then
              echo "No release work to do"
              exit
@@ -185,18 +185,18 @@ jobs:
                   exit 1
               else
                   echo "At least one PR was created - merge this one"
-                  echo '::set-output name=merge::true'
+                  echo "merge=true" >> $GITHUB_OUTPUT
               fi
               if [ "${DEV_PR_NOT_NEEDED}" == 'true' ]; then
                   echo "No dev PR so create release"
-                  echo "::set-output name=release_body::${{ steps.check_only_version_in_PR_and_authorized.outputs.PR_release_body }}"
-                  echo "::set-output name=release_tag::${{ steps.check_only_version_in_PR_and_authorized.outputs.PR_version }}"
+                  echo "release_body=${{ steps.check_only_version_in_PR_and_authorized.outputs.PR_release_body }}" >> $GITHUB_OUTPUT
+                  echo "release_tag=${{ steps.check_only_version_in_PR_and_authorized.outputs.PR_version }}" >> $GITHUB_OUTPUT
               fi
           elif [ "${DEV_PR_FOR_RELEASE}" == 'true' ]; then
               echo "Dev PR so create release"
-              echo '::set-output name=merge::true'
-              echo "::set-output name=release_body::${{ github.event.pull_request.body }}"
-              echo "::set-output name=release_tag::${{ steps.check_created_release_pr.outputs.PR_version }}"
+              echo "merge=true" >> $GITHUB_OUTPUT
+              echo "release_body=${{ github.event.pull_request.body }}" >> $GITHUB_OUTPUT
+              echo "release_tag=${{ steps.check_created_release_pr.outputs.PR_version }}" >> $GITHUB_OUTPUT
           fi
 
       - name: Approve PR

--- a/.github/workflows/token.yml
+++ b/.github/workflows/token.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Get Date
         id: get-date
         run: |
-          echo "::set-output name=date::$(/bin/date -u "+%Y%m%d")"
+          echo "date=$(/bin/date -u "+%Y%m%d")" >> $GITHUB_OUTPUT
         shell: bash
 
       - uses: actions/cache@v2

--- a/.github/workflows/version_check.yml
+++ b/.github/workflows/version_check.yml
@@ -36,22 +36,22 @@ jobs:
           echo "dry-run : ${{ github.event.inputs.dry-run }}"
           echo "update-version : ${{ github.event.inputs.update-version }}"
           if [ $GITHUB_EVENT_NAME == 'workflow_dispatch' ]; then
-            echo '::set-output name=run-job::true'
+            echo "run-job=true" >> $GITHUB_OUTPUT
             if [ "${{ github.event.inputs.dry-run }}" == "true" ]; then
                 if [[ "${{ github.event.inputs.update-version }}" == "true"  && $GITHUB_REPOSITORY != "openshift-helm-charts/charts" ]]; then
-                  echo '::set-output name=check-version::true'
+                  echo "check-version=true" >> $GITHUB_OUTPUT
                 else
-                  echo '::set-output name=check-version::false'
+                  echo "check-version=false" >> $GITHUB_OUTPUT
                 fi
             else
-                echo '::set-output name=check-version::true'
+                echo "check-version=true" >> $GITHUB_OUTPUT
             fi
           elif [ $GITHUB_REPOSITORY == "openshift-helm-charts/charts" ]; then
-            echo '::set-output name=run-job::true'
-            echo '::set-output name=check-version::true'
+            echo "run-job=true" >> $GITHUB_OUTPUT
+            echo "check-version=true" >> $GITHUB_OUTPUT
           else
-            echo '::set-output name=run-job::false'
-            echo '::set-output name=check-version::false'
+            echo "run-job=false" >> $GITHUB_OUTPUT
+            echo "check-version=false" >> $GITHUB_OUTPUT
           fi
 
 
@@ -75,7 +75,7 @@ jobs:
           OCP_VERSION=$(./oc version -o json | jq '.openshiftVersion')
           OCP_VERSION=$(sed -e 's/^"//' -e 's/"$//' <<< $OCP_VERSION)
           printf "[INFO] Current OCP Version: %s\n" ${OCP_VERSION}
-          echo "::set-output name=curr_ocp_version::${OCP_VERSION}"
+          echo "curr_ocp_version=${OCP_VERSION}" >> $GITHUB_OUTPUT
         shell: bash
 
       - name: Checkout software-version branch
@@ -97,30 +97,30 @@ jobs:
         run: |
           set -euo pipefail
           if [ "${{ steps.check_repo.outputs.run-job }}" != "true" ]; then
-            echo "::set-output name=run_tests::false"
-            echo "::set-output name=update-version::false"
+            echo "run_tests=false" >> $GITHUB_OUTPUT
+            echo "update-version=false" >> $GITHUB_OUTPUT
           elif [ "${{ steps.check_repo.outputs.check-version }}" == "true" ]; then
             if [ "${{ steps.get_curr_ocp_version.outputs.curr_ocp_version }}" == "${{ steps.get_prev_ocp_version.outputs.result }}" ]; then
               # No change in the OpenShift versions.
               printf "OpenShift version has not changed since last run: '%s' -> '%s'\n" "${{ steps.get_prev_ocp_version.outputs.result }}" "${{ steps.get_curr_ocp_version.outputs.curr_ocp_version }}"
-              echo "::set-output name=update-version::false"
+              echo "update-version=false" >> $GITHUB_OUTPUT
               if [ "${{ github.event.inputs.dry-run }}" == "true" ]; then
                 echo "Openshift version has not changed but run anyaway as dry-run is set"
-                echo "::set-output name=run_tests::true"
+                echo "run_tests=true" >> $GITHUB_OUTPUT
               else
                 echo "Openshift version has not changed do not run tests"
-                echo "::set-output name=run_tests::false"
+                echo "run_tests=false" >> $GITHUB_OUTPUT
               fi
             else
               printf "OpenShift version has changed since last run: '%s' -> '%s'\n" "${{ steps.get_prev_ocp_version.outputs.result }}" "${{ steps.get_curr_ocp_version.outputs.curr_ocp_version }}"
-              echo "::set-output name=run_tests::true"
-              echo "::set-output name=update-version::true"
+              echo "run_tests=true" >> $GITHUB_OUTPUT
+              echo "update-version=true" >> $GITHUB_OUTPUT
             fi
           else
             # Run whether open shift version has changed or not
             echo "Run tests - version check skipped"
-            echo "::set-output name=update-version::false"
-            echo "::set-output name=run_tests::true"
+            echo "update-version=false" >> $GITHUB_OUTPUT
+            echo "run_tests=true" >> $GITHUB_OUTPUT
           fi
         shell: bash
 
@@ -239,22 +239,22 @@ jobs:
           echo "dry-run : ${{ github.event.inputs.dry-run }}"
           echo "update-version : ${{ github.event.inputs.update-version }}"
           if [ $GITHUB_EVENT_NAME == 'workflow_dispatch' ]; then
-            echo '::set-output name=run-job::true'
+            echo "run-job=true" >> $GITHUB_OUTPUT
             if [ "${{ github.event.inputs.dry-run }}" == "true" ]; then
                 if [[ "${{ github.event.inputs.update-version }}" == "true"  && $GITHUB_REPOSITORY != "openshift-helm-charts/charts" ]]; then
-                  echo '::set-output name=check-version::true'
+                  echo "check-version=true" >> $GITHUB_OUTPUT
                 else
-                  echo '::set-output name=check-version::false'
+                  echo "check-version=false" >> $GITHUB_OUTPUT
                 fi
             else
-                echo '::set-output name=check-version::true'
+                echo "check-version=true" >> $GITHUB_OUTPUT
             fi
           elif [ $GITHUB_REPOSITORY == "openshift-helm-charts/charts" ]; then
-            echo '::set-output name=run-job::true'
-            echo '::set-output name=check-version::true'
+            echo "run-job=true" >> $GITHUB_OUTPUT
+            echo "check-version=true" >> $GITHUB_OUTPUT
           else
-            echo '::set-output name=run-job::false'
-            echo '::set-output name=check-version::false'
+            echo "run-job=false" >> $GITHUB_OUTPUT
+            echo "check-version=false" >> $GITHUB_OUTPUT
           fi
 
       - name: Get current Chart Verifier version
@@ -264,7 +264,7 @@ jobs:
           QUAY_API='https://quay.io/api/v1/repository/redhat-certification/chart-verifier/tag/'
           CV_DIGEST=$(curl ${QUAY_API} | jq '[.tags[] | select(.name == "latest")] | .[0].manifest_digest')
           printf "[INFO] Current Chart Verifier digest: %s\n" ${CV_DIGEST}
-          echo "::set-output name=current_cv_digest::${CV_DIGEST}"
+          echo "current_cv_digest=${CV_DIGEST}" >> $GITHUB_OUTPUT
         shell: bash
 
       - name: Checkout software-version branch
@@ -286,31 +286,31 @@ jobs:
         run: |
           set -euo pipefail
           if [ "${{ steps.check_repo.outputs.run-job }}" != "true" ]; then
-            echo "::set-output name=run_tests::false"
-            echo "::set-output name=update-version::false"
+            echo "run_tests=false" >> $GITHUB_OUTPUT
+            echo "update-version=false" >> $GITHUB_OUTPUT
           elif [ "${{ steps.check_repo.outputs.check-version }}" == "true" ]; then
              if [ "${{ steps.get_curr_cv_version.outputs.current_cv_digest }}" == "${{ steps.get_prev_cv_digest.outputs.result }}" ]; then
                # No change in the Chart Verifier image - do not run tests if a scheduled run or dry-run is not set
                printf "Chart Verifier has not changed since last run: '%s' -> '%s'\n" "${{ steps.get_prev_cv_digest.outputs.result }}" "${{ steps.get_curr_cv_version.outputs.current_cv_digest }}"
-               echo "::set-output name=update-version::false"
+               echo "update-version=false" >> $GITHUB_OUTPUT
                if [ "${{ github.event.inputs.dry-run }}" == "true" ]; then
                  echo "Chart Verifier image has not changed but run anyaway as dry-run is set"
-                 echo "::set-output name=run_tests::true"
+                 echo "run_tests=true" >> $GITHUB_OUTPUT
                else
                  echo "Chart Verifier image has not changed do not run tests"
-                 echo "::set-output name=run_tests::false"
+                 echo "run_tests=false" >> $GITHUB_OUTPUT
                fi
              else
                 # New Chart Verifier image is found
                 printf "Chart Verifier has changed since last run: '%s' -> '%s'\n" "${{ steps.get_prev_cv_digest.outputs.result }}" "${{ steps.get_curr_cv_version.outputs.current_cv_digest }}"
-                echo "::set-output name=run_tests::true"
-                echo "::set-output name=update-version::true"
+                echo "run_tests=true" >> $GITHUB_OUTPUT
+                echo "update-version=true" >> $GITHUB_OUTPUT
              fi
           else
             # Run whether Chart Verifier image has changed or not
             echo "Run tests - version check skipped"
-            echo "::set-output name=update-version::false"
-            echo "::set-output name=run_tests::true"
+            echo "update-version=false" >> $GITHUB_OUTPUT
+            echo "run_tests=true" >> $GITHUB_OUTPUT
           fi
 
         shell: bash

--- a/scripts/src/chartprreview/chartprreview.py
+++ b/scripts/src/chartprreview/chartprreview.py
@@ -23,6 +23,7 @@ from report import report_info
 from report import verifier_report
 from signedchart import signedchart
 from pullrequest import prartifact
+from tools import gitutils
 
 def write_error_log(directory, *msg):
     os.makedirs(directory, exist_ok=True)
@@ -211,7 +212,7 @@ def check_report_success(directory, api_url, report_path, report_info_path, vers
     print("[INFO] Full report: ")
     print(data)
     quoted_data = data.replace("%", "%25").replace("\n", "%0A").replace("\r", "%0D")
-    print(f"::set-output name=report_content::{quoted_data}")
+    gitutils.add_output("report_content",quoted_data)
 
     chart = report_info.get_report_chart(report_path=report_path,report_info_path=report_info_path)
     report_version = chart["version"]
@@ -268,17 +269,17 @@ def check_report_success(directory, api_url, report_path, report_info_path, vers
             msgs.append(f"  - {m}")
         write_error_log(directory, *msgs)
         if vendor_type == "redhat":
-            print(f"::set-output name=redhat_to_community::True")
+            gitutils.add_output("redhat_to_community","True")
         if vendor_type != "redhat" and "force-publish" not in label_names:
             if vendor_type == "community":
                 # requires manual review and approval
-                print(f"::set-output name=community_manual_review_required::True")
+                gitutils.add_output("community_manual_review_required","True")
             sys.exit(1)
 
     if vendor_type == "community" and "force-publish" not in label_names:
         # requires manual review and approval
         print("[INFO] Community submission requires manual approval.")
-        print(f"::set-output name=community_manual_review_required::True")
+        gitutils.add_output("community_manual_review_required","True")
         sys.exit(1)
 
     if failures_in_report or vendor_type == "community":

--- a/scripts/src/chartrepomanager/chartrepomanager.py
+++ b/scripts/src/chartrepomanager/chartrepomanager.py
@@ -25,6 +25,7 @@ from report import report_info
 from chartrepomanager import indexannotations
 from signedchart import signedchart
 from pullrequest import prartifact
+from tools import gitutils
 
 def get_modified_charts(api_url):
     files = prartifact.get_modified_files(api_url)
@@ -413,12 +414,12 @@ def main():
         if not tag:
             print("[ERROR] Internal error: missing chart name with version (tag)")
             sys.exit(1)
-        print(f"::set-output name=tag::{tag}")
+        gitutils.add_output("tag",tag)
 
         current_dir = os.getcwd()
-        print(f"::set-output name=report_file::{current_dir}/report.yaml")
+        gitutils.add_output("report_file",f"{current_dir}/report.yaml")
         if public_key_file:
             print(f"[INFO] Add key file for release : {current_dir}/{public_key_file}")
-            print(f"::set-output name=public_key_file::{current_dir}/{public_key_file}")
+            gitutils.add_output("public_key_file",f"{current_dir}/{public_key_file}")
 
     update_index_and_push(indexfile,indexdir, args.repository, branch, category, organization, chart, version, chart_url, chart_entry, args.pr_number, web_catalog_only)

--- a/scripts/src/pullrequest/prartifact.py
+++ b/scripts/src/pullrequest/prartifact.py
@@ -9,6 +9,7 @@ import requests
 
 sys.path.append('../')
 from checkprcontent import checkpr
+from tools import gitutils
 
 pr_files = []
 pr_labels = []
@@ -109,7 +110,7 @@ def main():
     if args.get_files:
         pr_files = get_modified_files(args.api_url)
         print(f"[INFO] files in pr: {pr_files}")
-        print(f"::set-output name=pr_files::{pr_files}")
+        gitutils.add_output("pr_files",pr_files)
     else:
         os.makedirs(args.directory, exist_ok=True)
         category, organization, chart, version = get_modified_charts(args.api_url)

--- a/scripts/src/pullrequest/prepare_pr_comment.py
+++ b/scripts/src/pullrequest/prepare_pr_comment.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from tools import gitutils
 
 def get_success_coment():
     return "Congratulations! Your chart has been certified and will be published shortly."
@@ -38,9 +39,9 @@ def prepare_failure_comment():
 {get_verifier_errors_trailer()}
 
 """
-        print(f"::set-output name=error-message::{errors}")
+        gitutils.add_output("error-message",errors)
     else:
-        print(f"::set-output name=error-message::{get_failure_comment()}")
+        gitutils.add_output("error-message",get_failure_comment())
     return msg
 
 def prepare_success_comment():
@@ -52,16 +53,16 @@ def prepare_pr_content_failure_comment():
     pr_content_error_msg = os.environ.get("PR_CONTENT_ERROR_MESSAGE", "")
     owners_error_msg = os.environ.get("OWNERS_ERROR_MESSAGE", "")
     if pr_content_error_msg:
-        print(f"::set-output name=error-message::{pr_content_error_msg}")
+        gitutils.add_output("error-message",pr_content_error_msg)
         msg += f"{pr_content_error_msg}\n\n"
     if owners_error_msg:
-        print(f"::set-output name=error-message::{owners_error_msg}")
+        gitutils.add_output("error-message",owners_error_msg)
         msg += f"{owners_error_msg}\n\n"
     return msg
 
 def prepare_run_verifier_failure_comment():
     verifier_error_msg = os.environ.get("VERIFIER_ERROR_MESSAGE", "")
-    print(f"::set-output name=error-message::{verifier_error_msg}")
+    gitutils.add_output("error-message",verifier_error_msg)
     msg = f"""   
 {verifier_error_msg}
 
@@ -106,30 +107,30 @@ def main():
     oc_install_result = os.environ.get("OC_INSTALL_RESULT", False)
     if pr_content_result == "failure":
         msg += prepare_pr_content_failure_comment()
-        print(f"::set-output name=pr_passed::false")
+        gitutils.add_output("pr_passed","false")
     elif run_verifier_result == "failure":
         msg += prepare_run_verifier_failure_comment()
-        print(f"::set-output name=pr_passed::false")
+        gitutils.add_output("pr_passed","false")
     elif verify_result == "failure":
         community_manual_review = os.environ.get("COMMUNITY_MANUAL_REVIEW",False)
         if community_manual_review:
             msg += prepare_community_comment()
-            print(f"::set-output name=pr_passed::true")
+            gitutils.add_output("pr_passed","true")
         else:
             msg += prepare_failure_comment()
-            print(f"::set-output name=pr_passed::false")
+            gitutils.add_output("pr_passed","false")
     elif oc_install_result == "failure":
         msg += prepare_oc_install_fail_comment()
-        print(f"::set-output name=pr_passed::false")
+        gitutils.add_output("pr_passed","false")
     else:
-        print(f"::set-output name=pr_passed::true")
+        gitutils.add_output("pr_passed","true")
         msg += prepare_success_comment()
 
     msg += get_comment_footer(vendor_label, chart_name)
 
     with open("./pr/comment", "w") as fd:
         fd.write(msg)
-        print(f"::set-output name=message-file::{fd.name}")
+        gitutils.add_output("message-file",fd.name)
 
 if __name__ == "__main__":
     main()

--- a/scripts/src/release/releasechecker.py
+++ b/scripts/src/release/releasechecker.py
@@ -150,7 +150,7 @@ def make_release_body(version, release_info):
         body += f"- {info}<br>"
 
     print(f"[INFO] Release body: {body}")
-    print(f"::set-output name=PR_release_body::{body}")
+    gitutils.add_output("PR_release_body",body)
 
 def get_version_info():
     data = {}
@@ -190,14 +190,14 @@ def main():
         if args.pr_base_repo.endswith(DEV_PR_BASE_REPO):
             if check_if_dev_release_branch(args.sender,args.pr_branch,args.pr_body,args.api_url,args.pr_head_repo):
                 print('[INFO] Dev release pull request found')
-                print(f'::set-output name=dev_release_branch::true')
+                gitutils.add_output("dev_release_branch","true")
                 version = args.pr_branch.removeprefix(releaser.DEV_PR_BRANCH_NAME_PREFIX)
-                print(f'::set-output name=PR_version::{version}')
-                print(f"::set-output name=PR_release_body::{args.pr_body}")
+                gitutils.add_output("PR_version",version)
+                gitutils.add_output("PR_release_body",args.pr_body)
         elif args.pr_base_repo.endswith(CHARTS_PR_BASE_REPO):
             if check_if_charts_release_branch(args.sender,args.pr_branch,args.pr_body,args.api_url,args.pr_head_repo):
                 print('[INFO] Workflow release pull request found')
-                print(f'::set-output name=charts_release_branch::true')
+                gitutils.add_output("charts_release_branch","true")
     elif args.api_url:
         ## should be on PR branch
         if args.pr_base_repo.endswith(DEV_PR_BASE_REPO):
@@ -205,17 +205,17 @@ def main():
             user_authorized = checkuser.verify_user(args.sender)
             if version_only and user_authorized:
                 organization = args.pr_base_repo.removesuffix(DEV_PR_BASE_REPO)
-                print(f'::set-output name=charts_repo::{organization}{CHARTS_PR_BASE_REPO}')
+                gitutils.add_output("charts_repo",f"{organization}{CHARTS_PR_BASE_REPO}")
                 version = release_info.get_version("./")
                 version_info = release_info.get_info("./")
                 print(f'[INFO] Release found in PR files : {version}.')
-                print(f'::set-output name=PR_version::{version}')
-                print(f'::set-output name=PR_release_info::{version_info}')
-                print(f'::set-output name=PR_includes_release_only::true')
+                gitutils.add_output("PR_version",version)
+                gitutils.add_output("PR_release_info",version_info)
+                gitutils.add_output("PR_includes_release_only","true")
                 make_release_body(version,version_info)
             elif version_only and not user_authorized:
                 print(f'[ERROR] sender not authorized : {args.sender}.')
-                print(f'::set-output name=sender_not_authorized::true')
+                gitutils.add_output("sender_not_authorized","true")
             else:
                 print('[INFO] Not a release PR')
         else:
@@ -226,7 +226,7 @@ def main():
             # should be on main branch
             if semver.compare(args.version,version) > 0 :
                 print(f'[INFO] Release {args.version} found in PR files is newer than: {version}.')
-                print(f'::set-output name=release_updated::true')
+                gitutils.add_output("release_updated","true")
             else:
                 print(f'[ERROR] Release found in PR files is not new  : {args.version}.')
         else:

--- a/scripts/src/release/releaser.py
+++ b/scripts/src/release/releaser.py
@@ -170,12 +170,12 @@ def main():
     message = f'{CHARTS_PR_BRANCH_BODY_PREFIX} {branch_name}'
     outcome = gitutils.create_pr(branch_name,[],charts_repository,message,args.target_branch)
     if outcome == gitutils.PR_CREATED:
-        print(f'::set-output name=charts_pr_created::true')
+        gitutils.add_output("charts_pr_created","true")
     elif outcome == gitutils.PR_NOT_NEEDED:
-        print(f'::set-output name=charts_pr_not_needed::true')
+        gitutils.add_output("charts_pr_not_needed","true")
     else:
         print("[ERROR] error creating charts PR")
-        print(f'::set-output name=charts_pr_error::true')
+        gitutils.add_output("charts_pr_error","true")
         os.chdir(start_directory)
         return
 
@@ -190,13 +190,13 @@ def main():
     outcome = gitutils.create_pr(branch_name,[release_info.RELEASE_INFO_FILE],args.target_repository,args.dev_pr_body,args.target_branch)
     if outcome == gitutils.PR_CREATED:
         print("Dev PR successfully created.")
-        print(f'::set-output name=dev_pr_created::true')
+        gitutils.add_output("dev_pr_created","true")
     elif outcome == gitutils.PR_NOT_NEEDED:
         print("Dev PR not needed.")
-        print(f'::set-output name=dev_pr_not_needed::true')
+        gitutils.add_output("dev_pr_not_needed","true")
     else:
         print("[ERROR] error creating development PR.")
-        print('::set-output name=dev_pr_error::true')
+        gitutils.add_output("dev_pr_error","true")
 
     os.chdir(start_directory)
 
@@ -209,12 +209,12 @@ def main():
     message = f'{STAGE_PR_BRANCH_BODY_PREFIX} {branch_name}'
     outcome = gitutils.create_pr(branch_name,[],stage_repository,message,args.target_branch)
     if outcome == gitutils.PR_CREATED:
-        print(f'::set-output name=stage_pr_created::true')
+        gitutils.add_output("stage_pr_created","true")
     elif outcome == gitutils.PR_NOT_NEEDED:
-        print(f'::set-output name=stage_pr_not_needed::true')
+        gitutils.add_output("stage_pr_not_needed","true")
     else:
         print("[ERROR] error creating stage PR")
-        print(f'::set-output name=stage_pr_error::true')
+        gitutils.add_output("stage_pr_error","true")
         os.chdir(start_directory)
         return
 

--- a/scripts/src/report/get_verify_params.py
+++ b/scripts/src/report/get_verify_params.py
@@ -6,6 +6,7 @@ import argparse
 sys.path.append('../')
 from chartprreview import chartprreview
 from signedchart import signedchart
+from tools import gitutils
 
 def generate_verify_options(directory,category, organization, chart, version):
     print("[INFO] Generate verify options. %s, %s, %s" % (organization,chart,version))
@@ -58,9 +59,9 @@ def main():
     category, organization, chart, version = chartprreview.get_modified_charts(args.directory, args.api_url)
 
     flags,chart_uri,report_needed,cluster_needed = generate_verify_options(args.directory,category, organization, chart, version)
-    print(f"::set-output name=report_needed::{report_needed}")
-    print(f"::set-output name=cluster_needed::{cluster_needed}")
+    gitutils.add_output("report_needed",report_needed)
+    gitutils.add_output("cluster_needed",cluster_needed)
     if report_needed:
-        print(f"::set-output name=verify_args::{flags}")
-        print(f"::set-output name=verify_uri::{chart_uri}")
+        gitutils.add_output("verify_args",flags)
+        gitutils.add_output("verify_uri",chart_uri)
 

--- a/scripts/src/tools/gitutils.py
+++ b/scripts/src/tools/gitutils.py
@@ -161,3 +161,7 @@ def add_changes(repo,skip_files):
                 repo.git.add(add)
 
     return len(repo.index.diff("HEAD")) > 0
+
+def add_output(name,value):
+    with open(os.environ['GITHUB_OUTPUT'],'a') as fh:
+        print(f'{name}={value}',file=fh)

--- a/scripts/src/workflowtesting/checkprforci.py
+++ b/scripts/src/workflowtesting/checkprforci.py
@@ -10,6 +10,7 @@ try:
     from yaml import CLoader as Loader, CDumper as Dumper
 except ImportError:
     from yaml import Loader, Dumper
+from tools import gitutils
 
 sys.path.append('../')
 from pullrequest import prartifact
@@ -37,10 +38,10 @@ def check_if_ci_only_is_modified(api_url):
             return False
 
     if others_found and not workflow_found:
-        print("::set-output name=do-not-build::true")
+        gitutils.add_output("do-not-build","true")
     elif tests_included:
         print(f"[INFO] set full_tests_in_pr to true")
-        print("::set-output name=full_tests_in_pr::true")
+        gitutils.add_output("full_tests_in_pr","true")
 
     return workflow_found
 
@@ -71,17 +72,17 @@ def main():
     if not args.api_url:
         if verify_user(args.username):
             print(f"[INFO] User authorized for manual invocation - run tests.")
-            print(f"::set-output name=run-tests::true")
+            gitutils.add_output("run-tests","true")
         else:
             print(f"[INFO] User not authorized for manual invocation - do not run tests.")
-            print(f"::set-output name=workflow-only-but-not-authorized::true")
+            gitutils.add_output("workflow-only-but-not-authorized","true")
     elif check_if_ci_only_is_modified(args.api_url):
         if verify_user(args.username):
             print(f"[INFO] PR is workflow changes only and user is authorized - run tests.")
-            print(f"::set-output name=run-tests::true")
+            gitutils.add_output("run-tests","true")
         else:
             print(f"[INFO] PR is workflow changes only but user is not authorized - do not run tests.")
-            print(f"::set-output name=workflow-only-but-not-authorized::true")
+            gitutils.add_output("workflow-only-but-not-authorized","true")
     else:
         print(f"[INFO] Non workflow changes were found - do not run tests")
 


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/HELM-437

Removes the deprecated set-output in favore for GITHUB_OUTPUT

The workflows and associated scripts make extensive use of set-output, but it is now being deprecated: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

This PR removes set-output and replaces it with GITHUB_OUTPUT within the workflow. It also introduces an addition function within the tools module that will handle adding the output to GITHUB_OUTPUT for the python scripts.