### PR TITLE
Bump the GHA run image to ubuntu 22.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   chart-certification:
     name: Chart Certification
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: |
       github.event.pull_request.draft == false &&
       (github.event.action != 'labeled' || github.event.label.name == 'force-publish') &&


### PR DESCRIPTION
To help with CGO-related issues with chart-verifier built using golang 1.20.