### PR TITLE
Create action to disable specific workflows based on repo config

### DIFF
--- a/.github/workflows/ci-enabled.yml
+++ b/.github/workflows/ci-enabled.yml
@@ -1,0 +1,41 @@
+name: Ensure CI is Enabled
+# This workflow allows a project to disable workflows based on a repository or
+# organizational environment variable. 
+#
+# Create a repo or org environment variable with its value set to 'true'
+# for this workflow to succeed. Any other value should cause this workflow
+# to fail.
+#
+# https://docs.github.com/en/actions/learn-github-actions/variables#creating-configuration-variables-for-a-repository
+#
+# Example usage, assuming this workflow is local to your repository:
+#
+# jobs:
+#   ensure_ci_enabled:
+#     uses: ./.github/workflows/check-ci-enabled.yml
+#     with:
+#       is-enabled: ${{ vars.CUSTOM_VAR_CI_ENABLED }}
+#
+#   next_task:
+#     needs: ensure_ci_enabled
+#     runs-on: ubuntu-latest
+#     steps:
+#     - ...
+
+on:
+  workflow_call:
+    inputs:
+      is-enabled:
+        type: string
+        required: true
+
+jobs:
+  fail_if_ci_disabled:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check enablement value
+      run: |
+        test "${{ inputs.is-enabled }}" = "true" \
+          || { echo "::error::Halting because this repo/org/env configuration has not explicitly enabled this CI."; \
+            exit 1 ;}
+        echo "::notice::CI is enabled!"

--- a/.github/workflows/test-ci-enabled.yml
+++ b/.github/workflows/test-ci-enabled.yml
@@ -1,0 +1,14 @@
+name: Test CERTIFICATION_ENABLED
+
+# A developer convenience workflow.
+# Tests to see if the CERTIFICATION_ENABLED value indicates
+# certification is enabled.
+
+on:
+  workflow_dispatch:
+
+jobs:
+  test_certification_enabled:
+    uses: ./.github/workflows/ci-enabled.yml
+    with:
+      is-enabled: ${{ vars.CERTIFICATION_ENABLED }}


### PR DESCRIPTION
In preparation for some replumbing that's will come in the near future, we need the ability to dynamically disconnect certification while also being able to re-run workflows so that we can retrigger them once we've finished our work.

This PR adds an action that fails if the input provided is not explicitly set to `true`. We feed it a contextual variable, in our case, the `CERTIFICATION_ENABLED` variable set at the repository, org, or environment level within the GitHub repo settings.

This isn't currently configured to block. For this PoC, I've also added a test workflow that can be manually called by developers to see if the workflow _would be blocked_. 

In a future iteration, I'll likely look to add this to the Certification workflows for the reason described above.

The requisite environment variable `CERTIFICATION_ENABLED` has been set on this repo, stage, charts, and sandbox.