### PR TITLE
Regenerate test reports after chart modifications

### DIFF
--- a/tests/data/HC-04/community/report.yaml
+++ b/tests/data/HC-04/community/report.yaml
@@ -2,19 +2,19 @@ apiversion: v1
 kind: verify-report
 metadata:
     tool:
-        verifier-version: 1.9.0
+        verifier-version: 1.12.2
         profile:
             VendorType: community
-            version: v1.1
-        reportDigest: uint64:6109394152551061817
-        chart-uri: vault-0.17.0.tgz
+            version: v1.2
+        reportDigest: uint64:12284475994233296417
+        chart-uri: tests/data/vault-0.17.0.tgz
         digests:
-            chart: sha256:f01dd362d81fe4b1ef99bb7fa5be268fa94dc96f3009d28bc93a18517aa1ef7a
-            package: 9cb7e3a5d82537f512319c754ccd6e9a4be08118b34849609d0fc261934d062a
-        lastCertifiedTimestamp: "2022-10-09T19:21:54.5696+05:30"
-        testedOpenShiftVersion: "4.11"
+            chart: sha256:aba56e4bc68704aa933a180a7a7abb309b73c7020a53020a3f2c17565faf12a3
+            package: 72f8d48aad2df1fe49e864a33a112793d2c8a67874d62a466d94bbe4e5f54fee
+        lastCertifiedTimestamp: "2023-07-26T13:27:49.167072-05:00"
+        testedOpenShiftVersion: "4.12"
         supportedOpenShiftVersions: '>=4.2'
-        providerControlledDelivery: false
+        webCatalogOnly: false
     chart:
         name: vault
         home: https://www.vaultproject.io
@@ -47,54 +47,58 @@ metadata:
         type: ""
     chart-overrides: ""
 results:
-    - check: v1.0/not-contains-crds
+    - check: v1.0/helm-lint
+      type: Mandatory
+      outcome: PASS
+      reason: Helm lint successful
+    - check: v1.0/not-contain-csi-objects
       type: Optional
       outcome: PASS
-      reason: Chart does not contain CRDs
-    - check: v1.0/is-helm-v3
-      type: Optional
-      outcome: PASS
-      reason: API version is V2, used in Helm 3
-    - check: v1.0/required-annotations-present
-      type: Optional
-      outcome: PASS
-      reason: All required annotations present
-    - check: v1.0/chart-testing
-      type: Optional
-      outcome: PASS
-      reason: Chart tests have passed
-    - check: v1.0/has-readme
-      type: Optional
-      outcome: PASS
-      reason: Chart has a README
-    - check: v1.0/images-are-certified
+      reason: CSI objects do not exist
+    - check: v1.1/images-are-certified
       type: Optional
       outcome: PASS
       reason: |-
         Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault-k8s:0.14.0-ubi
         Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault:1.8.4-ubi
-    - check: v1.0/not-contain-csi-objects
+    - check: v1.0/is-helm-v3
       type: Optional
       outcome: PASS
-      reason: CSI objects do not exist
-    - check: v1.0/contains-values-schema
+      reason: API version is V2, used in Helm 3
+    - check: v1.0/signature-is-valid
       type: Optional
-      outcome: PASS
-      reason: Values schema file exist
+      outcome: SKIPPED
+      reason: 'Chart is not signed : Signature verification not required'
     - check: v1.0/contains-test
       type: Optional
       outcome: PASS
       reason: Chart test files exist
+    - check: v1.0/contains-values-schema
+      type: Optional
+      outcome: PASS
+      reason: Values schema file exist
     - check: v1.0/contains-values
       type: Optional
       outcome: PASS
       reason: Values file exist
+    - check: v1.0/required-annotations-present
+      type: Optional
+      outcome: PASS
+      reason: All required annotations present
+    - check: v1.0/has-readme
+      type: Optional
+      outcome: PASS
+      reason: Chart has a README
     - check: v1.1/has-kubeversion
       type: Optional
       outcome: PASS
       reason: Kubernetes version specified
-    - check: v1.0/helm-lint
-      type: Mandatory
+    - check: v1.0/not-contains-crds
+      type: Optional
       outcome: PASS
-      reason: Helm lint successful
+      reason: Chart does not contain CRDs
+    - check: v1.0/chart-testing
+      type: Optional
+      outcome: PASS
+      reason: Chart tests have passed
 

--- a/tests/data/HC-04/partner/report.yaml
+++ b/tests/data/HC-04/partner/report.yaml
@@ -2,19 +2,19 @@ apiversion: v1
 kind: verify-report
 metadata:
     tool:
-        verifier-version: 1.9.0
+        verifier-version: 1.12.2
         profile:
             VendorType: partner
-            version: v1.1
-        reportDigest: uint64:2083954931931251669
-        chart-uri: vault-0.17.0.tgz
+            version: v1.2
+        reportDigest: uint64:7594949332872749418
+        chart-uri: tests/data/vault-0.17.0.tgz
         digests:
-            chart: sha256:f01dd362d81fe4b1ef99bb7fa5be268fa94dc96f3009d28bc93a18517aa1ef7a
-            package: 9cb7e3a5d82537f512319c754ccd6e9a4be08118b34849609d0fc261934d062a
-        lastCertifiedTimestamp: "2022-10-09T19:11:54.765745+05:30"
-        testedOpenShiftVersion: "4.11"
+            chart: sha256:aba56e4bc68704aa933a180a7a7abb309b73c7020a53020a3f2c17565faf12a3
+            package: 72f8d48aad2df1fe49e864a33a112793d2c8a67874d62a466d94bbe4e5f54fee
+        lastCertifiedTimestamp: "2023-07-26T13:25:44.500114-05:00"
+        testedOpenShiftVersion: "4.12"
         supportedOpenShiftVersions: '>=4.2'
-        providerControlledDelivery: false
+        webCatalogOnly: false
     chart:
         name: vault
         home: https://www.vaultproject.io
@@ -47,42 +47,48 @@ metadata:
         type: ""
     chart-overrides: ""
 results:
-    - check: v1.0/has-readme
+    - check: v1.1/images-are-certified
       type: Mandatory
       outcome: PASS
-      reason: Chart has a README
-    - check: v1.0/chart-testing
-      type: Mandatory
-      outcome: PASS
-      reason: Chart tests have passed
-    - check: v1.0/contains-test
-      type: Mandatory
-      outcome: PASS
-      reason: Chart test files exist
-    - check: v1.0/helm-lint
-      type: Mandatory
-      outcome: PASS
-      reason: Helm lint successful
-    - check: v1.0/required-annotations-present
-      type: Mandatory
-      outcome: PASS
-      reason: All required annotations present
-    - check: v1.0/contains-values-schema
-      type: Mandatory
-      outcome: PASS
-      reason: Values schema file exist
-    - check: v1.0/contains-values
-      type: Mandatory
-      outcome: PASS
-      reason: Values file exist
-    - check: v1.1/has-kubeversion
-      type: Mandatory
-      outcome: PASS
-      reason: Kubernetes version specified
+      reason: |-
+        Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault-k8s:0.14.0-ubi
+        Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault:1.8.4-ubi
     - check: v1.0/not-contain-csi-objects
       type: Mandatory
       outcome: PASS
       reason: CSI objects do not exist
+    - check: v1.0/signature-is-valid
+      type: Mandatory
+      outcome: SKIPPED
+      reason: 'Chart is not signed : Signature verification not required'
+    - check: v1.0/contains-test
+      type: Mandatory
+      outcome: PASS
+      reason: Chart test files exist
+    - check: v1.0/contains-values-schema
+      type: Mandatory
+      outcome: PASS
+      reason: Values schema file exist
+    - check: v1.1/has-kubeversion
+      type: Mandatory
+      outcome: PASS
+      reason: Kubernetes version specified
+    - check: v1.0/required-annotations-present
+      type: Mandatory
+      outcome: PASS
+      reason: All required annotations present
+    - check: v1.0/chart-testing
+      type: Mandatory
+      outcome: PASS
+      reason: Chart tests have passed
+    - check: v1.0/has-readme
+      type: Mandatory
+      outcome: PASS
+      reason: Chart has a README
+    - check: v1.0/helm-lint
+      type: Mandatory
+      outcome: PASS
+      reason: Helm lint successful
     - check: v1.0/is-helm-v3
       type: Mandatory
       outcome: PASS
@@ -91,10 +97,8 @@ results:
       type: Mandatory
       outcome: PASS
       reason: Chart does not contain CRDs
-    - check: v1.0/images-are-certified
+    - check: v1.0/contains-values
       type: Mandatory
       outcome: PASS
-      reason: |-
-        Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault-k8s:0.14.0-ubi
-        Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault:1.8.4-ubi
+      reason: Values file exist
 

--- a/tests/data/HC-04/redhat/report.yaml
+++ b/tests/data/HC-04/redhat/report.yaml
@@ -2,19 +2,19 @@ apiversion: v1
 kind: verify-report
 metadata:
     tool:
-        verifier-version: 1.9.0
+        verifier-version: 1.12.2
         profile:
             VendorType: redhat
-            version: v1.1
-        reportDigest: uint64:8490969933058949466
-        chart-uri: vault-0.17.0.tgz
+            version: v1.2
+        reportDigest: uint64:17589002506308805613
+        chart-uri: tests/data/vault-0.17.0.tgz
         digests:
-            chart: sha256:f01dd362d81fe4b1ef99bb7fa5be268fa94dc96f3009d28bc93a18517aa1ef7a
-            package: 9cb7e3a5d82537f512319c754ccd6e9a4be08118b34849609d0fc261934d062a
-        lastCertifiedTimestamp: "2022-10-09T19:18:05.749707+05:30"
-        testedOpenShiftVersion: "4.11"
+            chart: sha256:aba56e4bc68704aa933a180a7a7abb309b73c7020a53020a3f2c17565faf12a3
+            package: 72f8d48aad2df1fe49e864a33a112793d2c8a67874d62a466d94bbe4e5f54fee
+        lastCertifiedTimestamp: "2023-07-26T13:26:52.775951-05:00"
+        testedOpenShiftVersion: "4.12"
         supportedOpenShiftVersions: '>=4.2'
-        providerControlledDelivery: false
+        webCatalogOnly: false
     chart:
         name: vault
         home: https://www.vaultproject.io
@@ -47,54 +47,58 @@ metadata:
         type: ""
     chart-overrides: ""
 results:
-    - check: v1.0/required-annotations-present
-      type: Mandatory
-      outcome: PASS
-      reason: All required annotations present
-    - check: v1.0/contains-values
-      type: Mandatory
-      outcome: PASS
-      reason: Values file exist
-    - check: v1.0/not-contains-crds
-      type: Mandatory
-      outcome: PASS
-      reason: Chart does not contain CRDs
-    - check: v1.0/chart-testing
-      type: Mandatory
-      outcome: PASS
-      reason: Chart tests have passed
-    - check: v1.0/has-readme
-      type: Mandatory
-      outcome: PASS
-      reason: Chart has a README
-    - check: v1.0/contains-test
-      type: Mandatory
-      outcome: PASS
-      reason: Chart test files exist
-    - check: v1.1/has-kubeversion
-      type: Mandatory
-      outcome: PASS
-      reason: Kubernetes version specified
     - check: v1.0/helm-lint
       type: Mandatory
       outcome: PASS
       reason: Helm lint successful
