### PR TITLE
Adjust expected timeout message

### DIFF
--- a/tests/functional/behave_features/HC-16_chart_test_takes_more_than_30mins.feature
+++ b/tests/functional/behave_features/HC-16_chart_test_takes_more_than_30mins.feature
@@ -10,8 +10,8 @@ Feature: Chart test takes longer time and exceeds default timeout
 
     @partners @full
     Examples:
-      | vendor_type  | vendor    | chart_path                                  | message                                                                                     |
-      | partners     | hashicorp | tests/data/vault-test-timeout-0.17.0.tgz    | chart test failure: timed out waiting for the condition                                     |
+      | vendor_type  | vendor    | chart_path                                  | message                               |
+      | partners     | hashicorp | tests/data/vault-test-timeout-0.17.0.tgz    | * timed out waiting for the condition |
     
     @community @full
     Examples:

--- a/tests/functional/features/HC-16_chart_test_takes_more_than_30mins.feature
+++ b/tests/functional/features/HC-16_chart_test_takes_more_than_30mins.feature
@@ -14,7 +14,7 @@ Feature: Chart test takes longer time and exceeds default timeout
 
     Examples:
       | vendor_type  | vendor         | message                                                                                     |
-      | partners     | hashicorp      | Chart test failure: timed out waiting for the condition                                     |
+      | partners     | hashicorp      | * timed out waiting for the condition                                                       |
       | community    | redhat         | Community charts require maintainer review and approval, a review will be conducted shortly |
   
   Scenario Outline: [HC-16-002] A redhat associate submits a chart that takes more than 30 mins


### PR DESCRIPTION
Chart Testing was bumped in recent development versions of chart-verifier. The error message now returns a go-multierror, it seems, which doesn't quite output the exact single line that our e2e tests are expecting. This PR makes the expected message a bit less specific to accommodate this change.