### PR TITLE
adjust case of an error prefix produced by chart-verifier

### DIFF
--- a/tests/functional/behave_features/HC-16_chart_test_takes_more_than_30mins.feature
+++ b/tests/functional/behave_features/HC-16_chart_test_takes_more_than_30mins.feature
@@ -11,7 +11,7 @@ Feature: Chart test takes longer time and exceeds default timeout
     @partners @full
     Examples:
       | vendor_type  | vendor    | chart_path                                  | message                                                                                     |
-      | partners     | hashicorp | tests/data/vault-test-timeout-0.17.0.tgz    | Chart test failure: timed out waiting for the condition                                     |
+      | partners     | hashicorp | tests/data/vault-test-timeout-0.17.0.tgz    | chart test failure: timed out waiting for the condition                                     |
     
     @community @full
     Examples:


### PR DESCRIPTION
Chart Verifier recently ran style tooling which enforced that error messages should not start with capital letters, or end with punctuation. As a result, this feature contains a message string that directly corresponded to a capital letter that was previously used. This PR replaces that with a lower case letter to align the two.