-    - check: v1.0/images-are-certified
+    - check: v1.0/contains-values
+      type: Mandatory
+      outcome: PASS
+      reason: Values file exist
+    - check: v1.0/is-helm-v3
+      type: Mandatory
+      outcome: PASS
+      reason: API version is V2, used in Helm 3
+    - check: v1.0/not-contains-crds
+      type: Mandatory
+      outcome: PASS
+      reason: Chart does not contain CRDs
+    - check: v1.0/contains-values-schema
+      type: Mandatory
+      outcome: PASS
+      reason: Values schema file exist
+    - check: v1.1/has-kubeversion
+      type: Mandatory
+      outcome: PASS
+      reason: Kubernetes version specified
+    - check: v1.0/not-contain-csi-objects
+      type: Mandatory
+      outcome: PASS
+      reason: CSI objects do not exist
+    - check: v1.0/has-readme
+      type: Mandatory
+      outcome: PASS
+      reason: Chart has a README
+    - check: v1.0/required-annotations-present
+      type: Mandatory
+      outcome: PASS
+      reason: All required annotations present
+    - check: v1.0/signature-is-valid
+      type: Mandatory
+      outcome: SKIPPED
+      reason: 'Chart is not signed : Signature verification not required'
+    - check: v1.0/chart-testing
+      type: Mandatory
+      outcome: PASS
+      reason: Chart tests have passed
+    - check: v1.0/contains-test
+      type: Mandatory
+      outcome: PASS
+      reason: Chart test files exist
+    - check: v1.1/images-are-certified
       type: Mandatory
       outcome: PASS
       reason: |-
         Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault-k8s:0.14.0-ubi
         Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault:1.8.4-ubi
-    - check: v1.0/is-helm-v3
-      type: Mandatory
-      outcome: PASS
-      reason: API version is V2, used in Helm 3
-    - check: v1.0/not-contain-csi-objects
-      type: Mandatory
-      outcome: PASS
-      reason: CSI objects do not exist
-    - check: v1.0/contains-values-schema
-      type: Mandatory
-      outcome: PASS
-      reason: Values schema file exist
 

--- a/tests/data/HC-06/partner/report.yaml
+++ b/tests/data/HC-06/partner/report.yaml
@@ -2,19 +2,19 @@ apiversion: v1
 kind: verify-report
 metadata:
     tool:
-        verifier-version: 1.9.0
+        verifier-version: 1.12.2
         profile:
             VendorType: partner
-            version: v1.1
-        reportDigest: uint64:14723461504266211875
+            version: v1.2
+        reportDigest: uint64:13856952979000771687
         chart-uri: N/A
         digests:
-            chart: sha256:f01dd362d81fe4b1ef99bb7fa5be268fa94dc96f3009d28bc93a18517aa1ef7a
-            package: 9cb7e3a5d82537f512319c754ccd6e9a4be08118b34849609d0fc261934d062a
-        lastCertifiedTimestamp: "2022-10-09T19:33:32.953809+05:30"
-        testedOpenShiftVersion: "4.11"
+            chart: sha256:aba56e4bc68704aa933a180a7a7abb309b73c7020a53020a3f2c17565faf12a3
+            package: 72f8d48aad2df1fe49e864a33a112793d2c8a67874d62a466d94bbe4e5f54fee
+        lastCertifiedTimestamp: "2023-07-26T14:35:42.163661-05:00"
+        testedOpenShiftVersion: "4.12"
         supportedOpenShiftVersions: '>=4.2'
-        providerControlledDelivery: true
+        webCatalogOnly: true
     chart:
         name: vault
         home: https://www.vaultproject.io
@@ -47,54 +47,58 @@ metadata:
         type: ""
     chart-overrides: ""
 results:
+    - check: v1.0/not-contain-csi-objects
+      type: Mandatory
+      outcome: PASS
+      reason: CSI objects do not exist
+    - check: v1.0/required-annotations-present
+      type: Mandatory
+      outcome: PASS
+      reason: All required annotations present
+    - check: v1.0/not-contains-crds
+      type: Mandatory
+      outcome: PASS
+      reason: Chart does not contain CRDs
+    - check: v1.0/contains-values-schema
+      type: Mandatory
+      outcome: PASS
+      reason: Values schema file exist
+    - check: v1.1/has-kubeversion
+      type: Mandatory
+      outcome: PASS
+      reason: Kubernetes version specified
     - check: v1.0/helm-lint
       type: Mandatory
       outcome: PASS
       reason: Helm lint successful
+    - check: v1.0/chart-testing
+      type: Mandatory
+      outcome: PASS
+      reason: Chart tests have passed
     - check: v1.0/contains-test
       type: Mandatory
       outcome: PASS
       reason: Chart test files exist
-    - check: v1.0/images-are-certified
+    - check: v1.0/has-readme
+      type: Mandatory
+      outcome: PASS
+      reason: Chart has a README
+    - check: v1.1/images-are-certified
       type: Mandatory
       outcome: PASS
       reason: |-
         Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault-k8s:0.14.0-ubi
         Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault:1.8.4-ubi
-    - check: v1.0/not-contains-crds
-      type: Mandatory
-      outcome: PASS
-      reason: Chart does not contain CRDs
-    - check: v1.0/required-annotations-present
-      type: Mandatory
-      outcome: PASS
-      reason: All required annotations present
-    - check: v1.1/has-kubeversion
-      type: Mandatory
-      outcome: PASS
-      reason: Kubernetes version specified
     - check: v1.0/is-helm-v3
       type: Mandatory
       outcome: PASS
       reason: API version is V2, used in Helm 3
-    - check: v1.0/has-readme
-      type: Mandatory
-      outcome: PASS
-      reason: Chart has a README
-    - check: v1.0/not-contain-csi-objects
-      type: Mandatory
-      outcome: PASS
-      reason: CSI objects do not exist
-    - check: v1.0/chart-testing
-      type: Mandatory
-      outcome: PASS
-      reason: Chart tests have passed
-    - check: v1.0/contains-values-schema
-      type: Mandatory
-      outcome: PASS
-      reason: Values schema file exist
     - check: v1.0/contains-values
       type: Mandatory
       outcome: PASS
       reason: Values file exist
+    - check: v1.0/signature-is-valid
+      type: Mandatory
+      outcome: SKIPPED
+      reason: 'Chart is not signed : Signature verification not required'
 

