### PR TITLE
Add missing BOT_TOKEN environment variable in Mercury Bot workflow

### DIFF
--- a/.github/workflows/mercury_bot.yml
+++ b/.github/workflows/mercury_bot.yml
@@ -27,6 +27,8 @@ jobs:
 
       - name: get files changed
         id: get_files_changed
+        env:
+          BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
         run: |
           # get files in PR
           ./ve1/bin/pr-artifact --api-url=${{ github.event.pull_request._links.self.href }} \


### PR DESCRIPTION
HELM-487 - The Mercury Bot PR-based workflow that's being tested in stage would fail to pull the changes in the invoking PR because the BOT_TOKEN secret was not being passed into the workflow.

This PR adds that context to the specific task.