### PR TITLE
Create error if tarball name not as expected

### DIFF
--- a/scripts/src/pullrequest/prartifact.py
+++ b/scripts/src/pullrequest/prartifact.py
@@ -19,7 +19,7 @@ xRateRemain = "X-RateLimit-Remaining"
 # TODO(baijum): Move this code under chartsubmission.chart module
 def get_modified_charts(api_url):
     files = get_modified_files(api_url)
-    pattern,_ = checkpr.get_file_match_compiled_patterns()
+    pattern,_,_ = checkpr.get_file_match_compiled_patterns()
     for file in files:
         match = pattern.match(file)
         if match:


### PR DESCRIPTION
Added some code to error if the tarbal name is bad. 
See: https://issues.redhat.com/browse/HELM-382

Confirmed it worked manualy, this ii the PR:

```
Thank you for submitting PR #391 for Helm Chart Certification!

One or more errors were found with the pull request: 
[ERROR] the tgz file is named incorrectly. Expected: psql-service-0.1.12.tgz
```