### PR TITLE
Ensure chart annotations are merged with generated annotations on index creation

### DIFF
--- a/scripts/src/chartrepomanager/chartrepomanager.py
+++ b/scripts/src/chartrepomanager/chartrepomanager.py
@@ -333,7 +333,11 @@ def update_chart_annotation(category, organization, chart_file_name, chart, repo
 
     fd = open(os.path.join(dr, chart, "Chart.yaml"))
     data = yaml.load(fd, Loader=Loader)
-    data["annotations"] = annotations
+    # merge the existing annotations with our new ones, overwriting
+    # values for overlapping keys with our own. |= syntax requires py3.9
+    # Overwriting is important because the chart may contain values that we
+    # must override, such as the providerType which changes in redhat-to-community cases.
+    data["annotations"] |= annotations
     out = yaml.dump(data, Dumper=Dumper)
     with open(os.path.join(dr, chart, "Chart.yaml"), "w") as fd:
         fd.write(out)


### PR DESCRIPTION
Fixes: https://github.com/openshift-helm-charts/charts/issues/894

When chart-only PRs are submitted, our automation extracts annotations that would otherwise have been submitted in a report from the report generated on the partner's behalf. These annotations were then replacing the existing annotations in a given chart instead of merging with them.

This PR merges the annotations with existing annotations in the chart, replacing overlapping keys with the values that were generated by our automation.