### PR TITLE
Release 1.5.2

### DIFF
--- a/release/release_info.json
+++ b/release/release_info.json
@@ -1,7 +1,8 @@
 {
-  "version": "1.5.1",
+  "version": "1.5.2",
   "info" : [
-    "Various Bug Fixes and updates for latest chart-verifier"
+    "Remove a deprecated script",
+    "Allow insecure-tls-verify for the charts repo on new 4.12 test cluster"
   ],
   "charts" : {
     "development": {


### PR DESCRIPTION
Puts in some fixes that are blocking the production charts/ repo with the new 4.12 cluster.