### PR TITLE
allow insecure-skip-tls-verify for charts repo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,16 +79,15 @@ jobs:
       - name: Set Environment
         id: set-env
         run: |
-          #set environemnt based on repository
+          #set environment based on repository
           if [ $GITHUB_REPOSITORY == "openshift-helm-charts/charts" ]; then
             echo "Use latest verifier image"
-            echo "insecure_skip_tls_verify=false" >> $GITHUB_OUTPUT
             echo "verifier-action-image=latest" >> $GITHUB_OUTPUT
           else
             echo "Use dev verifier image"
-            echo "insecure_skip_tls_verify=true" >> $GITHUB_OUTPUT
             echo "verifier-action-image=0.1.0" >> $GITHUB_OUTPUT
           fi
+          echo "insecure_skip_tls_verify=true" >> $GITHUB_OUTPUT
 
       - name: Checkout
         if: ${{ steps.check_build_required.outputs.run-build == 'true' }}


### PR DESCRIPTION
The cluster currently used for testing utilizes a self-signed cert local to the cluster. The charts repo enforced strict tls verification for oc login while other repos did not.

This resolves the issue temporarily until either (a) the cluster LB endpoint uses valid certificates, or (b) the signing key is pulled and added to oc login.