--- a/tests/data/HC-09/community/report.json
+++ b/tests/data/HC-09/community/report.json
@@ -3,21 +3,21 @@
   "kind": "verify-report",
   "metadata": {
     "tool": {
-      "verifier-version": "1.9.0",
+      "verifier-version": "1.12.2",
       "profile": {
         "vendorType": "community",
-        "version": "v1.1"
+        "version": "v1.2"
       },
-      "reportDigest": "uint64:589776597986644110",
+      "reportDigest": "uint64:7752956879194513465",
       "chart-uri": "https://github.com/openshift-helm-charts/development/blob/main/tests/data/vault-0.17.0.tgz?raw=true",
       "digests": {
-        "chart": "sha256:f01dd362d81fe4b1ef99bb7fa5be268fa94dc96f3009d28bc93a18517aa1ef7a",
-        "package": "9cb7e3a5d82537f512319c754ccd6e9a4be08118b34849609d0fc261934d062a"
+        "chart": "sha256:aba56e4bc68704aa933a180a7a7abb309b73c7020a53020a3f2c17565faf12a3",
+        "package": "72f8d48aad2df1fe49e864a33a112793d2c8a67874d62a466d94bbe4e5f54fee"
       },
-      "lastCertifiedTimestamp": "2022-10-10T12:53:48.691795+05:30",
-      "testedOpenShiftVersion": "4.11",
+      "lastCertifiedTimestamp": "2023-07-26T14:49:22.48006-05:00",
+      "testedOpenShiftVersion": "4.12",
       "supportedOpenShiftVersions": ">=4.2",
-      "providerControlledDelivery": false
+      "webCatalogOnly": false
     },
     "chart": {
       "name": "vault",
@@ -51,52 +51,10 @@
   },
   "results": [
     {
-      "check": "v1.0/not-contain-csi-objects",
-      "type": "Optional",
-      "outcome": "PASS",
-      "reason": "CSI objects do not exist"
-    },
-    {
-      "check": "v1.0/required-annotations-present",
-      "type": "Optional",
-      "outcome": "PASS",
-      "reason": "All required annotations present"
-    },
-    {
-      "check": "v1.0/contains-test",
-      "type": "Optional",
-      "outcome": "PASS",
-      "reason": "Chart test files exist"
-    },
-    {
       "check": "v1.0/contains-values",
       "type": "Optional",
       "outcome": "PASS",
       "reason": "Values file exist"
-    },
-    {
-      "check": "v1.0/not-contains-crds",
-      "type": "Optional",
-      "outcome": "PASS",
-      "reason": "Chart does not contain CRDs"
-    },
-    {
-      "check": "v1.0/contains-values-schema",
-      "type": "Optional",
-      "outcome": "PASS",
-      "reason": "Values schema file exist"
-    },
-    {
-      "check": "v1.0/helm-lint",
-      "type": "Mandatory",
-      "outcome": "PASS",
-      "reason": "Helm lint successful"
-    },
-    {
-      "check": "v1.0/chart-testing",
-      "type": "Optional",
-      "outcome": "PASS",
-      "reason": "Chart tests have passed"
     },
     {
       "check": "v1.1/has-kubeversion",
@@ -105,16 +63,64 @@
       "reason": "Kubernetes version specified"
     },
     {
+      "check": "v1.0/contains-values-schema",
+      "type": "Optional",
+      "outcome": "PASS",
+      "reason": "Values schema file exist"
+    },
+    {
       "check": "v1.0/has-readme",
       "type": "Optional",
       "outcome": "PASS",
       "reason": "Chart has a README"
     },
     {
-      "check": "v1.0/images-are-certified",
+      "check": "v1.0/helm-lint",
+      "type": "Mandatory",
+      "outcome": "PASS",
+      "reason": "Helm lint successful"
+    },
+    {
+      "check": "v1.1/images-are-certified",
       "type": "Optional",
       "outcome": "PASS",
       "reason": "Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault-k8s:0.14.0-ubi\nImage is Red Hat certified : registry.connect.redhat.com/hashicorp/vault:1.8.4-ubi"
+    },
+    {
+      "check": "v1.0/not-contain-csi-objects",
+      "type": "Optional",
+      "outcome": "PASS",
+      "reason": "CSI objects do not exist"
+    },
+    {
+      "check": "v1.0/contains-test",
+      "type": "Optional",
+      "outcome": "PASS",
+      "reason": "Chart test files exist"
+    },
+    {
+      "check": "v1.0/not-contains-crds",
+      "type": "Optional",
+      "outcome": "PASS",
+      "reason": "Chart does not contain CRDs"
+    },
+    {
+      "check": "v1.0/required-annotations-present",
+      "type": "Optional",
+      "outcome": "PASS",
+      "reason": "All required annotations present"
+    },
+    {
+      "check": "v1.0/chart-testing",
+      "type": "Optional",
+      "outcome": "PASS",
+      "reason": "Chart tests have passed"
+    },
+    {
+      "check": "v1.0/signature-is-valid",
+      "type": "Optional",
+      "outcome": "SKIPPED",
+      "reason": "Chart is not signed : Signature verification not required"
     },
     {
       "check": "v1.0/is-helm-v3",

--- a/tests/data/HC-09/partner/report.json
+++ b/tests/data/HC-09/partner/report.json
@@ -3,21 +3,21 @@
   "kind": "verify-report",
   "metadata": {
     "tool": {
-      "verifier-version": "1.9.0",
+      "verifier-version": "1.12.2",
       "profile": {
         "vendorType": "partner",
-        "version": "v1.1"
+        "version": "v1.2"
       },
-      "reportDigest": "uint64:7581213721422938469",
+      "reportDigest": "uint64:12972419698442256528",
       "chart-uri": "https://github.com/openshift-helm-charts/development/blob/main/tests/data/vault-0.17.0.tgz?raw=true",
       "digests": {
-        "chart": "sha256:f01dd362d81fe4b1ef99bb7fa5be268fa94dc96f3009d28bc93a18517aa1ef7a",
-        "package": "9cb7e3a5d82537f512319c754ccd6e9a4be08118b34849609d0fc261934d062a"
+        "chart": "sha256:aba56e4bc68704aa933a180a7a7abb309b73c7020a53020a3f2c17565faf12a3",
+        "package": "72f8d48aad2df1fe49e864a33a112793d2c8a67874d62a466d94bbe4e5f54fee"
       },
-      "lastCertifiedTimestamp": "2022-10-10T12:45:13.619288+05:30",
-      "testedOpenShiftVersion": "4.11",
+      "lastCertifiedTimestamp": "2023-07-26T14:37:04.138359-05:00",
+      "testedOpenShiftVersion": "4.12",
       "supportedOpenShiftVersions": ">=4.2",
-      "providerControlledDelivery": false
+      "webCatalogOnly": false
     },
     "chart": {
       "name": "vault",
@@ -51,34 +51,10 @@
   },
   "results": [
     {
-      "check": "v1.0/has-readme",
-      "type": "Mandatory",
-      "outcome": "PASS",
-      "reason": "Chart has a README"
-    },
-    {
-      "check": "v1.0/images-are-certified",
-      "type": "Mandatory",
-      "outcome": "PASS",
-      "reason": "Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault-k8s:0.14.0-ubi\nImage is Red Hat certified : registry.connect.redhat.com/hashicorp/vault:1.8.4-ubi"
-    },
-    {
-      "check": "v1.0/contains-values",
-      "type": "Mandatory",
-      "outcome": "PASS",
-      "reason": "Values file exist"
-    },
-    {
       "check": "v1.0/not-contain-csi-objects",
       "type": "Mandatory",
       "outcome": "PASS",
       "reason": "CSI objects do not exist"
-    },
-    {
-      "check": "v1.0/not-contains-crds",
-      "type": "Mandatory",
-      "outcome": "PASS",
-      "reason": "Chart does not contain CRDs"
     },
     {
       "check": "v1.0/chart-testing",
@@ -99,16 +75,40 @@
       "reason": "Kubernetes version specified"
     },
     {
-      "check": "v1.0/contains-values-schema",
+      "check": "v1.1/images-are-certified",
       "type": "Mandatory",
       "outcome": "PASS",
-      "reason": "Values schema file exist"
+      "reason": "Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault-k8s:0.14.0-ubi\nImage is Red Hat certified : registry.connect.redhat.com/hashicorp/vault:1.8.4-ubi"
     },
     {
       "check": "v1.0/required-annotations-present",
       "type": "Mandatory",
       "outcome": "PASS",
       "reason": "All required annotations present"
+    },
+    {
+      "check": "v1.0/contains-values",
+      "type": "Mandatory",
+      "outcome": "PASS",
+      "reason": "Values file exist"
+    },
+    {
+      "check": "v1.0/has-readme",
+      "type": "Mandatory",
+      "outcome": "PASS",
+      "reason": "Chart has a README"
+    },
+    {
+      "check": "v1.0/not-contains-crds",
+      "type": "Mandatory",
+      "outcome": "PASS",
+      "reason": "Chart does not contain CRDs"
+    },
+    {
+      "check": "v1.0/signature-is-valid",
+      "type": "Mandatory",
+      "outcome": "SKIPPED",
+      "reason": "Chart is not signed : Signature verification not required"
     },
     {
       "check": "v1.0/helm-lint",
@@ -121,6 +121,12 @@
       "type": "Mandatory",
       "outcome": "PASS",
       "reason": "API version is V2, used in Helm 3"
+    },
+    {
+      "check": "v1.0/contains-values-schema",
+      "type": "Mandatory",
+      "outcome": "PASS",
+      "reason": "Values schema file exist"
     }
   ]
 }

--- a/tests/data/HC-09/redhat/report.json
+++ b/tests/data/HC-09/redhat/report.json
@@ -3,21 +3,21 @@
   "kind": "verify-report",
   "metadata": {
     "tool": {
-      "verifier-version": "1.9.0",
+      "verifier-version": "1.12.2",
       "profile": {
         "vendorType": "redhat",
-        "version": "v1.1"
+        "version": "v1.2"
       },
-      "reportDigest": "uint64:2143053838337354791",
+      "reportDigest": "uint64:2833960720574391467",
       "chart-uri": "https://github.com/openshift-helm-charts/development/blob/main/tests/data/vault-0.17.0.tgz?raw=true",
       "digests": {
-        "chart": "sha256:f01dd362d81fe4b1ef99bb7fa5be268fa94dc96f3009d28bc93a18517aa1ef7a",
-        "package": "9cb7e3a5d82537f512319c754ccd6e9a4be08118b34849609d0fc261934d062a"
+        "chart": "sha256:aba56e4bc68704aa933a180a7a7abb309b73c7020a53020a3f2c17565faf12a3",
+        "package": "72f8d48aad2df1fe49e864a33a112793d2c8a67874d62a466d94bbe4e5f54fee"
       },
-      "lastCertifiedTimestamp": "2022-10-10T12:50:52.638518+05:30",
-      "testedOpenShiftVersion": "4.11",
+      "lastCertifiedTimestamp": "2023-07-26T14:47:28.562444-05:00",
+      "testedOpenShiftVersion": "4.12",
       "supportedOpenShiftVersions": ">=4.2",
-      "providerControlledDelivery": false
+      "webCatalogOnly": false
     },
     "chart": {
       "name": "vault",
@@ -51,34 +51,10 @@
   },
   "results": [
     {
-      "check": "v1.0/contains-test",
-      "type": "Mandatory",
-      "outcome": "PASS",
-      "reason": "Chart test files exist"
-    },
-    {
-      "check": "v1.0/helm-lint",
-      "type": "Mandatory",
-      "outcome": "PASS",
-      "reason": "Helm lint successful"
-    },
-    {
       "check": "v1.0/is-helm-v3",
       "type": "Mandatory",
       "outcome": "PASS",
       "reason": "API version is V2, used in Helm 3"
-    },
-    {
-      "check": "v1.0/required-annotations-present",
-      "type": "Mandatory",
-      "outcome": "PASS",
-      "reason": "All required annotations present"
-    },
-    {
-      "check": "v1.1/has-kubeversion",
-      "type": "Mandatory",
-      "outcome": "PASS",
-      "reason": "Kubernetes version specified"
     },
     {
       "check": "v1.0/not-contain-csi-objects",
@@ -87,16 +63,10 @@
       "reason": "CSI objects do not exist"
     },
     {
-      "check": "v1.0/chart-testing",
+      "check": "v1.0/contains-test",
       "type": "Mandatory",
       "outcome": "PASS",
-      "reason": "Chart tests have passed"
-    },
-    {
-      "check": "v1.0/contains-values-schema",
-      "type": "Mandatory",
-      "outcome": "PASS",
-      "reason": "Values schema file exist"
+      "reason": "Chart test files exist"
     },
     {
       "check": "v1.0/has-readme",
@@ -105,10 +75,10 @@
       "reason": "Chart has a README"
     },
     {
-      "check": "v1.0/images-are-certified",
+      "check": "v1.0/helm-lint",
       "type": "Mandatory",
       "outcome": "PASS",
-      "reason": "Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault-k8s:0.14.0-ubi\nImage is Red Hat certified : registry.connect.redhat.com/hashicorp/vault:1.8.4-ubi"
+      "reason": "Helm lint successful"
     },
     {
       "check": "v1.0/not-contains-crds",
@@ -117,10 +87,46 @@
       "reason": "Chart does not contain CRDs"
     },
     {
+      "check": "v1.0/signature-is-valid",
+      "type": "Mandatory",
+      "outcome": "SKIPPED",
+      "reason": "Chart is not signed : Signature verification not required"
+    },
+    {
+      "check": "v1.0/required-annotations-present",
+      "type": "Mandatory",
+      "outcome": "PASS",
+      "reason": "All required annotations present"
+    },
+    {
+      "check": "v1.0/chart-testing",
+      "type": "Mandatory",
+      "outcome": "PASS",
+      "reason": "Chart tests have passed"
+    },
+    {
+      "check": "v1.1/images-are-certified",
+      "type": "Mandatory",
+      "outcome": "PASS",
+      "reason": "Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault:1.8.4-ubi\nImage is Red Hat certified : registry.connect.redhat.com/hashicorp/vault-k8s:0.14.0-ubi"
+    },
+    {
+      "check": "v1.0/contains-values-schema",
+      "type": "Mandatory",
+      "outcome": "PASS",
+      "reason": "Values schema file exist"
+    },
+    {
       "check": "v1.0/contains-values",
       "type": "Mandatory",
       "outcome": "PASS",
       "reason": "Values file exist"
+    },
+    {
+      "check": "v1.1/has-kubeversion",
+      "type": "Mandatory",
+      "outcome": "PASS",
+      "reason": "Kubernetes version specified"
     }
   ]
 }

--- a/tests/data/HC-10/signed_chart/report/partner/report.yaml
+++ b/tests/data/HC-10/signed_chart/report/partner/report.yaml
@@ -2,20 +2,20 @@ apiversion: v1
 kind: verify-report
 metadata:
     tool:
-        verifier-version: 1.9.0
+        verifier-version: 1.12.2
         profile:
             VendorType: partner
             version: v1.2
-        reportDigest: uint64:5138098052618695524
+        reportDigest: uint64:11059064537300626010
         chart-uri: https://github.com/openshift-helm-charts/development/blob/main/tests/data/HC-10/signed_chart/vault-0.17.0.tgz?raw=true
         digests:
-            chart: sha256:f01dd362d81fe4b1ef99bb7fa5be268fa94dc96f3009d28bc93a18517aa1ef7a
-            package: df206272be1282a05af0576a054c9b35a8d2cebb836dc990d8b87dced82dcdb9
-            publicKey: 662ba24b23e80f0b26a634f3c215e74d973943e32d0ee85868759365a5640995
-        lastCertifiedTimestamp: "2023-01-17T14:39:57.760254+05:30"
-        testedOpenShiftVersion: "4.11"
+            chart: sha256:aba56e4bc68704aa933a180a7a7abb309b73c7020a53020a3f2c17565faf12a3
+            package: afcd1a19f5801a17a370925a1743f29a5bb853d05b513e716dc4d7798cb95f10
+            publicKey: 0bcbdc417456c2c6489abda4d6c8098223ea36469be3d75feeb2c595db62719d
+        lastCertifiedTimestamp: "2023-07-26T16:30:32.604568-05:00"
+        testedOpenShiftVersion: "4.12"
         supportedOpenShiftVersions: '>=4.2'
-        providerControlledDelivery: false
+        webCatalogOnly: false
     chart:
         name: vault
         home: https://www.vaultproject.io
@@ -48,58 +48,58 @@ metadata:
         type: ""
     chart-overrides: ""
 results:
-    - check: v1.0/contains-test
-      type: Mandatory
-      outcome: PASS
-      reason: Chart test files exist
-    - check: v1.0/helm-lint
-      type: Mandatory
-      outcome: PASS
-      reason: Helm lint successful
-    - check: v1.0/not-contains-crds
-      type: Mandatory
-      outcome: PASS
-      reason: Chart does not contain CRDs
-    - check: v1.0/contains-values
-      type: Mandatory
-      outcome: PASS
-      reason: Values file exist
-    - check: v1.0/not-contain-csi-objects
-      type: Mandatory
-      outcome: PASS
-      reason: CSI objects do not exist
-    - check: v1.0/required-annotations-present
-      type: Mandatory
-      outcome: PASS
-      reason: All required annotations present
-    - check: v1.0/chart-testing
-      type: Mandatory
-      outcome: PASS
-      reason: Chart tests have passed
-    - check: v1.1/has-kubeversion
-      type: Mandatory
-      outcome: PASS
-      reason: Kubernetes version specified
-    - check: v1.0/signature-is-valid
-      type: Mandatory
-      outcome: PASS
-      reason: 'Chart is signed : Signature verification passed'
-    - check: v1.0/contains-values-schema
-      type: Mandatory
-      outcome: PASS
-      reason: Values schema file exist
     - check: v1.0/has-readme
       type: Mandatory
       outcome: PASS
       reason: Chart has a README
+    - check: v1.0/helm-lint
+      type: Mandatory
+      outcome: PASS
+      reason: Helm lint successful
+    - check: v1.0/not-contain-csi-objects
+      type: Mandatory
+      outcome: PASS
+      reason: CSI objects do not exist
+    - check: v1.0/is-helm-v3
+      type: Mandatory
+      outcome: PASS
+      reason: API version is V2, used in Helm 3
+    - check: v1.0/not-contains-crds
+      type: Mandatory
+      outcome: PASS
+      reason: Chart does not contain CRDs
+    - check: v1.0/required-annotations-present
+      type: Mandatory
+      outcome: PASS
+      reason: All required annotations present
+    - check: v1.0/signature-is-valid
+      type: Mandatory
+      outcome: PASS
+      reason: 'Chart is signed : Signature verification passed'
+    - check: v1.1/has-kubeversion
+      type: Mandatory
+      outcome: PASS
+      reason: Kubernetes version specified
+    - check: v1.0/contains-test
+      type: Mandatory
+      outcome: PASS
+      reason: Chart test files exist
+    - check: v1.0/contains-values-schema
+      type: Mandatory
+      outcome: PASS
+      reason: Values schema file exist
+    - check: v1.0/contains-values
+      type: Mandatory
+      outcome: PASS
+      reason: Values file exist
     - check: v1.1/images-are-certified
       type: Mandatory
       outcome: PASS
       reason: |-
         Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault-k8s:0.14.0-ubi
         Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault:1.8.4-ubi
-    - check: v1.0/is-helm-v3
+    - check: v1.0/chart-testing
       type: Mandatory
       outcome: PASS
-      reason: API version is V2, used in Helm 3
+      reason: Chart tests have passed
 

--- a/tests/data/HC-10/signed_chart/report/redhat/report.yaml
+++ b/tests/data/HC-10/signed_chart/report/redhat/report.yaml
@@ -2,20 +2,20 @@ apiversion: v1
 kind: verify-report
 metadata:
     tool:
-        verifier-version: 1.9.0
+        verifier-version: 1.12.2
         profile:
             VendorType: redhat
             version: v1.2
-        reportDigest: uint64:18038370130181201778
+        reportDigest: uint64:5503902640131384354
         chart-uri: https://github.com/openshift-helm-charts/development/blob/main/tests/data/HC-10/signed_chart/vault-0.17.0.tgz?raw=true
         digests:
-            chart: sha256:f01dd362d81fe4b1ef99bb7fa5be268fa94dc96f3009d28bc93a18517aa1ef7a
-            package: df206272be1282a05af0576a054c9b35a8d2cebb836dc990d8b87dced82dcdb9
-            publicKey: 662ba24b23e80f0b26a634f3c215e74d973943e32d0ee85868759365a5640995
-        lastCertifiedTimestamp: "2023-01-17T14:49:46.03165+05:30"
-        testedOpenShiftVersion: "4.11"
+            chart: sha256:aba56e4bc68704aa933a180a7a7abb309b73c7020a53020a3f2c17565faf12a3
+            package: afcd1a19f5801a17a370925a1743f29a5bb853d05b513e716dc4d7798cb95f10
+            publicKey: 0bcbdc417456c2c6489abda4d6c8098223ea36469be3d75feeb2c595db62719d
+        lastCertifiedTimestamp: "2023-07-26T16:31:21.387752-05:00"
+        testedOpenShiftVersion: "4.12"
         supportedOpenShiftVersions: '>=4.2'
-        providerControlledDelivery: false
+        webCatalogOnly: false
     chart:
         name: vault
         home: https://www.vaultproject.io
@@ -48,44 +48,44 @@ metadata:
         type: ""
     chart-overrides: ""
 results:
-    - check: v1.0/is-helm-v3
+    - check: v1.0/contains-test
       type: Mandatory
       outcome: PASS
-      reason: API version is V2, used in Helm 3
-    - check: v1.0/not-contain-csi-objects
-      type: Mandatory
-      outcome: PASS
-      reason: CSI objects do not exist
-    - check: v1.0/has-readme
-      type: Mandatory
-      outcome: PASS
-      reason: Chart has a README
+      reason: Chart test files exist
     - check: v1.1/images-are-certified
       type: Mandatory
       outcome: PASS
       reason: |-
         Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault-k8s:0.14.0-ubi
         Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault:1.8.4-ubi
-    - check: v1.0/not-contains-crds
+    - check: v1.0/is-helm-v3
       type: Mandatory
       outcome: PASS
-      reason: Chart does not contain CRDs
-    - check: v1.0/required-annotations-present
-      type: Mandatory
-      outcome: PASS
-      reason: All required annotations present
+      reason: API version is V2, used in Helm 3
     - check: v1.0/chart-testing
       type: Mandatory
       outcome: PASS
       reason: Chart tests have passed
+    - check: v1.0/required-annotations-present
+      type: Mandatory
+      outcome: PASS
+      reason: All required annotations present
+    - check: v1.0/has-readme
+      type: Mandatory
+      outcome: PASS
+      reason: Chart has a README
+    - check: v1.0/not-contain-csi-objects
+      type: Mandatory
+      outcome: PASS
+      reason: CSI objects do not exist
+    - check: v1.0/not-contains-crds
+      type: Mandatory
+      outcome: PASS
+      reason: Chart does not contain CRDs
     - check: v1.0/contains-values-schema
       type: Mandatory
       outcome: PASS
       reason: Values schema file exist
-    - check: v1.0/contains-test
-      type: Mandatory
-      outcome: PASS
-      reason: Chart test files exist
     - check: v1.1/has-kubeversion
       type: Mandatory
       outcome: PASS

--- a/tests/data/HC-11/community/report.yaml
+++ b/tests/data/HC-11/community/report.yaml
@@ -2,19 +2,19 @@ apiversion: v1
 kind: verify-report
 metadata:
     tool:
-        verifier-version: 1.9.0
+        verifier-version: 1.12.2
         profile:
             VendorType: community
-            version: v1.1
-        reportDigest: uint64:6188835510583069887
+            version: v1.2
+        reportDigest: uint64:10214964780218666338
         chart-uri: https://github.com/openshift-helm-charts/development/blob/main/tests/data/vault-0.17.0.tgz?raw=true
         digests:
-            chart: sha256:f01dd362d81fe4b1ef99bb7fa5be268fa94dc96f3009d28bc93a18517aa1ef7a
-            package: 9cb7e3a5d82537f512319c754ccd6e9a4be08118b34849609d0fc261934d062a
-        lastCertifiedTimestamp: "2022-10-10T15:07:06.610015+05:30"
-        testedOpenShiftVersion: "4.11"
+            chart: sha256:aba56e4bc68704aa933a180a7a7abb309b73c7020a53020a3f2c17565faf12a3
+            package: 72f8d48aad2df1fe49e864a33a112793d2c8a67874d62a466d94bbe4e5f54fee
+        lastCertifiedTimestamp: "2023-07-26T14:52:59.770083-05:00"
+        testedOpenShiftVersion: "4.12"
         supportedOpenShiftVersions: '>=4.2'
-        providerControlledDelivery: false
+        webCatalogOnly: false
     chart:
         name: vault
         home: https://www.vaultproject.io
@@ -47,50 +47,54 @@ metadata:
         type: ""
     chart-overrides: ""
 results:
-    - check: v1.0/is-helm-v3
-      type: Optional
-      outcome: PASS
-      reason: API version is V2, used in Helm 3
-    - check: v1.0/not-contains-crds
-      type: Optional
-      outcome: PASS
-      reason: Chart does not contain CRDs
-    - check: v1.0/contains-test
-      type: Optional
-      outcome: PASS
-      reason: Chart test files exist
-    - check: v1.0/not-contain-csi-objects
-      type: Optional
-      outcome: PASS
-      reason: CSI objects do not exist
     - check: v1.1/has-kubeversion
       type: Optional
       outcome: PASS
       reason: Kubernetes version specified
+    - check: v1.1/images-are-certified
+      type: Optional
+      outcome: PASS
+      reason: |-
+        Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault-k8s:0.14.0-ubi
+        Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault:1.8.4-ubi
+    - check: v1.0/is-helm-v3
+      type: Optional
+      outcome: PASS
+      reason: API version is V2, used in Helm 3
+    - check: v1.0/not-contain-csi-objects
+      type: Optional
+      outcome: PASS
+      reason: CSI objects do not exist
+    - check: v1.0/not-contains-crds
+      type: Optional
+      outcome: PASS
+      reason: Chart does not contain CRDs
     - check: v1.0/required-annotations-present
       type: Optional
       outcome: PASS
       reason: All required annotations present
-    - check: v1.0/contains-values-schema
-      type: Optional
-      outcome: PASS
-      reason: Values schema file exist
-    - check: v1.0/contains-values
-      type: Optional
-      outcome: PASS
-      reason: Values file exist
-    - check: v1.0/images-are-certified
-      type: Optional
-      outcome: PASS
-      reason: |-
-        Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault:1.8.4-ubi
-        Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault-k8s:0.14.0-ubi
     - check: v1.0/chart-testing
       type: Optional
       outcome: PASS
       reason: Chart tests have passed
+    - check: v1.0/contains-values
+      type: Optional
+      outcome: PASS
+      reason: Values file exist
+    - check: v1.0/contains-values-schema
+      type: Optional
+      outcome: PASS
+      reason: Values schema file exist
+    - check: v1.0/signature-is-valid
+      type: Optional
+      outcome: SKIPPED
+      reason: 'Chart is not signed : Signature verification not required'
     - check: v1.0/has-readme
       type: Optional
       outcome: PASS
       reason: Chart has a README
+    - check: v1.0/contains-test
+      type: Optional
+      outcome: PASS
+      reason: Chart test files exist
 

--- a/tests/data/HC-11/partner/report.yaml
+++ b/tests/data/HC-11/partner/report.yaml
@@ -2,19 +2,19 @@ apiversion: v1
 kind: verify-report
 metadata:
     tool:
-        verifier-version: 1.9.0
+        verifier-version: 1.12.2
         profile:
             VendorType: partner
-            version: v1.1
-        reportDigest: uint64:7728592976812301878
+            version: v1.2
+        reportDigest: uint64:2093766326891469747
         chart-uri: https://github.com/openshift-helm-charts/development/blob/main/tests/data/vault-0.17.0.tgz?raw=true
         digests:
-            chart: sha256:f01dd362d81fe4b1ef99bb7fa5be268fa94dc96f3009d28bc93a18517aa1ef7a
-            package: 9cb7e3a5d82537f512319c754ccd6e9a4be08118b34849609d0fc261934d062a
-        lastCertifiedTimestamp: "2022-10-10T14:51:53.556914+05:30"
-        testedOpenShiftVersion: "4.11"
+            chart: sha256:aba56e4bc68704aa933a180a7a7abb309b73c7020a53020a3f2c17565faf12a3
+            package: 72f8d48aad2df1fe49e864a33a112793d2c8a67874d62a466d94bbe4e5f54fee
+        lastCertifiedTimestamp: "2023-07-26T14:50:38.51101-05:00"
+        testedOpenShiftVersion: "4.12"
         supportedOpenShiftVersions: '>=4.2'
-        providerControlledDelivery: false
+        webCatalogOnly: false
     chart:
         name: vault
         home: https://www.vaultproject.io
@@ -47,50 +47,54 @@ metadata:
         type: ""
     chart-overrides: ""
 results:
-    - check: v1.0/chart-testing
-      type: Mandatory
-      outcome: PASS
-      reason: Chart tests have passed
-    - check: v1.0/contains-test
-      type: Mandatory
-      outcome: PASS
-      reason: Chart test files exist
-    - check: v1.0/contains-values
-      type: Mandatory
-      outcome: PASS
-      reason: Values file exist
-    - check: v1.1/has-kubeversion
-      type: Mandatory
-      outcome: PASS
-      reason: Kubernetes version specified
-    - check: v1.0/has-readme
-      type: Mandatory
-      outcome: PASS
-      reason: Chart has a README
-    - check: v1.0/not-contain-csi-objects
-      type: Mandatory
-      outcome: PASS
-      reason: CSI objects do not exist
     - check: v1.0/contains-values-schema
       type: Mandatory
       outcome: PASS
       reason: Values schema file exist
-    - check: v1.0/images-are-certified
+    - check: v1.1/has-kubeversion
       type: Mandatory
       outcome: PASS
-      reason: |-
-        Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault-k8s:0.14.0-ubi
-        Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault:1.8.4-ubi
-    - check: v1.0/is-helm-v3
+      reason: Kubernetes version specified
+    - check: v1.0/chart-testing
       type: Mandatory
       outcome: PASS
-      reason: API version is V2, used in Helm 3
+      reason: Chart tests have passed
+    - check: v1.0/not-contain-csi-objects
+      type: Mandatory
+      outcome: PASS
+      reason: CSI objects do not exist
     - check: v1.0/required-annotations-present
       type: Mandatory
       outcome: PASS
       reason: All required annotations present
+    - check: v1.0/contains-values
+      type: Mandatory
+      outcome: PASS
+      reason: Values file exist
+    - check: v1.0/contains-test
+      type: Mandatory
+      outcome: PASS
+      reason: Chart test files exist
+    - check: v1.0/has-readme
+      type: Mandatory
+      outcome: PASS
+      reason: Chart has a README
+    - check: v1.1/images-are-certified
+      type: Mandatory
+      outcome: PASS
+      reason: |-
+        Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault:1.8.4-ubi
+        Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault-k8s:0.14.0-ubi
+    - check: v1.0/is-helm-v3
+      type: Mandatory
+      outcome: PASS
+      reason: API version is V2, used in Helm 3
     - check: v1.0/not-contains-crds
       type: Mandatory
       outcome: PASS
       reason: Chart does not contain CRDs
+    - check: v1.0/signature-is-valid
+      type: Mandatory
+      outcome: SKIPPED
+      reason: 'Chart is not signed : Signature verification not required'
 

--- a/tests/data/HC-11/partner_not_contain_crds/report.yaml
+++ b/tests/data/HC-11/partner_not_contain_crds/report.yaml
@@ -2,19 +2,19 @@ apiversion: v1
 kind: verify-report
 metadata:
     tool:
-        verifier-version: 1.9.0
+        verifier-version: 1.12.2
         profile:
             VendorType: partner
-            version: v1.1
-        reportDigest: uint64:11593295899204523336
+            version: v1.2
+        reportDigest: uint64:5951359665935255357
         chart-uri: https://github.com/openshift-helm-charts/development/blob/main/tests/data/vault-0.17.0.tgz?raw=true
         digests:
-            chart: sha256:f01dd362d81fe4b1ef99bb7fa5be268fa94dc96f3009d28bc93a18517aa1ef7a
-            package: 9cb7e3a5d82537f512319c754ccd6e9a4be08118b34849609d0fc261934d062a
-        lastCertifiedTimestamp: "2022-10-10T15:02:15.476386+05:30"
-        testedOpenShiftVersion: "4.11"
+            chart: sha256:aba56e4bc68704aa933a180a7a7abb309b73c7020a53020a3f2c17565faf12a3
+            package: 72f8d48aad2df1fe49e864a33a112793d2c8a67874d62a466d94bbe4e5f54fee
+        lastCertifiedTimestamp: "2023-07-26T14:51:23.074725-05:00"
+        testedOpenShiftVersion: "4.12"
         supportedOpenShiftVersions: '>=4.2'
-        providerControlledDelivery: false
+        webCatalogOnly: false
     chart:
         name: vault
         home: https://www.vaultproject.io
@@ -47,50 +47,54 @@ metadata:
         type: ""
     chart-overrides: ""
 results:
-    - check: v1.0/chart-testing
-      type: Mandatory
-      outcome: PASS
-      reason: Chart tests have passed
     - check: v1.0/helm-lint
       type: Mandatory
       outcome: PASS
       reason: Helm lint successful
-    - check: v1.0/images-are-certified
+    - check: v1.1/images-are-certified
       type: Mandatory
       outcome: PASS
       reason: |-
-        Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault:1.8.4-ubi
         Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault-k8s:0.14.0-ubi
-    - check: v1.0/required-annotations-present
+        Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault:1.8.4-ubi
+    - check: v1.0/signature-is-valid
       type: Mandatory
-      outcome: PASS
-      reason: All required annotations present
-    - check: v1.0/not-contain-csi-objects
-      type: Mandatory
-      outcome: PASS
-      reason: CSI objects do not exist
-    - check: v1.0/contains-values-schema
-      type: Mandatory
-      outcome: PASS
-      reason: Values schema file exist
-    - check: v1.0/contains-test
-      type: Mandatory
-      outcome: PASS
-      reason: Chart test files exist
-    - check: v1.0/contains-values
-      type: Mandatory
-      outcome: PASS
-      reason: Values file exist
-    - check: v1.1/has-kubeversion
-      type: Mandatory
-      outcome: PASS
-      reason: Kubernetes version specified
-    - check: v1.0/has-readme
-      type: Mandatory
-      outcome: PASS
-      reason: Chart has a README
+      outcome: SKIPPED
+      reason: 'Chart is not signed : Signature verification not required'
     - check: v1.0/is-helm-v3
       type: Mandatory
       outcome: PASS
       reason: API version is V2, used in Helm 3
+    - check: v1.0/required-annotations-present
+      type: Mandatory
+      outcome: PASS
+      reason: All required annotations present
+    - check: v1.0/contains-values-schema
+      type: Mandatory
+      outcome: PASS
+      reason: Values schema file exist
+    - check: v1.1/has-kubeversion
+      type: Mandatory
+      outcome: PASS
+      reason: Kubernetes version specified
+    - check: v1.0/contains-values
+      type: Mandatory
+      outcome: PASS
+      reason: Values file exist
+    - check: v1.0/not-contain-csi-objects
+      type: Mandatory
+      outcome: PASS
+      reason: CSI objects do not exist
+    - check: v1.0/chart-testing
+      type: Mandatory
+      outcome: PASS
+      reason: Chart tests have passed
+    - check: v1.0/has-readme
+      type: Mandatory
+      outcome: PASS
+      reason: Chart has a README
+    - check: v1.0/contains-test
+      type: Mandatory
+      outcome: PASS
+      reason: Chart test files exist
 

--- a/tests/data/HC-18/community/report.yaml
+++ b/tests/data/HC-18/community/report.yaml
@@ -2,19 +2,19 @@ apiversion: v1
 kind: verify-report
 metadata:
     tool:
-        verifier-version: 1.9.0
+        verifier-version: 1.12.2
         profile:
             VendorType: community
-            version: v1.1
-        reportDigest: uint64:17697596350982566196
+            version: v1.2
+        reportDigest: uint64:6449768437428808615
         chart-uri: https://github.com/openshift-helm-charts/development/blob/main/tests/data/vault-0.18.0.tgz?raw=true
         digests:
-            chart: sha256:e976630aa2d8a6aed25284b627b0e9255a942e1aec456657357f9e6e81ec13da
-            package: 840f81ece382ad64a0e9b6e07b799931c030eb60985c20bab2ea57311b84c08b
-        lastCertifiedTimestamp: "2022-10-11T19:23:54.029529+05:30"
-        testedOpenShiftVersion: "4.11"
+            chart: sha256:c9663a0f5efe22bfb89d10cdd282959c8d880a3cef8a6301fca2ccf150dd703d
+            package: c82f8931f67747d1bf3909680523362bcef471d840be12fe9a1f7aa43e39c07b
+        lastCertifiedTimestamp: "2023-07-26T14:55:59.706521-05:00"
+        testedOpenShiftVersion: "4.12"
         supportedOpenShiftVersions: '>=4.2'
-        providerControlledDelivery: false
+        webCatalogOnly: false
     chart:
         name: vault
         home: https://www.vaultproject.io
@@ -47,26 +47,40 @@ metadata:
         type: ""
     chart-overrides: ""
 results:
+    - check: v1.0/signature-is-valid
+      type: Optional
+      outcome: SKIPPED
+      reason: 'Chart is not signed : Signature verification not required'
     - check: v1.0/contains-values-schema
       type: Optional
       outcome: PASS
       reason: Values schema file exist
-    - check: v1.0/helm-lint
-      type: Mandatory
+    - check: v1.1/images-are-certified
+      type: Optional
       outcome: PASS
-      reason: Helm lint successful
+      reason: |-
+        Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault-k8s:0.14.1-ubi
+        Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault:1.9.0-ubi
     - check: v1.0/is-helm-v3
       type: Optional
       outcome: PASS
       reason: API version is V2, used in Helm 3
-    - check: v1.0/not-contains-crds
+    - check: v1.0/chart-testing
       type: Optional
       outcome: PASS
-      reason: Chart does not contain CRDs
+      reason: Chart tests have passed
+    - check: v1.0/has-readme
+      type: Optional
+      outcome: PASS
+      reason: Chart has a README
     - check: v1.0/required-annotations-present
       type: Optional
       outcome: PASS
       reason: All required annotations present
+    - check: v1.0/contains-test
+      type: Optional
+      outcome: PASS
+      reason: Chart test files exist
     - check: v1.0/contains-values
       type: Optional
       outcome: PASS
@@ -75,26 +89,16 @@ results:
       type: Optional
       outcome: PASS
       reason: Kubernetes version specified
-    - check: v1.0/chart-testing
-      type: Optional
+    - check: v1.0/helm-lint
+      type: Mandatory
       outcome: PASS
-      reason: Chart tests have passed
-    - check: v1.0/contains-test
-      type: Optional
-      outcome: PASS
-      reason: Chart test files exist
-    - check: v1.0/has-readme
-      type: Optional
-      outcome: PASS
-      reason: Chart has a README
-    - check: v1.0/images-are-certified
-      type: Optional
-      outcome: PASS
-      reason: |-
-        Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault-k8s:0.14.1-ubi
-        Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault:1.9.0-ubi
+      reason: Helm lint successful
     - check: v1.0/not-contain-csi-objects
       type: Optional
       outcome: PASS
       reason: CSI objects do not exist
+    - check: v1.0/not-contains-crds
+      type: Optional
+      outcome: PASS
+      reason: Chart does not contain CRDs
 

--- a/tests/data/HC-18/partner/report.yaml
+++ b/tests/data/HC-18/partner/report.yaml
@@ -2,19 +2,19 @@ apiversion: v1
 kind: verify-report
 metadata:
     tool:
-        verifier-version: 1.9.0
+        verifier-version: 1.12.2
         profile:
             VendorType: partner
-            version: v1.1
-        reportDigest: uint64:7580685454878718317
+            version: v1.2
+        reportDigest: uint64:18424692730570792782
         chart-uri: https://github.com/openshift-helm-charts/development/blob/main/tests/data/vault-0.18.0.tgz?raw=true
         digests:
-            chart: sha256:e976630aa2d8a6aed25284b627b0e9255a942e1aec456657357f9e6e81ec13da
-            package: 840f81ece382ad64a0e9b6e07b799931c030eb60985c20bab2ea57311b84c08b
-        lastCertifiedTimestamp: "2022-10-11T19:17:07.929076+05:30"
-        testedOpenShiftVersion: "4.11"
+            chart: sha256:c9663a0f5efe22bfb89d10cdd282959c8d880a3cef8a6301fca2ccf150dd703d
+            package: c82f8931f67747d1bf3909680523362bcef471d840be12fe9a1f7aa43e39c07b
+        lastCertifiedTimestamp: "2023-07-26T14:54:41.057968-05:00"
+        testedOpenShiftVersion: "4.12"
         supportedOpenShiftVersions: '>=4.2'
-        providerControlledDelivery: false
+        webCatalogOnly: false
     chart:
         name: vault
         home: https://www.vaultproject.io
@@ -47,32 +47,6 @@ metadata:
         type: ""
     chart-overrides: ""
 results:
-    - check: v1.0/contains-values-schema
-      type: Mandatory
-      outcome: PASS
-      reason: Values schema file exist
-    - check: v1.0/contains-values
-      type: Mandatory
-      outcome: PASS
-      reason: Values file exist
-    - check: v1.0/has-readme
-      type: Mandatory
-      outcome: PASS
-      reason: Chart has a README
-    - check: v1.0/images-are-certified
-      type: Mandatory
-      outcome: PASS
-      reason: |-
-        Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault-k8s:0.14.1-ubi
-        Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault:1.9.0-ubi
-    - check: v1.0/not-contain-csi-objects
-      type: Mandatory
-      outcome: PASS
-      reason: CSI objects do not exist
-    - check: v1.0/not-contains-crds
-      type: Mandatory
-      outcome: PASS
-      reason: Chart does not contain CRDs
     - check: v1.0/contains-test
       type: Mandatory
       outcome: PASS
@@ -81,18 +55,48 @@ results:
       type: Mandatory
       outcome: PASS
       reason: API version is V2, used in Helm 3
-    - check: v1.0/required-annotations-present
+    - check: v1.0/not-contains-crds
       type: Mandatory
       outcome: PASS
-      reason: All required annotations present
+      reason: Chart does not contain CRDs
+    - check: v1.0/not-contain-csi-objects
+      type: Mandatory
+      outcome: PASS
+      reason: CSI objects do not exist
+    - check: v1.0/contains-values-schema
+      type: Mandatory
+      outcome: PASS
+      reason: Values schema file exist
+    - check: v1.0/contains-values
+      type: Mandatory
+      outcome: PASS
+      reason: Values file exist
     - check: v1.1/has-kubeversion
       type: Mandatory
       outcome: PASS
       reason: Kubernetes version specified
+    - check: v1.0/has-readme
+      type: Mandatory
+      outcome: PASS
+      reason: Chart has a README
+    - check: v1.0/required-annotations-present
+      type: Mandatory
+      outcome: PASS
+      reason: All required annotations present
+    - check: v1.0/signature-is-valid
+      type: Mandatory
+      outcome: SKIPPED
+      reason: 'Chart is not signed : Signature verification not required'
     - check: v1.0/helm-lint
       type: Mandatory
       outcome: PASS
       reason: Helm lint successful
+    - check: v1.1/images-are-certified
+      type: Mandatory
+      outcome: PASS
+      reason: |-
+        Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault-k8s:0.14.1-ubi
+        Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault:1.9.0-ubi
     - check: v1.0/chart-testing
       type: Mandatory
       outcome: PASS

--- a/tests/data/HC-18/redhat/report.yaml
+++ b/tests/data/HC-18/redhat/report.yaml
@@ -2,19 +2,19 @@ apiversion: v1
 kind: verify-report
 metadata:
     tool:
-        verifier-version: 1.9.0
+        verifier-version: 1.12.2
         profile:
             VendorType: redhat
-            version: v1.1
-        reportDigest: uint64:13622060880342329981
+            version: v1.2
+        reportDigest: uint64:11930215818488035709
         chart-uri: https://github.com/openshift-helm-charts/development/blob/main/tests/data/vault-0.18.0.tgz?raw=true
         digests:
-            chart: sha256:e976630aa2d8a6aed25284b627b0e9255a942e1aec456657357f9e6e81ec13da
-            package: 840f81ece382ad64a0e9b6e07b799931c030eb60985c20bab2ea57311b84c08b
-        lastCertifiedTimestamp: "2022-10-11T19:19:32.612485+05:30"
-        testedOpenShiftVersion: "4.11"
+            chart: sha256:c9663a0f5efe22bfb89d10cdd282959c8d880a3cef8a6301fca2ccf150dd703d
+            package: c82f8931f67747d1bf3909680523362bcef471d840be12fe9a1f7aa43e39c07b
+        lastCertifiedTimestamp: "2023-07-26T14:55:19.243533-05:00"
+        testedOpenShiftVersion: "4.12"
         supportedOpenShiftVersions: '>=4.2'
-        providerControlledDelivery: false
+        webCatalogOnly: false
     chart:
         name: vault
         home: https://www.vaultproject.io
@@ -47,32 +47,32 @@ metadata:
         type: ""
     chart-overrides: ""
 results:
-    - check: v1.0/images-are-certified
+    - check: v1.0/signature-is-valid
+      type: Mandatory
+      outcome: SKIPPED
+      reason: 'Chart is not signed : Signature verification not required'
+    - check: v1.0/helm-lint
+      type: Mandatory
+      outcome: PASS
+      reason: Helm lint successful
+    - check: v1.1/images-are-certified
       type: Mandatory
       outcome: PASS
       reason: |-
         Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault-k8s:0.14.1-ubi
         Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault:1.9.0-ubi
-    - check: v1.0/is-helm-v3
+    - check: v1.0/not-contain-csi-objects
       type: Mandatory
       outcome: PASS
-      reason: API version is V2, used in Helm 3
-    - check: v1.0/contains-test
+      reason: CSI objects do not exist
+    - check: v1.0/chart-testing
       type: Mandatory
       outcome: PASS
-      reason: Chart test files exist
-    - check: v1.0/contains-values-schema
-      type: Mandatory
-      outcome: PASS
-      reason: Values schema file exist
+      reason: Chart tests have passed
     - check: v1.1/has-kubeversion
       type: Mandatory
       outcome: PASS
       reason: Kubernetes version specified
-    - check: v1.0/contains-values
-      type: Mandatory
-      outcome: PASS
-      reason: Values file exist
     - check: v1.0/has-readme
       type: Mandatory
       outcome: PASS
@@ -81,20 +81,24 @@ results:
       type: Mandatory
       outcome: PASS
       reason: All required annotations present
-    - check: v1.0/helm-lint
+    - check: v1.0/contains-values-schema
       type: Mandatory
       outcome: PASS
-      reason: Helm lint successful
-    - check: v1.0/not-contain-csi-objects
-      type: Mandatory
-      outcome: PASS
-      reason: CSI objects do not exist
+      reason: Values schema file exist
     - check: v1.0/not-contains-crds
       type: Mandatory
       outcome: PASS
       reason: Chart does not contain CRDs
-    - check: v1.0/chart-testing
+    - check: v1.0/is-helm-v3
       type: Mandatory
       outcome: PASS
-      reason: Chart tests have passed
+      reason: API version is V2, used in Helm 3
+    - check: v1.0/contains-test
+      type: Mandatory
+      outcome: PASS
+      reason: Chart test files exist
+    - check: v1.0/contains-values
+      type: Mandatory
+      outcome: PASS
+      reason: Values file exist
 

--- a/tests/data/HC-19/report_edited_sha_bad/report.yaml
+++ b/tests/data/HC-19/report_edited_sha_bad/report.yaml
@@ -2,19 +2,19 @@ apiversion: v1
 kind: verify-report
 metadata:
     tool:
-        verifier-version: 1.9.0
-        reportDigest: uint64:17691208852129424495
+        verifier-version: 1.12.2
         profile:
             VendorType: partner
-            version: v1.1
+            version: v1.2
+        reportDigest: uint64:16298400239424284705
         chart-uri: https://github.com/openshift-helm-charts/development/blob/main/tests/data/vault-0.17.0.tgz?raw=true
         digests:
-            chart: sha256:f01dd362d81fe4b1ef99bb7fa5be268fa94dc96f3009d28bc93a18517aa1ef7a
-            package: 9cb7e3a5d82537f512319c754ccd6e9a4be08118b34849609d0fc261934d062a
-        lastCertifiedTimestamp: "2022-06-13T10:43:25.314602-04:00"
+            chart: sha256:aba56e4bc68704aa933a180a7a7abb309b73c7020a53020a3f2c17565faf12a3
+            package: 72f8d48aad2df1fe49e864a33a112793d2c8a67874d62a466d94bbe4e5f54fee
+        lastCertifiedTimestamp: "2023-07-26T14:57:54.024672-05:00"
         testedOpenShiftVersion: "4.11"
-        supportedOpenShiftVersions: '>=4.3'
-        providerControlledDelivery: false
+        supportedOpenShiftVersions: '>=4.2'
+        webCatalogOnly: false
     chart:
         name: vault
         home: https://www.vaultproject.io
@@ -47,24 +47,22 @@ metadata:
         type: ""
     chart-overrides: ""
 results:
+    - check: v1.0/required-annotations-present
+      type: Mandatory
+      outcome: PASS
+      reason: All required annotations present
+    - check: v1.0/not-contain-csi-objects
+      type: Mandatory
+      outcome: PASS
+      reason: CSI objects do not exist
     - check: v1.0/not-contains-crds
       type: Mandatory
       outcome: PASS
       reason: Chart does not contain CRDs
-    - check: v1.0/helm-lint
+    - check: v1.0/contains-test
       type: Mandatory
       outcome: PASS
-      reason: Helm lint successful
-    - check: v1.0/images-are-certified
-      type: Mandatory
-      outcome: PASS
-      reason: |-
-        Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault-k8s:0.14.0-ubi
-        Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault:1.8.4-ubi
-    - check: v1.0/chart-testing
-      type: Mandatory
-      outcome: PASS
-      reason: Chart tests have passed
+      reason: Chart test files exist
     - check: v1.0/has-readme
       type: Mandatory
       outcome: PASS
@@ -73,14 +71,6 @@ results:
       type: Mandatory
       outcome: PASS
       reason: API version is V2, used in Helm 3
-    - check: v1.0/contains-test
-      type: Mandatory
-      outcome: PASS
-      reason: Chart test files exist
-    - check: v1.0/contains-values
-      type: Mandatory
-      outcome: PASS
-      reason: Values file exist
     - check: v1.0/contains-values-schema
       type: Mandatory
       outcome: PASS
@@ -89,12 +79,26 @@ results:
       type: Mandatory
       outcome: PASS
       reason: Kubernetes version specified
-    - check: v1.0/not-contain-csi-objects
+    - check: v1.1/images-are-certified
       type: Mandatory
       outcome: PASS
-      reason: CSI objects do not exist
-    - check: v1.0/required-annotations-present
+      reason: |-
+        Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault-k8s:0.14.0-ubi
+        Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault:1.8.4-ubi
+    - check: v1.0/signature-is-valid
+      type: Mandatory
+      outcome: SKIPPED
+      reason: 'Chart is not signed : Signature verification not required'
+    - check: v1.0/contains-values
       type: Mandatory
       outcome: PASS
-      reason: All required annotations present
+      reason: Values file exist
+    - check: v1.0/helm-lint
+      type: Mandatory
+      outcome: PASS
+      reason: Helm lint successful
+    - check: v1.0/chart-testing
+      type: Mandatory
+      outcome: PASS
+      reason: Chart tests have passed
 

--- a/tests/data/HC-19/report_sha_bad/report.yaml
+++ b/tests/data/HC-19/report_sha_bad/report.yaml
@@ -2,19 +2,19 @@ apiversion: v1
 kind: verify-report
 metadata:
     tool:
-        verifier-version: 1.9.0
-        reportDigest: uint64:934293765184967420
+        verifier-version: 1.12.2
         profile:
             VendorType: partner
-            version: v1.1
+            version: v1.2
+        reportDigest: uint64:16298400239424284704
         chart-uri: https://github.com/openshift-helm-charts/development/blob/main/tests/data/vault-0.17.0.tgz?raw=true
         digests:
-            chart: sha256:f01dd362d81fe4b1ef99bb7fa5be268fa94dc96f3009d28bc93a18517aa1ef7a
-            package: 9cb7e3a5d82537f512319c754ccd6e9a4be08118b34849609d0fc261934d062a
-        lastCertifiedTimestamp: "2022-06-13T10:43:25.314602-04:00"
-        testedOpenShiftVersion: "4.10"
+            chart: sha256:aba56e4bc68704aa933a180a7a7abb309b73c7020a53020a3f2c17565faf12a3
+            package: 72f8d48aad2df1fe49e864a33a112793d2c8a67874d62a466d94bbe4e5f54fee
+        lastCertifiedTimestamp: "2023-07-26T14:57:54.024672-05:00"
+        testedOpenShiftVersion: "4.12"
         supportedOpenShiftVersions: '>=4.2'
-        providerControlledDelivery: false
+        webCatalogOnly: false
     chart:
         name: vault
         home: https://www.vaultproject.io
@@ -47,24 +47,22 @@ metadata:
         type: ""
     chart-overrides: ""
 results:
+    - check: v1.0/required-annotations-present
+      type: Mandatory
+      outcome: PASS
+      reason: All required annotations present
+    - check: v1.0/not-contain-csi-objects
+      type: Mandatory
+      outcome: PASS
+      reason: CSI objects do not exist
     - check: v1.0/not-contains-crds
       type: Mandatory
       outcome: PASS
       reason: Chart does not contain CRDs
-    - check: v1.0/helm-lint
+    - check: v1.0/contains-test
       type: Mandatory
       outcome: PASS
-      reason: Helm lint successful
-    - check: v1.0/images-are-certified
-      type: Mandatory
-      outcome: PASS
-      reason: |-
-        Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault-k8s:0.14.0-ubi
-        Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault:1.8.4-ubi
-    - check: v1.0/chart-testing
-      type: Mandatory
-      outcome: PASS
-      reason: Chart tests have passed
+      reason: Chart test files exist
     - check: v1.0/has-readme
       type: Mandatory
       outcome: PASS
@@ -73,14 +71,6 @@ results:
       type: Mandatory
       outcome: PASS
       reason: API version is V2, used in Helm 3
-    - check: v1.0/contains-test
-      type: Mandatory
-      outcome: PASS
-      reason: Chart test files exist
-    - check: v1.0/contains-values
-      type: Mandatory
-      outcome: PASS
-      reason: Values file exist
     - check: v1.0/contains-values-schema
       type: Mandatory
       outcome: PASS
@@ -89,12 +79,26 @@ results:
       type: Mandatory
       outcome: PASS
       reason: Kubernetes version specified
-    - check: v1.0/not-contain-csi-objects
+    - check: v1.1/images-are-certified
       type: Mandatory
       outcome: PASS
-      reason: CSI objects do not exist
-    - check: v1.0/required-annotations-present
+      reason: |-
+        Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault-k8s:0.14.0-ubi
+        Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault:1.8.4-ubi
+    - check: v1.0/signature-is-valid
+      type: Mandatory
+      outcome: SKIPPED
+      reason: 'Chart is not signed : Signature verification not required'
+    - check: v1.0/contains-values
       type: Mandatory
       outcome: PASS
-      reason: All required annotations present
+      reason: Values file exist
+    - check: v1.0/helm-lint
+      type: Mandatory
+      outcome: PASS
+      reason: Helm lint successful
+    - check: v1.0/chart-testing
+      type: Mandatory
+      outcome: PASS
+      reason: Chart tests have passed
 

--- a/tests/data/HC-19/report_sha_good/report.yaml
+++ b/tests/data/HC-19/report_sha_good/report.yaml
@@ -2,19 +2,19 @@ apiversion: v1
 kind: verify-report
 metadata:
     tool:
-        verifier-version: 1.9.0
-        reportDigest: uint64:4706854001499919657
+        verifier-version: 1.12.2
         profile:
             VendorType: partner
-            version: v1.1
+            version: v1.2
+        reportDigest: uint64:16298400239424284705
         chart-uri: https://github.com/openshift-helm-charts/development/blob/main/tests/data/vault-0.17.0.tgz?raw=true
         digests:
-            chart: sha256:f01dd362d81fe4b1ef99bb7fa5be268fa94dc96f3009d28bc93a18517aa1ef7a
-            package: 9cb7e3a5d82537f512319c754ccd6e9a4be08118b34849609d0fc261934d062a
-        lastCertifiedTimestamp: "2022-06-13T10:43:25.314602-04:00"
-        testedOpenShiftVersion: "4.10"
+            chart: sha256:aba56e4bc68704aa933a180a7a7abb309b73c7020a53020a3f2c17565faf12a3
+            package: 72f8d48aad2df1fe49e864a33a112793d2c8a67874d62a466d94bbe4e5f54fee
+        lastCertifiedTimestamp: "2023-07-26T14:57:54.024672-05:00"
+        testedOpenShiftVersion: "4.12"
         supportedOpenShiftVersions: '>=4.2'
-        providerControlledDelivery: false
+        webCatalogOnly: false
     chart:
         name: vault
         home: https://www.vaultproject.io
@@ -47,24 +47,22 @@ metadata:
         type: ""
     chart-overrides: ""
 results:
+    - check: v1.0/required-annotations-present
+      type: Mandatory
+      outcome: PASS
+      reason: All required annotations present
+    - check: v1.0/not-contain-csi-objects
+      type: Mandatory
+      outcome: PASS
+      reason: CSI objects do not exist
     - check: v1.0/not-contains-crds
       type: Mandatory
       outcome: PASS
       reason: Chart does not contain CRDs
-    - check: v1.0/helm-lint
+    - check: v1.0/contains-test
       type: Mandatory
       outcome: PASS
-      reason: Helm lint successful
-    - check: v1.0/images-are-certified
-      type: Mandatory
-      outcome: PASS
-      reason: |-
-        Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault-k8s:0.14.0-ubi
-        Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault:1.8.4-ubi
-    - check: v1.0/chart-testing
-      type: Mandatory
-      outcome: PASS
-      reason: Chart tests have passed
+      reason: Chart test files exist
     - check: v1.0/has-readme
       type: Mandatory
       outcome: PASS
@@ -73,14 +71,6 @@ results:
       type: Mandatory
       outcome: PASS
       reason: API version is V2, used in Helm 3
-    - check: v1.0/contains-test
-      type: Mandatory
-      outcome: PASS
-      reason: Chart test files exist
-    - check: v1.0/contains-values
-      type: Mandatory
-      outcome: PASS
-      reason: Values file exist
     - check: v1.0/contains-values-schema
       type: Mandatory
       outcome: PASS
@@ -89,12 +79,26 @@ results:
       type: Mandatory
       outcome: PASS
       reason: Kubernetes version specified
-    - check: v1.0/not-contain-csi-objects
+    - check: v1.1/images-are-certified
       type: Mandatory
       outcome: PASS
-      reason: CSI objects do not exist
-    - check: v1.0/required-annotations-present
+      reason: |-
+        Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault-k8s:0.14.0-ubi
+        Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault:1.8.4-ubi
+    - check: v1.0/signature-is-valid
+      type: Mandatory
+      outcome: SKIPPED
+      reason: 'Chart is not signed : Signature verification not required'
+    - check: v1.0/contains-values
       type: Mandatory
       outcome: PASS
-      reason: All required annotations present
+      reason: Values file exist
+    - check: v1.0/helm-lint
+      type: Mandatory
+      outcome: PASS
+      reason: Helm lint successful
+    - check: v1.0/chart-testing
+      type: Mandatory
+      outcome: PASS
+      reason: Chart tests have passed
 

--- a/tests/data/README.md
+++ b/tests/data/README.md
@@ -31,7 +31,7 @@ Copy report.yaml to tests/data/HC-04/community/
 ### HC-06
 
 ```
-chart-verifier verify https://github.com/openshift-helm-charts/development/blob/main/tests/data/vault-0.17.0.tgz?raw=true --provider-delivery > report.yaml
+chart-verifier verify https://github.com/openshift-helm-charts/development/blob/main/tests/data/vault-0.17.0.tgz?raw=true --web-catalog-only > report.yaml
 Copy report.yaml to tests/data/HC-06/partner/
 ```
 

--- a/tests/data/common/community/report.yaml
+++ b/tests/data/common/community/report.yaml
@@ -2,19 +2,19 @@ apiversion: v1
 kind: verify-report
 metadata:
     tool:
-        verifier-version: 1.9.0
+        verifier-version: 1.12.2
         profile:
             VendorType: community
-            version: v1.1
-        reportDigest: uint64:6486223755507931085
+            version: v1.2
+        reportDigest: uint64:8706487021119090591
         chart-uri: https://github.com/openshift-helm-charts/development/blob/main/tests/data/vault-0.17.0.tgz?raw=true
         digests:
-            chart: sha256:f01dd362d81fe4b1ef99bb7fa5be268fa94dc96f3009d28bc93a18517aa1ef7a
-            package: 9cb7e3a5d82537f512319c754ccd6e9a4be08118b34849609d0fc261934d062a
-        lastCertifiedTimestamp: "2022-10-09T18:47:37.831969+05:30"
-        testedOpenShiftVersion: "4.11"
+            chart: sha256:aba56e4bc68704aa933a180a7a7abb309b73c7020a53020a3f2c17565faf12a3
+            package: 72f8d48aad2df1fe49e864a33a112793d2c8a67874d62a466d94bbe4e5f54fee
+        lastCertifiedTimestamp: "2023-07-26T14:34:28.721432-05:00"
+        testedOpenShiftVersion: "4.12"
         supportedOpenShiftVersions: '>=4.2'
-        providerControlledDelivery: false
+        webCatalogOnly: false
     chart:
         name: vault
         home: https://www.vaultproject.io
@@ -47,24 +47,6 @@ metadata:
         type: ""
     chart-overrides: ""
 results:
-    - check: v1.0/helm-lint
-      type: Mandatory
-      outcome: PASS
-      reason: Helm lint successful
-    - check: v1.0/images-are-certified
-      type: Optional
-      outcome: PASS
-      reason: |-
-        Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault-k8s:0.14.0-ubi
-        Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault:1.8.4-ubi
-    - check: v1.0/is-helm-v3
-      type: Optional
-      outcome: PASS
-      reason: API version is V2, used in Helm 3
-    - check: v1.0/has-readme
-      type: Optional
-      outcome: PASS
-      reason: Chart has a README
     - check: v1.0/not-contain-csi-objects
       type: Optional
       outcome: PASS
@@ -73,28 +55,50 @@ results:
       type: Optional
       outcome: PASS
       reason: All required annotations present
-    - check: v1.0/contains-values
-      type: Optional
-      outcome: PASS
-      reason: Values file exist
-    - check: v1.1/has-kubeversion
-      type: Optional
-      outcome: PASS
-      reason: Kubernetes version specified
-    - check: v1.0/not-contains-crds
-      type: Optional
-      outcome: PASS
-      reason: Chart does not contain CRDs
     - check: v1.0/chart-testing
       type: Optional
       outcome: PASS
       reason: Chart tests have passed
-    - check: v1.0/contains-test
-      type: Optional
-      outcome: PASS
-      reason: Chart test files exist
     - check: v1.0/contains-values-schema
       type: Optional
       outcome: PASS
       reason: Values schema file exist
+    - check: v1.1/images-are-certified
+      type: Optional
+      outcome: PASS
+      reason: |-
+        Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault-k8s:0.14.0-ubi
+        Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault:1.8.4-ubi
+    - check: v1.0/helm-lint
+      type: Mandatory
+      outcome: PASS
+      reason: Helm lint successful
+    - check: v1.0/not-contains-crds
+      type: Optional
+      outcome: PASS
+      reason: Chart does not contain CRDs
+    - check: v1.0/signature-is-valid
+      type: Optional
+      outcome: SKIPPED
+      reason: 'Chart is not signed : Signature verification not required'
+    - check: v1.0/contains-values
+      type: Optional
+      outcome: PASS
+      reason: Values file exist
+    - check: v1.0/is-helm-v3
+      type: Optional
+      outcome: PASS
+      reason: API version is V2, used in Helm 3
+    - check: v1.0/contains-test
+      type: Optional
+      outcome: PASS
+      reason: Chart test files exist
+    - check: v1.1/has-kubeversion
+      type: Optional
+      outcome: PASS
+      reason: Kubernetes version specified
+    - check: v1.0/has-readme
+      type: Optional
+      outcome: PASS
+      reason: Chart has a README
 

--- a/tests/data/common/partner/report.yaml
+++ b/tests/data/common/partner/report.yaml
@@ -2,19 +2,19 @@ apiversion: v1
 kind: verify-report
 metadata:
     tool:
-        verifier-version: 1.9.0
+        verifier-version: 1.12.2
         profile:
             VendorType: partner
-            version: v1.1
-        reportDigest: uint64:1709340413986663090
+            version: v1.2
+        reportDigest: uint64:16939048952212352520
         chart-uri: https://github.com/openshift-helm-charts/development/blob/main/tests/data/vault-0.17.0.tgz?raw=true
         digests:
-            chart: sha256:f01dd362d81fe4b1ef99bb7fa5be268fa94dc96f3009d28bc93a18517aa1ef7a
-            package: 9cb7e3a5d82537f512319c754ccd6e9a4be08118b34849609d0fc261934d062a
-        lastCertifiedTimestamp: "2022-10-09T18:17:00.692384+05:30"
-        testedOpenShiftVersion: "4.11"
+            chart: sha256:aba56e4bc68704aa933a180a7a7abb309b73c7020a53020a3f2c17565faf12a3
+            package: 72f8d48aad2df1fe49e864a33a112793d2c8a67874d62a466d94bbe4e5f54fee
+        lastCertifiedTimestamp: "2023-07-26T14:32:29.116507-05:00"
+        testedOpenShiftVersion: "4.12"
         supportedOpenShiftVersions: '>=4.2'
-        providerControlledDelivery: false
+        webCatalogOnly: false
     chart:
         name: vault
         home: https://www.vaultproject.io
@@ -47,34 +47,22 @@ metadata:
         type: ""
     chart-overrides: ""
 results:
-    - check: v1.0/contains-values-schema
-      type: Mandatory
-      outcome: PASS
-      reason: Values schema file exist
-    - check: v1.0/has-readme
-      type: Mandatory
-      outcome: PASS
-      reason: Chart has a README
-    - check: v1.0/contains-values
-      type: Mandatory
-      outcome: PASS
-      reason: Values file exist
-    - check: v1.0/required-annotations-present
-      type: Mandatory
-      outcome: PASS
-      reason: All required annotations present
-    - check: v1.0/is-helm-v3
-      type: Mandatory
-      outcome: PASS
-      reason: API version is V2, used in Helm 3
     - check: v1.0/chart-testing
       type: Mandatory
       outcome: PASS
       reason: Chart tests have passed
-    - check: v1.0/contains-test
+    - check: v1.0/has-readme
       type: Mandatory
       outcome: PASS
-      reason: Chart test files exist
+      reason: Chart has a README
+    - check: v1.0/required-annotations-present
+      type: Mandatory
+      outcome: PASS
+      reason: All required annotations present
+    - check: v1.0/contains-values
+      type: Mandatory
+      outcome: PASS
+      reason: Values file exist
     - check: v1.1/has-kubeversion
       type: Mandatory
       outcome: PASS
@@ -83,6 +71,20 @@ results:
       type: Mandatory
       outcome: PASS
       reason: Helm lint successful
+    - check: v1.0/contains-values-schema
+      type: Mandatory
+      outcome: PASS
+      reason: Values schema file exist
+    - check: v1.1/images-are-certified
+      type: Mandatory
+      outcome: PASS
+      reason: |-
+        Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault-k8s:0.14.0-ubi
+        Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault:1.8.4-ubi
+    - check: v1.0/is-helm-v3
+      type: Mandatory
+      outcome: PASS
+      reason: API version is V2, used in Helm 3
     - check: v1.0/not-contain-csi-objects
       type: Mandatory
       outcome: PASS
@@ -91,10 +93,12 @@ results:
       type: Mandatory
       outcome: PASS
       reason: Chart does not contain CRDs
-    - check: v1.0/images-are-certified
+    - check: v1.0/contains-test
       type: Mandatory
       outcome: PASS
-      reason: |-
-        Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault-k8s:0.14.0-ubi
-        Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault:1.8.4-ubi
+      reason: Chart test files exist
+    - check: v1.0/signature-is-valid
+      type: Mandatory
+      outcome: SKIPPED
+      reason: 'Chart is not signed : Signature verification not required'
 

--- a/tests/data/common/redhat/report.yaml
+++ b/tests/data/common/redhat/report.yaml
@@ -2,19 +2,19 @@ apiversion: v1
 kind: verify-report
 metadata:
     tool:
-        verifier-version: 1.9.0
+        verifier-version: 1.12.2
         profile:
             VendorType: redhat
-            version: v1.1
-        reportDigest: uint64:14250977800867714981
+            version: v1.2
+        reportDigest: uint64:3220258970301292478
         chart-uri: https://github.com/openshift-helm-charts/development/blob/main/tests/data/vault-0.17.0.tgz?raw=true
         digests:
-            chart: sha256:f01dd362d81fe4b1ef99bb7fa5be268fa94dc96f3009d28bc93a18517aa1ef7a
-            package: 9cb7e3a5d82537f512319c754ccd6e9a4be08118b34849609d0fc261934d062a
-        lastCertifiedTimestamp: "2022-10-09T18:45:02.882159+05:30"
-        testedOpenShiftVersion: "4.11"
+            chart: sha256:aba56e4bc68704aa933a180a7a7abb309b73c7020a53020a3f2c17565faf12a3
+            package: 72f8d48aad2df1fe49e864a33a112793d2c8a67874d62a466d94bbe4e5f54fee
+        lastCertifiedTimestamp: "2023-07-26T14:33:52.398715-05:00"
+        testedOpenShiftVersion: "4.12"
         supportedOpenShiftVersions: '>=4.2'
-        providerControlledDelivery: false
+        webCatalogOnly: false
     chart:
         name: vault
         home: https://www.vaultproject.io
@@ -47,34 +47,10 @@ metadata:
         type: ""
     chart-overrides: ""
 results:
-    - check: v1.0/not-contain-csi-objects
-      type: Mandatory
-      outcome: PASS
-      reason: CSI objects do not exist
-    - check: v1.0/required-annotations-present
-      type: Mandatory
-      outcome: PASS
-      reason: All required annotations present
-    - check: v1.0/chart-testing
-      type: Mandatory
-      outcome: PASS
-      reason: Chart tests have passed
-    - check: v1.0/is-helm-v3
-      type: Mandatory
-      outcome: PASS
-      reason: API version is V2, used in Helm 3
     - check: v1.0/not-contains-crds
       type: Mandatory
       outcome: PASS
       reason: Chart does not contain CRDs
-    - check: v1.0/contains-values-schema
-      type: Mandatory
-      outcome: PASS
-      reason: Values schema file exist
-    - check: v1.0/contains-values
-      type: Mandatory
-      outcome: PASS
-      reason: Values file exist
     - check: v1.1/has-kubeversion
       type: Mandatory
       outcome: PASS
@@ -83,18 +59,46 @@ results:
       type: Mandatory
       outcome: PASS
       reason: Chart has a README
-    - check: v1.0/contains-test
+    - check: v1.0/required-annotations-present
       type: Mandatory
       outcome: PASS
-      reason: Chart test files exist
+      reason: All required annotations present
+    - check: v1.0/chart-testing
+      type: Mandatory
+      outcome: PASS
+      reason: Chart tests have passed
     - check: v1.0/helm-lint
       type: Mandatory
       outcome: PASS
       reason: Helm lint successful
-    - check: v1.0/images-are-certified
+    - check: v1.0/contains-values
+      type: Mandatory
+      outcome: PASS
+      reason: Values file exist
+    - check: v1.1/images-are-certified
       type: Mandatory
       outcome: PASS
       reason: |-
         Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault-k8s:0.14.0-ubi
         Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault:1.8.4-ubi
+    - check: v1.0/is-helm-v3
+      type: Mandatory
+      outcome: PASS
+      reason: API version is V2, used in Helm 3
+    - check: v1.0/not-contain-csi-objects
+      type: Mandatory
+      outcome: PASS
+      reason: CSI objects do not exist
+    - check: v1.0/signature-is-valid
+      type: Mandatory
+      outcome: SKIPPED
+      reason: 'Chart is not signed : Signature verification not required'
+    - check: v1.0/contains-values-schema
+      type: Mandatory
+      outcome: PASS
+      reason: Values schema file exist
+    - check: v1.0/contains-test
+      type: Mandatory
+      outcome: PASS
+      reason: Chart test files exist
 


### PR DESCRIPTION
In the recent move to OCP 4.13 underpinning this repo's tests, one of the test charts would not run. That's been resolved, but in resolving that, we needed to regenerate various permutations of reports that use those charts as a base. 

This PR regenerates those reports. 
