### PR TITLE
Release 1.5.5

### DIFF
--- a/release/release_info.json
+++ b/release/release_info.json
@@ -1,7 +1,7 @@
 {
-  "version": "1.5.4",
+  "version": "1.5.5",
   "info" : [
-    "Allow the BOT_TOKEN to be used for the mercury_bot workflow"
+    "Ensure chart annotations are merged with generated annotations on index creation"
   ],
   "charts" : {
     "development": {


### PR DESCRIPTION
Release a bugfix for chart-only PRs getting their annotations squashed when merged into the index.