### PR TITLE
Add OpDev maintainers as owners

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,6 +1,9 @@
 # See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
 
 approvers:
+- komish
+- jsm84
+- jomkz
 - baijum
 - dperaza4dustbit
 - mmulholla
@@ -11,6 +14,9 @@ approvers:
 - PatAKnight
 
 reviewers:
+- komish
+- jsm84
+- jomkz
 - baijum
 - dperaza4dustbit
 - mmulholla


### PR DESCRIPTION
Updates the top-level owners file for this repository to match the charts repo.