### PR TITLE
Updated reports for vault chart fixtures

### DIFF
--- a/tests/data/HC-04/community/report.yaml
+++ b/tests/data/HC-04/community/report.yaml
@@ -6,13 +6,13 @@ metadata:
         profile:
             VendorType: community
             version: v1.2
-        reportDigest: uint64:12284475994233296417
+        reportDigest: uint64:12809162393075256090
         chart-uri: tests/data/vault-0.17.0.tgz
         digests:
-            chart: sha256:aba56e4bc68704aa933a180a7a7abb309b73c7020a53020a3f2c17565faf12a3
-            package: 72f8d48aad2df1fe49e864a33a112793d2c8a67874d62a466d94bbe4e5f54fee
-        lastCertifiedTimestamp: "2023-07-26T13:27:49.167072-05:00"
-        testedOpenShiftVersion: "4.12"
+            chart: sha256:d075d16bb33bb33f66cc6fb8af5cce935b647972de4b4af49be385fcce7bed05
+            package: 641f6c03aac5117eb679b341426adaa612829acc546c18e59c58ea1b45b2e513
+        lastCertifiedTimestamp: "2023-09-11T12:24:35.651882-04:00"
+        testedOpenShiftVersion: "4.13"
         supportedOpenShiftVersions: '>=4.2'
         webCatalogOnly: false
     chart:
@@ -47,20 +47,30 @@ metadata:
         type: ""
     chart-overrides: ""
 results:
-    - check: v1.0/helm-lint
-      type: Mandatory
-      outcome: PASS
-      reason: Helm lint successful
     - check: v1.0/not-contain-csi-objects
       type: Optional
       outcome: PASS
       reason: CSI objects do not exist
-    - check: v1.1/images-are-certified
+    - check: v1.0/not-contains-crds
       type: Optional
       outcome: PASS
-      reason: |-
-        Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault-k8s:0.14.0-ubi
-        Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault:1.8.4-ubi
+      reason: Chart does not contain CRDs
+    - check: v1.0/contains-test
+      type: Optional
+      outcome: PASS
+      reason: Chart test files exist
+    - check: v1.0/required-annotations-present
+      type: Optional
+      outcome: PASS
+      reason: All required annotations present
+    - check: v1.0/chart-testing
+      type: Optional
+      outcome: PASS
+      reason: Chart tests have passed
+    - check: v1.0/contains-values
+      type: Optional
+      outcome: PASS
+      reason: Values file exist
     - check: v1.0/is-helm-v3
       type: Optional
       outcome: PASS
@@ -69,36 +79,26 @@ results:
       type: Optional
       outcome: SKIPPED
       reason: 'Chart is not signed : Signature verification not required'
-    - check: v1.0/contains-test
-      type: Optional
-      outcome: PASS
-      reason: Chart test files exist
     - check: v1.0/contains-values-schema
       type: Optional
       outcome: PASS
       reason: Values schema file exist
-    - check: v1.0/contains-values
-      type: Optional
-      outcome: PASS
-      reason: Values file exist
-    - check: v1.0/required-annotations-present
-      type: Optional
-      outcome: PASS
-      reason: All required annotations present
     - check: v1.0/has-readme
       type: Optional
       outcome: PASS
       reason: Chart has a README
+    - check: v1.0/helm-lint
+      type: Mandatory
+      outcome: PASS
+      reason: Helm lint successful
     - check: v1.1/has-kubeversion
       type: Optional
       outcome: PASS
       reason: Kubernetes version specified
-    - check: v1.0/not-contains-crds
+    - check: v1.1/images-are-certified
       type: Optional
       outcome: PASS
-      reason: Chart does not contain CRDs
-    - check: v1.0/chart-testing
-      type: Optional
-      outcome: PASS
-      reason: Chart tests have passed
+      reason: |-
+        Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault-k8s:0.14.0-ubi
+        Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault:1.8.4-ubi
 

--- a/tests/data/HC-04/partner/report.yaml
+++ b/tests/data/HC-04/partner/report.yaml
@@ -6,13 +6,13 @@ metadata:
         profile:
             VendorType: partner
             version: v1.2
-        reportDigest: uint64:7594949332872749418
+        reportDigest: uint64:5889874118220183952
         chart-uri: tests/data/vault-0.17.0.tgz
         digests:
-            chart: sha256:aba56e4bc68704aa933a180a7a7abb309b73c7020a53020a3f2c17565faf12a3
-            package: 72f8d48aad2df1fe49e864a33a112793d2c8a67874d62a466d94bbe4e5f54fee
-        lastCertifiedTimestamp: "2023-07-26T13:25:44.500114-05:00"
-        testedOpenShiftVersion: "4.12"
+            chart: sha256:d075d16bb33bb33f66cc6fb8af5cce935b647972de4b4af49be385fcce7bed05
+            package: 641f6c03aac5117eb679b341426adaa612829acc546c18e59c58ea1b45b2e513
+        lastCertifiedTimestamp: "2023-09-11T12:23:45.06562-04:00"
+        testedOpenShiftVersion: "4.13"
         supportedOpenShiftVersions: '>=4.2'
         webCatalogOnly: false
     chart:
@@ -47,58 +47,58 @@ metadata:
         type: ""
     chart-overrides: ""
 results:
+    - check: v1.0/helm-lint
+      type: Mandatory
+      outcome: PASS
+      reason: Helm lint successful
     - check: v1.1/images-are-certified
       type: Mandatory
       outcome: PASS
       reason: |-
         Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault-k8s:0.14.0-ubi
         Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault:1.8.4-ubi
-    - check: v1.0/not-contain-csi-objects
-      type: Mandatory
-      outcome: PASS
-      reason: CSI objects do not exist
-    - check: v1.0/signature-is-valid
-      type: Mandatory
-      outcome: SKIPPED
-      reason: 'Chart is not signed : Signature verification not required'
-    - check: v1.0/contains-test
-      type: Mandatory
-      outcome: PASS
-      reason: Chart test files exist
-    - check: v1.0/contains-values-schema
-      type: Mandatory
-      outcome: PASS
-      reason: Values schema file exist
-    - check: v1.1/has-kubeversion
-      type: Mandatory
-      outcome: PASS
-      reason: Kubernetes version specified
     - check: v1.0/required-annotations-present
       type: Mandatory
       outcome: PASS
       reason: All required annotations present
-    - check: v1.0/chart-testing
-      type: Mandatory
-      outcome: PASS
-      reason: Chart tests have passed
-    - check: v1.0/has-readme
-      type: Mandatory
-      outcome: PASS
-      reason: Chart has a README
-    - check: v1.0/helm-lint
-      type: Mandatory
-      outcome: PASS
-      reason: Helm lint successful
-    - check: v1.0/is-helm-v3
-      type: Mandatory
-      outcome: PASS
-      reason: API version is V2, used in Helm 3
-    - check: v1.0/not-contains-crds
-      type: Mandatory
-      outcome: PASS
-      reason: Chart does not contain CRDs
     - check: v1.0/contains-values
       type: Mandatory
       outcome: PASS
       reason: Values file exist
+    - check: v1.1/has-kubeversion
+      type: Mandatory
+      outcome: PASS
+      reason: Kubernetes version specified
+    - check: v1.0/chart-testing
+      type: Mandatory
+      outcome: PASS
+      reason: Chart tests have passed
+    - check: v1.0/contains-values-schema
+      type: Mandatory
+      outcome: PASS
+      reason: Values schema file exist
+    - check: v1.0/has-readme
+      type: Mandatory
+      outcome: PASS
+      reason: Chart has a README
+    - check: v1.0/not-contain-csi-objects
+      type: Mandatory
+      outcome: PASS
+      reason: CSI objects do not exist
+    - check: v1.0/not-contains-crds
+      type: Mandatory
+      outcome: PASS
+      reason: Chart does not contain CRDs
+    - check: v1.0/contains-test
+      type: Mandatory
+      outcome: PASS
+      reason: Chart test files exist
+    - check: v1.0/is-helm-v3
+      type: Mandatory
+      outcome: PASS
+      reason: API version is V2, used in Helm 3
+    - check: v1.0/signature-is-valid
+      type: Mandatory
+      outcome: SKIPPED
+      reason: 'Chart is not signed : Signature verification not required'
 

--- a/tests/data/HC-04/redhat/report.yaml
+++ b/tests/data/HC-04/redhat/report.yaml
@@ -6,13 +6,13 @@ metadata:
         profile:
             VendorType: redhat
             version: v1.2
-        reportDigest: uint64:17589002506308805613
+        reportDigest: uint64:8130407775330379847
         chart-uri: tests/data/vault-0.17.0.tgz
         digests:
-            chart: sha256:aba56e4bc68704aa933a180a7a7abb309b73c7020a53020a3f2c17565faf12a3
-            package: 72f8d48aad2df1fe49e864a33a112793d2c8a67874d62a466d94bbe4e5f54fee
-        lastCertifiedTimestamp: "2023-07-26T13:26:52.775951-05:00"
-        testedOpenShiftVersion: "4.12"
+            chart: sha256:d075d16bb33bb33f66cc6fb8af5cce935b647972de4b4af49be385fcce7bed05
+            package: 641f6c03aac5117eb679b341426adaa612829acc546c18e59c58ea1b45b2e513
+        lastCertifiedTimestamp: "2023-09-11T12:24:10.256101-04:00"
+        testedOpenShiftVersion: "4.13"
         supportedOpenShiftVersions: '>=4.2'
         webCatalogOnly: false
     chart:
@@ -47,38 +47,32 @@ metadata:
         type: ""
     chart-overrides: ""
 results:
-    - check: v1.0/helm-lint
+    - check: v1.0/chart-testing
       type: Mandatory
       outcome: PASS
-      reason: Helm lint successful
-    - check: v1.0/contains-values
-      type: Mandatory
-      outcome: PASS
-      reason: Values file exist
-    - check: v1.0/is-helm-v3
-      type: Mandatory
-      outcome: PASS
-      reason: API version is V2, used in Helm 3
-    - check: v1.0/not-contains-crds
-      type: Mandatory
-      outcome: PASS
-      reason: Chart does not contain CRDs
-    - check: v1.0/contains-values-schema
-      type: Mandatory
-      outcome: PASS
-      reason: Values schema file exist
+      reason: Chart tests have passed
     - check: v1.1/has-kubeversion
       type: Mandatory
       outcome: PASS
       reason: Kubernetes version specified
-    - check: v1.0/not-contain-csi-objects
-      type: Mandatory
-      outcome: PASS
-      reason: CSI objects do not exist
     - check: v1.0/has-readme
       type: Mandatory
       outcome: PASS
       reason: Chart has a README
+    - check: v1.1/images-are-certified
+      type: Mandatory
+      outcome: PASS
+      reason: |-
+        Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault-k8s:0.14.0-ubi
+        Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault:1.8.4-ubi
+    - check: v1.0/not-contain-csi-objects
+      type: Mandatory
+      outcome: PASS
+      reason: CSI objects do not exist
+    - check: v1.0/is-helm-v3
+      type: Mandatory
+      outcome: PASS
+      reason: API version is V2, used in Helm 3
     - check: v1.0/required-annotations-present
       type: Mandatory
       outcome: PASS
@@ -87,18 +81,24 @@ results:
       type: Mandatory
       outcome: SKIPPED
       reason: 'Chart is not signed : Signature verification not required'
-    - check: v1.0/chart-testing
+    - check: v1.0/contains-values-schema
       type: Mandatory
       outcome: PASS
-      reason: Chart tests have passed
+      reason: Values schema file exist
+    - check: v1.0/contains-values
+      type: Mandatory
+      outcome: PASS
+      reason: Values file exist
+    - check: v1.0/helm-lint
+      type: Mandatory
+      outcome: PASS
+      reason: Helm lint successful
     - check: v1.0/contains-test
       type: Mandatory
       outcome: PASS
       reason: Chart test files exist
-    - check: v1.1/images-are-certified
+    - check: v1.0/not-contains-crds
       type: Mandatory
       outcome: PASS
-      reason: |-
-        Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault-k8s:0.14.0-ubi
-        Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault:1.8.4-ubi
+      reason: Chart does not contain CRDs
 

--- a/tests/data/HC-06/partner/report.yaml
+++ b/tests/data/HC-06/partner/report.yaml
@@ -6,13 +6,13 @@ metadata:
         profile:
             VendorType: partner
             version: v1.2
-        reportDigest: uint64:13856952979000771687
+        reportDigest: uint64:68037995052838460
         chart-uri: N/A
         digests:
-            chart: sha256:aba56e4bc68704aa933a180a7a7abb309b73c7020a53020a3f2c17565faf12a3
-            package: 72f8d48aad2df1fe49e864a33a112793d2c8a67874d62a466d94bbe4e5f54fee
-        lastCertifiedTimestamp: "2023-07-26T14:35:42.163661-05:00"
-        testedOpenShiftVersion: "4.12"
+            chart: sha256:d075d16bb33bb33f66cc6fb8af5cce935b647972de4b4af49be385fcce7bed05
+            package: 641f6c03aac5117eb679b341426adaa612829acc546c18e59c58ea1b45b2e513
+        lastCertifiedTimestamp: "2023-09-11T12:25:00.405795-04:00"
+        testedOpenShiftVersion: "4.13"
         supportedOpenShiftVersions: '>=4.2'
         webCatalogOnly: true
     chart:
@@ -47,6 +47,26 @@ metadata:
         type: ""
     chart-overrides: ""
 results:
+    - check: v1.0/contains-values
+      type: Mandatory
+      outcome: PASS
+      reason: Values file exist
+    - check: v1.0/helm-lint
+      type: Mandatory
+      outcome: PASS
+      reason: Helm lint successful
+    - check: v1.0/contains-test
+      type: Mandatory
+      outcome: PASS
+      reason: Chart test files exist
+    - check: v1.1/has-kubeversion
+      type: Mandatory
+      outcome: PASS
+      reason: Kubernetes version specified
+    - check: v1.0/has-readme
+      type: Mandatory
+      outcome: PASS
+      reason: Chart has a README
     - check: v1.0/not-contain-csi-objects
       type: Mandatory
       outcome: PASS
@@ -55,34 +75,10 @@ results:
       type: Mandatory
       outcome: PASS
       reason: All required annotations present
-    - check: v1.0/not-contains-crds
-      type: Mandatory
-      outcome: PASS
-      reason: Chart does not contain CRDs
     - check: v1.0/contains-values-schema
       type: Mandatory
       outcome: PASS
       reason: Values schema file exist
-    - check: v1.1/has-kubeversion
-      type: Mandatory
-      outcome: PASS
-      reason: Kubernetes version specified
-    - check: v1.0/helm-lint
-      type: Mandatory
-      outcome: PASS
-      reason: Helm lint successful
-    - check: v1.0/chart-testing
-      type: Mandatory
-      outcome: PASS
-      reason: Chart tests have passed
-    - check: v1.0/contains-test
-      type: Mandatory
-      outcome: PASS
-      reason: Chart test files exist
-    - check: v1.0/has-readme
-      type: Mandatory
-      outcome: PASS
-      reason: Chart has a README
     - check: v1.1/images-are-certified
       type: Mandatory
       outcome: PASS
@@ -93,12 +89,16 @@ results:
       type: Mandatory
       outcome: PASS
       reason: API version is V2, used in Helm 3
-    - check: v1.0/contains-values
-      type: Mandatory
-      outcome: PASS
-      reason: Values file exist
     - check: v1.0/signature-is-valid
       type: Mandatory
       outcome: SKIPPED
       reason: 'Chart is not signed : Signature verification not required'
+    - check: v1.0/chart-testing
+      type: Mandatory
+      outcome: PASS
+      reason: Chart tests have passed
+    - check: v1.0/not-contains-crds
+      type: Mandatory
+      outcome: PASS
+      reason: Chart does not contain CRDs
 

--- a/tests/data/HC-09/community/report.json
+++ b/tests/data/HC-09/community/report.json
@@ -8,14 +8,14 @@
         "vendorType": "community",
         "version": "v1.2"
       },
-      "reportDigest": "uint64:7752956879194513465",
+      "reportDigest": "uint64:15967274106154560417",
       "chart-uri": "https://github.com/openshift-helm-charts/development/blob/main/tests/data/vault-0.17.0.tgz?raw=true",
       "digests": {
-        "chart": "sha256:aba56e4bc68704aa933a180a7a7abb309b73c7020a53020a3f2c17565faf12a3",
-        "package": "72f8d48aad2df1fe49e864a33a112793d2c8a67874d62a466d94bbe4e5f54fee"
+        "chart": "sha256:d075d16bb33bb33f66cc6fb8af5cce935b647972de4b4af49be385fcce7bed05",
+        "package": "641f6c03aac5117eb679b341426adaa612829acc546c18e59c58ea1b45b2e513"
       },
-      "lastCertifiedTimestamp": "2023-07-26T14:49:22.48006-05:00",
-      "testedOpenShiftVersion": "4.12",
+      "lastCertifiedTimestamp": "2023-09-11T12:26:16.660772-04:00",
+      "testedOpenShiftVersion": "4.13",
       "supportedOpenShiftVersions": ">=4.2",
       "webCatalogOnly": false
     },
@@ -51,24 +51,6 @@
   },
   "results": [
     {
-      "check": "v1.0/contains-values",
-      "type": "Optional",
-      "outcome": "PASS",
-      "reason": "Values file exist"
-    },
-    {
-      "check": "v1.1/has-kubeversion",
-      "type": "Optional",
-      "outcome": "PASS",
-      "reason": "Kubernetes version specified"
-    },
-    {
-      "check": "v1.0/contains-values-schema",
-      "type": "Optional",
-      "outcome": "PASS",
-      "reason": "Values schema file exist"
-    },
-    {
       "check": "v1.0/has-readme",
       "type": "Optional",
       "outcome": "PASS",
@@ -87,22 +69,16 @@
       "reason": "Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault-k8s:0.14.0-ubi\nImage is Red Hat certified : registry.connect.redhat.com/hashicorp/vault:1.8.4-ubi"
     },
     {
-      "check": "v1.0/not-contain-csi-objects",
+      "check": "v1.0/signature-is-valid",
       "type": "Optional",
-      "outcome": "PASS",
-      "reason": "CSI objects do not exist"
+      "outcome": "SKIPPED",
+      "reason": "Chart is not signed : Signature verification not required"
     },
     {
       "check": "v1.0/contains-test",
       "type": "Optional",
       "outcome": "PASS",
       "reason": "Chart test files exist"
-    },
-    {
-      "check": "v1.0/not-contains-crds",
-      "type": "Optional",
-      "outcome": "PASS",
-      "reason": "Chart does not contain CRDs"
     },
     {
       "check": "v1.0/required-annotations-present",
@@ -117,16 +93,40 @@
       "reason": "Chart tests have passed"
     },
     {
-      "check": "v1.0/signature-is-valid",
-      "type": "Optional",
-      "outcome": "SKIPPED",
-      "reason": "Chart is not signed : Signature verification not required"
-    },
-    {
       "check": "v1.0/is-helm-v3",
       "type": "Optional",
       "outcome": "PASS",
       "reason": "API version is V2, used in Helm 3"
+    },
+    {
+      "check": "v1.0/contains-values",
+      "type": "Optional",
+      "outcome": "PASS",
+      "reason": "Values file exist"
+    },
+    {
+      "check": "v1.1/has-kubeversion",
+      "type": "Optional",
+      "outcome": "PASS",
+      "reason": "Kubernetes version specified"
+    },
+    {
+      "check": "v1.0/not-contains-crds",
+      "type": "Optional",
+      "outcome": "PASS",
+      "reason": "Chart does not contain CRDs"
+    },
+    {
+      "check": "v1.0/not-contain-csi-objects",
+      "type": "Optional",
+      "outcome": "PASS",
+      "reason": "CSI objects do not exist"
+    },
+    {
+      "check": "v1.0/contains-values-schema",
+      "type": "Optional",
+      "outcome": "PASS",
+      "reason": "Values schema file exist"
     }
   ]
 }

--- a/tests/data/HC-09/partner/report.json
+++ b/tests/data/HC-09/partner/report.json
@@ -8,14 +8,14 @@
         "vendorType": "partner",
         "version": "v1.2"
       },
-      "reportDigest": "uint64:12972419698442256528",
+      "reportDigest": "uint64:708741566645764623",
       "chart-uri": "https://github.com/openshift-helm-charts/development/blob/main/tests/data/vault-0.17.0.tgz?raw=true",
       "digests": {
-        "chart": "sha256:aba56e4bc68704aa933a180a7a7abb309b73c7020a53020a3f2c17565faf12a3",
-        "package": "72f8d48aad2df1fe49e864a33a112793d2c8a67874d62a466d94bbe4e5f54fee"
+        "chart": "sha256:d075d16bb33bb33f66cc6fb8af5cce935b647972de4b4af49be385fcce7bed05",
+        "package": "641f6c03aac5117eb679b341426adaa612829acc546c18e59c58ea1b45b2e513"
       },
-      "lastCertifiedTimestamp": "2023-07-26T14:37:04.138359-05:00",
-      "testedOpenShiftVersion": "4.12",
+      "lastCertifiedTimestamp": "2023-09-11T12:25:26.76148-04:00",
+      "testedOpenShiftVersion": "4.13",
       "supportedOpenShiftVersions": ">=4.2",
       "webCatalogOnly": false
     },
@@ -51,46 +51,10 @@
   },
   "results": [
     {
-      "check": "v1.0/not-contain-csi-objects",
-      "type": "Mandatory",
-      "outcome": "PASS",
-      "reason": "CSI objects do not exist"
-    },
-    {
-      "check": "v1.0/chart-testing",
-      "type": "Mandatory",
-      "outcome": "PASS",
-      "reason": "Chart tests have passed"
-    },
-    {
       "check": "v1.0/contains-test",
       "type": "Mandatory",
       "outcome": "PASS",
       "reason": "Chart test files exist"
-    },
-    {
-      "check": "v1.1/has-kubeversion",
-      "type": "Mandatory",
-      "outcome": "PASS",
-      "reason": "Kubernetes version specified"
-    },
-    {
-      "check": "v1.1/images-are-certified",
-      "type": "Mandatory",
-      "outcome": "PASS",
-      "reason": "Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault-k8s:0.14.0-ubi\nImage is Red Hat certified : registry.connect.redhat.com/hashicorp/vault:1.8.4-ubi"
-    },
-    {
-      "check": "v1.0/required-annotations-present",
-      "type": "Mandatory",
-      "outcome": "PASS",
-      "reason": "All required annotations present"
-    },
-    {
-      "check": "v1.0/contains-values",
-      "type": "Mandatory",
-      "outcome": "PASS",
-      "reason": "Values file exist"
     },
     {
       "check": "v1.0/has-readme",
@@ -99,10 +63,34 @@
       "reason": "Chart has a README"
     },
     {
+      "check": "v1.1/has-kubeversion",
+      "type": "Mandatory",
+      "outcome": "PASS",
+      "reason": "Kubernetes version specified"
+    },
+    {
+      "check": "v1.0/is-helm-v3",
+      "type": "Mandatory",
+      "outcome": "PASS",
+      "reason": "API version is V2, used in Helm 3"
+    },
+    {
       "check": "v1.0/not-contains-crds",
       "type": "Mandatory",
       "outcome": "PASS",
       "reason": "Chart does not contain CRDs"
+    },
+    {
+      "check": "v1.0/chart-testing",
+      "type": "Mandatory",
+      "outcome": "PASS",
+      "reason": "Chart tests have passed"
+    },
+    {
+      "check": "v1.0/not-contain-csi-objects",
+      "type": "Mandatory",
+      "outcome": "PASS",
+      "reason": "CSI objects do not exist"
     },
     {
       "check": "v1.0/signature-is-valid",
@@ -117,16 +105,28 @@
       "reason": "Helm lint successful"
     },
     {
-      "check": "v1.0/is-helm-v3",
-      "type": "Mandatory",
-      "outcome": "PASS",
-      "reason": "API version is V2, used in Helm 3"
-    },
-    {
       "check": "v1.0/contains-values-schema",
       "type": "Mandatory",
       "outcome": "PASS",
       "reason": "Values schema file exist"
+    },
+    {
+      "check": "v1.0/contains-values",
+      "type": "Mandatory",
+      "outcome": "PASS",
+      "reason": "Values file exist"
+    },
+    {
+      "check": "v1.1/images-are-certified",
+      "type": "Mandatory",
+      "outcome": "PASS",
+      "reason": "Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault-k8s:0.14.0-ubi\nImage is Red Hat certified : registry.connect.redhat.com/hashicorp/vault:1.8.4-ubi"
+    },
+    {
+      "check": "v1.0/required-annotations-present",
+      "type": "Mandatory",
+      "outcome": "PASS",
+      "reason": "All required annotations present"
     }
   ]
 }

--- a/tests/data/HC-09/redhat/report.json
+++ b/tests/data/HC-09/redhat/report.json
@@ -8,14 +8,14 @@
         "vendorType": "redhat",
         "version": "v1.2"
       },
-      "reportDigest": "uint64:2833960720574391467",
+      "reportDigest": "uint64:13615454925704897580",
       "chart-uri": "https://github.com/openshift-helm-charts/development/blob/main/tests/data/vault-0.17.0.tgz?raw=true",
       "digests": {
-        "chart": "sha256:aba56e4bc68704aa933a180a7a7abb309b73c7020a53020a3f2c17565faf12a3",
-        "package": "72f8d48aad2df1fe49e864a33a112793d2c8a67874d62a466d94bbe4e5f54fee"
+        "chart": "sha256:d075d16bb33bb33f66cc6fb8af5cce935b647972de4b4af49be385fcce7bed05",
+        "package": "641f6c03aac5117eb679b341426adaa612829acc546c18e59c58ea1b45b2e513"
       },
-      "lastCertifiedTimestamp": "2023-07-26T14:47:28.562444-05:00",
-      "testedOpenShiftVersion": "4.12",
+      "lastCertifiedTimestamp": "2023-09-11T12:25:52.103513-04:00",
+      "testedOpenShiftVersion": "4.13",
       "supportedOpenShiftVersions": ">=4.2",
       "webCatalogOnly": false
     },
@@ -51,10 +51,10 @@
   },
   "results": [
     {
-      "check": "v1.0/is-helm-v3",
+      "check": "v1.0/has-readme",
       "type": "Mandatory",
       "outcome": "PASS",
-      "reason": "API version is V2, used in Helm 3"
+      "reason": "Chart has a README"
     },
     {
       "check": "v1.0/not-contain-csi-objects",
@@ -63,40 +63,22 @@
       "reason": "CSI objects do not exist"
     },
     {
-      "check": "v1.0/contains-test",
-      "type": "Mandatory",
-      "outcome": "PASS",
-      "reason": "Chart test files exist"
-    },
-    {
-      "check": "v1.0/has-readme",
-      "type": "Mandatory",
-      "outcome": "PASS",
-      "reason": "Chart has a README"
-    },
-    {
-      "check": "v1.0/helm-lint",
-      "type": "Mandatory",
-      "outcome": "PASS",
-      "reason": "Helm lint successful"
-    },
-    {
       "check": "v1.0/not-contains-crds",
       "type": "Mandatory",
       "outcome": "PASS",
       "reason": "Chart does not contain CRDs"
     },
     {
-      "check": "v1.0/signature-is-valid",
-      "type": "Mandatory",
-      "outcome": "SKIPPED",
-      "reason": "Chart is not signed : Signature verification not required"
-    },
-    {
-      "check": "v1.0/required-annotations-present",
+      "check": "v1.0/contains-values-schema",
       "type": "Mandatory",
       "outcome": "PASS",
-      "reason": "All required annotations present"
+      "reason": "Values schema file exist"
+    },
+    {
+      "check": "v1.0/contains-test",
+      "type": "Mandatory",
+      "outcome": "PASS",
+      "reason": "Chart test files exist"
     },
     {
       "check": "v1.0/chart-testing",
@@ -105,16 +87,22 @@
       "reason": "Chart tests have passed"
     },
     {
+      "check": "v1.0/helm-lint",
+      "type": "Mandatory",
+      "outcome": "PASS",
+      "reason": "Helm lint successful"
+    },
+    {
       "check": "v1.1/images-are-certified",
       "type": "Mandatory",
       "outcome": "PASS",
-      "reason": "Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault:1.8.4-ubi\nImage is Red Hat certified : registry.connect.redhat.com/hashicorp/vault-k8s:0.14.0-ubi"
+      "reason": "Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault-k8s:0.14.0-ubi\nImage is Red Hat certified : registry.connect.redhat.com/hashicorp/vault:1.8.4-ubi"
     },
     {
-      "check": "v1.0/contains-values-schema",
+      "check": "v1.0/required-annotations-present",
       "type": "Mandatory",
       "outcome": "PASS",
-      "reason": "Values schema file exist"
+      "reason": "All required annotations present"
     },
     {
       "check": "v1.0/contains-values",
@@ -127,6 +115,18 @@
       "type": "Mandatory",
       "outcome": "PASS",
       "reason": "Kubernetes version specified"
+    },
+    {
+      "check": "v1.0/is-helm-v3",
+      "type": "Mandatory",
+      "outcome": "PASS",
+      "reason": "API version is V2, used in Helm 3"
+    },
+    {
+      "check": "v1.0/signature-is-valid",
+      "type": "Mandatory",
+      "outcome": "SKIPPED",
+      "reason": "Chart is not signed : Signature verification not required"
     }
   ]
 }

--- a/tests/data/HC-10/signed_chart/report/partner/report.yaml
+++ b/tests/data/HC-10/signed_chart/report/partner/report.yaml
@@ -6,14 +6,14 @@ metadata:
         profile:
             VendorType: partner
             version: v1.2
-        reportDigest: uint64:11059064537300626010
+        reportDigest: uint64:4470320058153955158
         chart-uri: https://github.com/openshift-helm-charts/development/blob/main/tests/data/HC-10/signed_chart/vault-0.17.0.tgz?raw=true
         digests:
-            chart: sha256:aba56e4bc68704aa933a180a7a7abb309b73c7020a53020a3f2c17565faf12a3
-            package: afcd1a19f5801a17a370925a1743f29a5bb853d05b513e716dc4d7798cb95f10
-            publicKey: 0bcbdc417456c2c6489abda4d6c8098223ea36469be3d75feeb2c595db62719d
-        lastCertifiedTimestamp: "2023-07-26T16:30:32.604568-05:00"
-        testedOpenShiftVersion: "4.12"
+            chart: sha256:d075d16bb33bb33f66cc6fb8af5cce935b647972de4b4af49be385fcce7bed05
+            package: 6fb1fea44b19334adff0b9c8bb2946d35f59150fea2ba98fb2d2fc902162ecb5
+            publicKey: 678b498cef687fc38ac5af7b2afe447b1562f79c046a5210678203afdaebf558
+        lastCertifiedTimestamp: "2023-09-11T12:30:18.702841-04:00"
+        testedOpenShiftVersion: "4.13"
         supportedOpenShiftVersions: '>=4.2'
         webCatalogOnly: false
     chart:
@@ -48,10 +48,10 @@ metadata:
         type: ""
     chart-overrides: ""
 results:
-    - check: v1.0/has-readme
+    - check: v1.1/has-kubeversion
       type: Mandatory
       outcome: PASS
-      reason: Chart has a README
+      reason: Kubernetes version specified
     - check: v1.0/helm-lint
       type: Mandatory
       outcome: PASS
@@ -72,34 +72,34 @@ results:
       type: Mandatory
       outcome: PASS
       reason: All required annotations present
-    - check: v1.0/signature-is-valid
+    - check: v1.0/chart-testing
       type: Mandatory
       outcome: PASS
-      reason: 'Chart is signed : Signature verification passed'
-    - check: v1.1/has-kubeversion
-      type: Mandatory
-      outcome: PASS
-      reason: Kubernetes version specified
-    - check: v1.0/contains-test
-      type: Mandatory
-      outcome: PASS
-      reason: Chart test files exist
+      reason: Chart tests have passed
     - check: v1.0/contains-values-schema
       type: Mandatory
       outcome: PASS
       reason: Values schema file exist
+    - check: v1.0/contains-test
+      type: Mandatory
+      outcome: PASS
+      reason: Chart test files exist
     - check: v1.0/contains-values
       type: Mandatory
       outcome: PASS
       reason: Values file exist
+    - check: v1.0/has-readme
+      type: Mandatory
+      outcome: PASS
+      reason: Chart has a README
     - check: v1.1/images-are-certified
       type: Mandatory
       outcome: PASS
       reason: |-
         Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault-k8s:0.14.0-ubi
         Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault:1.8.4-ubi
-    - check: v1.0/chart-testing
+    - check: v1.0/signature-is-valid
       type: Mandatory
       outcome: PASS
-      reason: Chart tests have passed
+      reason: 'Chart is signed : Signature verification passed'
 

--- a/tests/data/HC-10/signed_chart/report/redhat/report.yaml
+++ b/tests/data/HC-10/signed_chart/report/redhat/report.yaml
@@ -6,14 +6,14 @@ metadata:
         profile:
             VendorType: redhat
             version: v1.2
-        reportDigest: uint64:5503902640131384354
+        reportDigest: uint64:5289725535514073789
         chart-uri: https://github.com/openshift-helm-charts/development/blob/main/tests/data/HC-10/signed_chart/vault-0.17.0.tgz?raw=true
         digests:
-            chart: sha256:aba56e4bc68704aa933a180a7a7abb309b73c7020a53020a3f2c17565faf12a3
-            package: afcd1a19f5801a17a370925a1743f29a5bb853d05b513e716dc4d7798cb95f10
-            publicKey: 0bcbdc417456c2c6489abda4d6c8098223ea36469be3d75feeb2c595db62719d
-        lastCertifiedTimestamp: "2023-07-26T16:31:21.387752-05:00"
-        testedOpenShiftVersion: "4.12"
+            chart: sha256:d075d16bb33bb33f66cc6fb8af5cce935b647972de4b4af49be385fcce7bed05
+            package: 6fb1fea44b19334adff0b9c8bb2946d35f59150fea2ba98fb2d2fc902162ecb5
+            publicKey: 678b498cef687fc38ac5af7b2afe447b1562f79c046a5210678203afdaebf558
+        lastCertifiedTimestamp: "2023-09-11T12:30:43.037256-04:00"
+        testedOpenShiftVersion: "4.13"
         supportedOpenShiftVersions: '>=4.2'
         webCatalogOnly: false
     chart:
@@ -48,58 +48,58 @@ metadata:
         type: ""
     chart-overrides: ""
 results:
-    - check: v1.0/contains-test
+    - check: v1.0/required-annotations-present
       type: Mandatory
       outcome: PASS
-      reason: Chart test files exist
+      reason: All required annotations present
+    - check: v1.0/contains-values
+      type: Mandatory
+      outcome: PASS
+      reason: Values file exist
+    - check: v1.1/has-kubeversion
+      type: Mandatory
+      outcome: PASS
+      reason: Kubernetes version specified
     - check: v1.1/images-are-certified
       type: Mandatory
       outcome: PASS
       reason: |-
         Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault-k8s:0.14.0-ubi
         Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault:1.8.4-ubi
-    - check: v1.0/is-helm-v3
-      type: Mandatory
-      outcome: PASS
-      reason: API version is V2, used in Helm 3
-    - check: v1.0/chart-testing
-      type: Mandatory
-      outcome: PASS
-      reason: Chart tests have passed
-    - check: v1.0/required-annotations-present
-      type: Mandatory
-      outcome: PASS
-      reason: All required annotations present
-    - check: v1.0/has-readme
-      type: Mandatory
-      outcome: PASS
-      reason: Chart has a README
-    - check: v1.0/not-contain-csi-objects
-      type: Mandatory
-      outcome: PASS
-      reason: CSI objects do not exist
     - check: v1.0/not-contains-crds
       type: Mandatory
       outcome: PASS
       reason: Chart does not contain CRDs
-    - check: v1.0/contains-values-schema
+    - check: v1.0/not-contain-csi-objects
       type: Mandatory
       outcome: PASS
-      reason: Values schema file exist
-    - check: v1.1/has-kubeversion
+      reason: CSI objects do not exist
+    - check: v1.0/contains-test
       type: Mandatory
       outcome: PASS
-      reason: Kubernetes version specified
-    - check: v1.0/helm-lint
+      reason: Chart test files exist
+    - check: v1.0/has-readme
       type: Mandatory
       outcome: PASS
-      reason: Helm lint successful
+      reason: Chart has a README
     - check: v1.0/signature-is-valid
       type: Mandatory
       outcome: PASS
       reason: 'Chart is signed : Signature verification passed'
-    - check: v1.0/contains-values
+    - check: v1.0/chart-testing
       type: Mandatory
       outcome: PASS
-      reason: Values file exist
+      reason: Chart tests have passed
+    - check: v1.0/contains-values-schema
+      type: Mandatory
+      outcome: PASS
+      reason: Values schema file exist
+    - check: v1.0/helm-lint
+      type: Mandatory
+      outcome: PASS
+      reason: Helm lint successful
+    - check: v1.0/is-helm-v3
+      type: Mandatory
+      outcome: PASS
+      reason: API version is V2, used in Helm 3
 

--- a/tests/data/HC-11/community/report.yaml
+++ b/tests/data/HC-11/community/report.yaml
@@ -6,13 +6,13 @@ metadata:
         profile:
             VendorType: community
             version: v1.2
-        reportDigest: uint64:10214964780218666338
+        reportDigest: uint64:2311548969647311891
         chart-uri: https://github.com/openshift-helm-charts/development/blob/main/tests/data/vault-0.17.0.tgz?raw=true
         digests:
-            chart: sha256:aba56e4bc68704aa933a180a7a7abb309b73c7020a53020a3f2c17565faf12a3
-            package: 72f8d48aad2df1fe49e864a33a112793d2c8a67874d62a466d94bbe4e5f54fee
-        lastCertifiedTimestamp: "2023-07-26T14:52:59.770083-05:00"
-        testedOpenShiftVersion: "4.12"
+            chart: sha256:d075d16bb33bb33f66cc6fb8af5cce935b647972de4b4af49be385fcce7bed05
+            package: 641f6c03aac5117eb679b341426adaa612829acc546c18e59c58ea1b45b2e513
+        lastCertifiedTimestamp: "2023-09-11T12:27:30.198044-04:00"
+        testedOpenShiftVersion: "4.13"
         supportedOpenShiftVersions: '>=4.2'
         webCatalogOnly: false
     chart:
@@ -47,32 +47,10 @@ metadata:
         type: ""
     chart-overrides: ""
 results:
-    - check: v1.1/has-kubeversion
+    - check: v1.0/signature-is-valid
       type: Optional
-      outcome: PASS
-      reason: Kubernetes version specified
-    - check: v1.1/images-are-certified
-      type: Optional
-      outcome: PASS
-      reason: |-
-        Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault-k8s:0.14.0-ubi
-        Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault:1.8.4-ubi
-    - check: v1.0/is-helm-v3
-      type: Optional
-      outcome: PASS
-      reason: API version is V2, used in Helm 3
-    - check: v1.0/not-contain-csi-objects
-      type: Optional
-      outcome: PASS
-      reason: CSI objects do not exist
-    - check: v1.0/not-contains-crds
-      type: Optional
-      outcome: PASS
-      reason: Chart does not contain CRDs
-    - check: v1.0/required-annotations-present
-      type: Optional
-      outcome: PASS
-      reason: All required annotations present
+      outcome: SKIPPED
+      reason: 'Chart is not signed : Signature verification not required'
     - check: v1.0/chart-testing
       type: Optional
       outcome: PASS
@@ -81,18 +59,40 @@ results:
       type: Optional
       outcome: PASS
       reason: Values file exist
+    - check: v1.0/is-helm-v3
+      type: Optional
+      outcome: PASS
+      reason: API version is V2, used in Helm 3
     - check: v1.0/contains-values-schema
       type: Optional
       outcome: PASS
       reason: Values schema file exist
-    - check: v1.0/signature-is-valid
+    - check: v1.1/images-are-certified
       type: Optional
-      outcome: SKIPPED
-      reason: 'Chart is not signed : Signature verification not required'
+      outcome: PASS
+      reason: |-
+        Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault-k8s:0.14.0-ubi
+        Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault:1.8.4-ubi
+    - check: v1.0/required-annotations-present
+      type: Optional
+      outcome: PASS
+      reason: All required annotations present
+    - check: v1.1/has-kubeversion
+      type: Optional
+      outcome: PASS
+      reason: Kubernetes version specified
+    - check: v1.0/not-contains-crds
+      type: Optional
+      outcome: PASS
+      reason: Chart does not contain CRDs
     - check: v1.0/has-readme
       type: Optional
       outcome: PASS
       reason: Chart has a README
+    - check: v1.0/not-contain-csi-objects
+      type: Optional
+      outcome: PASS
+      reason: CSI objects do not exist
     - check: v1.0/contains-test
       type: Optional
       outcome: PASS

--- a/tests/data/HC-11/partner/report.yaml
+++ b/tests/data/HC-11/partner/report.yaml
@@ -6,13 +6,13 @@ metadata:
         profile:
             VendorType: partner
             version: v1.2
-        reportDigest: uint64:2093766326891469747
+        reportDigest: uint64:15011152628298919945
         chart-uri: https://github.com/openshift-helm-charts/development/blob/main/tests/data/vault-0.17.0.tgz?raw=true
         digests:
-            chart: sha256:aba56e4bc68704aa933a180a7a7abb309b73c7020a53020a3f2c17565faf12a3
-            package: 72f8d48aad2df1fe49e864a33a112793d2c8a67874d62a466d94bbe4e5f54fee
-        lastCertifiedTimestamp: "2023-07-26T14:50:38.51101-05:00"
-        testedOpenShiftVersion: "4.12"
+            chart: sha256:d075d16bb33bb33f66cc6fb8af5cce935b647972de4b4af49be385fcce7bed05
+            package: 641f6c03aac5117eb679b341426adaa612829acc546c18e59c58ea1b45b2e513
+        lastCertifiedTimestamp: "2023-09-11T12:26:40.391703-04:00"
+        testedOpenShiftVersion: "4.13"
         supportedOpenShiftVersions: '>=4.2'
         webCatalogOnly: false
     chart:
@@ -47,18 +47,6 @@ metadata:
         type: ""
     chart-overrides: ""
 results:
-    - check: v1.0/contains-values-schema
-      type: Mandatory
-      outcome: PASS
-      reason: Values schema file exist
-    - check: v1.1/has-kubeversion
-      type: Mandatory
-      outcome: PASS
-      reason: Kubernetes version specified
-    - check: v1.0/chart-testing
-      type: Mandatory
-      outcome: PASS
-      reason: Chart tests have passed
     - check: v1.0/not-contain-csi-objects
       type: Mandatory
       outcome: PASS
@@ -67,34 +55,46 @@ results:
       type: Mandatory
       outcome: PASS
       reason: All required annotations present
-    - check: v1.0/contains-values
-      type: Mandatory
-      outcome: PASS
-      reason: Values file exist
-    - check: v1.0/contains-test
-      type: Mandatory
-      outcome: PASS
-      reason: Chart test files exist
-    - check: v1.0/has-readme
-      type: Mandatory
-      outcome: PASS
-      reason: Chart has a README
-    - check: v1.1/images-are-certified
-      type: Mandatory
-      outcome: PASS
-      reason: |-
-        Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault:1.8.4-ubi
-        Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault-k8s:0.14.0-ubi
-    - check: v1.0/is-helm-v3
-      type: Mandatory
-      outcome: PASS
-      reason: API version is V2, used in Helm 3
-    - check: v1.0/not-contains-crds
-      type: Mandatory
-      outcome: PASS
-      reason: Chart does not contain CRDs
     - check: v1.0/signature-is-valid
       type: Mandatory
       outcome: SKIPPED
       reason: 'Chart is not signed : Signature verification not required'
+    - check: v1.0/contains-values
+      type: Mandatory
+      outcome: PASS
+      reason: Values file exist
+    - check: v1.0/has-readme
+      type: Mandatory
+      outcome: PASS
+      reason: Chart has a README
+    - check: v1.0/is-helm-v3
+      type: Mandatory
+      outcome: PASS
+      reason: API version is V2, used in Helm 3
+    - check: v1.0/contains-values-schema
+      type: Mandatory
+      outcome: PASS
+      reason: Values schema file exist
+    - check: v1.0/not-contains-crds
+      type: Mandatory
+      outcome: PASS
+      reason: Chart does not contain CRDs
+    - check: v1.0/chart-testing
+      type: Mandatory
+      outcome: PASS
+      reason: Chart tests have passed
+    - check: v1.0/contains-test
+      type: Mandatory
+      outcome: PASS
+      reason: Chart test files exist
+    - check: v1.1/has-kubeversion
+      type: Mandatory
+      outcome: PASS
+      reason: Kubernetes version specified
+    - check: v1.1/images-are-certified
+      type: Mandatory
+      outcome: PASS
+      reason: |-
+        Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault-k8s:0.14.0-ubi
+        Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault:1.8.4-ubi
 

--- a/tests/data/HC-11/partner_not_contain_crds/report.yaml
+++ b/tests/data/HC-11/partner_not_contain_crds/report.yaml
@@ -6,13 +6,13 @@ metadata:
         profile:
             VendorType: partner
             version: v1.2
-        reportDigest: uint64:5951359665935255357
+        reportDigest: uint64:9874489681103011099
         chart-uri: https://github.com/openshift-helm-charts/development/blob/main/tests/data/vault-0.17.0.tgz?raw=true
         digests:
-            chart: sha256:aba56e4bc68704aa933a180a7a7abb309b73c7020a53020a3f2c17565faf12a3
-            package: 72f8d48aad2df1fe49e864a33a112793d2c8a67874d62a466d94bbe4e5f54fee
-        lastCertifiedTimestamp: "2023-07-26T14:51:23.074725-05:00"
-        testedOpenShiftVersion: "4.12"
+            chart: sha256:d075d16bb33bb33f66cc6fb8af5cce935b647972de4b4af49be385fcce7bed05
+            package: 641f6c03aac5117eb679b341426adaa612829acc546c18e59c58ea1b45b2e513
+        lastCertifiedTimestamp: "2023-09-11T12:27:05.389934-04:00"
+        testedOpenShiftVersion: "4.13"
         supportedOpenShiftVersions: '>=4.2'
         webCatalogOnly: false
     chart:
@@ -51,24 +51,44 @@ results:
       type: Mandatory
       outcome: PASS
       reason: Helm lint successful
+    - check: v1.0/has-readme
+      type: Mandatory
+      outcome: PASS
+      reason: Chart has a README
+    - check: v1.0/not-contain-csi-objects
+      type: Mandatory
+      outcome: PASS
+      reason: CSI objects do not exist
+    - check: v1.0/signature-is-valid
+      type: Mandatory
+      outcome: SKIPPED
+      reason: 'Chart is not signed : Signature verification not required'
+    - check: v1.0/contains-values
+      type: Mandatory
+      outcome: PASS
+      reason: Values file exist
+    - check: v1.0/required-annotations-present
+      type: Mandatory
+      outcome: PASS
+      reason: All required annotations present
+    - check: v1.0/chart-testing
+      type: Mandatory
+      outcome: PASS
+      reason: Chart tests have passed
+    - check: v1.0/contains-test
+      type: Mandatory
+      outcome: PASS
+      reason: Chart test files exist
     - check: v1.1/images-are-certified
       type: Mandatory
       outcome: PASS
       reason: |-
         Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault-k8s:0.14.0-ubi
         Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault:1.8.4-ubi
-    - check: v1.0/signature-is-valid
-      type: Mandatory
-      outcome: SKIPPED
-      reason: 'Chart is not signed : Signature verification not required'
     - check: v1.0/is-helm-v3
       type: Mandatory
       outcome: PASS
       reason: API version is V2, used in Helm 3
-    - check: v1.0/required-annotations-present
-      type: Mandatory
-      outcome: PASS
-      reason: All required annotations present
     - check: v1.0/contains-values-schema
       type: Mandatory
       outcome: PASS
@@ -77,24 +97,4 @@ results:
       type: Mandatory
       outcome: PASS
       reason: Kubernetes version specified
-    - check: v1.0/contains-values
-      type: Mandatory
-      outcome: PASS
-      reason: Values file exist
-    - check: v1.0/not-contain-csi-objects
-      type: Mandatory
-      outcome: PASS
-      reason: CSI objects do not exist
-    - check: v1.0/chart-testing
-      type: Mandatory
-      outcome: PASS
-      reason: Chart tests have passed
-    - check: v1.0/has-readme
-      type: Mandatory
-      outcome: PASS
-      reason: Chart has a README
-    - check: v1.0/contains-test
-      type: Mandatory
-      outcome: PASS
-      reason: Chart test files exist
 

--- a/tests/data/HC-18/community/report.yaml
+++ b/tests/data/HC-18/community/report.yaml
@@ -6,13 +6,13 @@ metadata:
         profile:
             VendorType: community
             version: v1.2
-        reportDigest: uint64:6449768437428808615
+        reportDigest: uint64:2120021724436576277
         chart-uri: https://github.com/openshift-helm-charts/development/blob/main/tests/data/vault-0.18.0.tgz?raw=true
         digests:
-            chart: sha256:c9663a0f5efe22bfb89d10cdd282959c8d880a3cef8a6301fca2ccf150dd703d
-            package: c82f8931f67747d1bf3909680523362bcef471d840be12fe9a1f7aa43e39c07b
-        lastCertifiedTimestamp: "2023-07-26T14:55:59.706521-05:00"
-        testedOpenShiftVersion: "4.12"
+            chart: sha256:bca63b8a5fd7083080effe38b5da54e413dd6da6778150590b1313d98e1e8b5a
+            package: 4d971920da45dc948fc57fcb216625c65b20b141c789f8348573c1e32d9a1c72
+        lastCertifiedTimestamp: "2023-09-11T12:29:25.69303-04:00"
+        testedOpenShiftVersion: "4.13"
         supportedOpenShiftVersions: '>=4.2'
         webCatalogOnly: false
     chart:
@@ -47,10 +47,42 @@ metadata:
         type: ""
     chart-overrides: ""
 results:
+    - check: v1.0/contains-values
+      type: Optional
+      outcome: PASS
+      reason: Values file exist
+    - check: v1.0/helm-lint
+      type: Mandatory
+      outcome: PASS
+      reason: Helm lint successful
+    - check: v1.0/not-contains-crds
+      type: Optional
+      outcome: PASS
+      reason: Chart does not contain CRDs
+    - check: v1.0/chart-testing
+      type: Optional
+      outcome: PASS
+      reason: Chart tests have passed
     - check: v1.0/signature-is-valid
       type: Optional
       outcome: SKIPPED
       reason: 'Chart is not signed : Signature verification not required'
+    - check: v1.0/has-readme
+      type: Optional
+      outcome: PASS
+      reason: Chart has a README
+    - check: v1.0/is-helm-v3
+      type: Optional
+      outcome: PASS
+      reason: API version is V2, used in Helm 3
+    - check: v1.0/required-annotations-present
+      type: Optional
+      outcome: PASS
+      reason: All required annotations present
+    - check: v1.1/has-kubeversion
+      type: Optional
+      outcome: PASS
+      reason: Kubernetes version specified
     - check: v1.0/contains-values-schema
       type: Optional
       outcome: PASS
@@ -61,44 +93,12 @@ results:
       reason: |-
         Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault-k8s:0.14.1-ubi
         Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault:1.9.0-ubi
-    - check: v1.0/is-helm-v3
-      type: Optional
-      outcome: PASS
-      reason: API version is V2, used in Helm 3
-    - check: v1.0/chart-testing
-      type: Optional
-      outcome: PASS
-      reason: Chart tests have passed
-    - check: v1.0/has-readme
-      type: Optional
-      outcome: PASS
-      reason: Chart has a README
-    - check: v1.0/required-annotations-present
-      type: Optional
-      outcome: PASS
-      reason: All required annotations present
-    - check: v1.0/contains-test
-      type: Optional
-      outcome: PASS
-      reason: Chart test files exist
-    - check: v1.0/contains-values
-      type: Optional
-      outcome: PASS
-      reason: Values file exist
-    - check: v1.1/has-kubeversion
-      type: Optional
-      outcome: PASS
-      reason: Kubernetes version specified
-    - check: v1.0/helm-lint
-      type: Mandatory
-      outcome: PASS
-      reason: Helm lint successful
     - check: v1.0/not-contain-csi-objects
       type: Optional
       outcome: PASS
       reason: CSI objects do not exist
-    - check: v1.0/not-contains-crds
+    - check: v1.0/contains-test
       type: Optional
       outcome: PASS
-      reason: Chart does not contain CRDs
+      reason: Chart test files exist
 

--- a/tests/data/HC-18/partner/report.yaml
+++ b/tests/data/HC-18/partner/report.yaml
@@ -6,13 +6,13 @@ metadata:
         profile:
             VendorType: partner
             version: v1.2
-        reportDigest: uint64:18424692730570792782
+        reportDigest: uint64:11482306088874782120
         chart-uri: https://github.com/openshift-helm-charts/development/blob/main/tests/data/vault-0.18.0.tgz?raw=true
         digests:
-            chart: sha256:c9663a0f5efe22bfb89d10cdd282959c8d880a3cef8a6301fca2ccf150dd703d
-            package: c82f8931f67747d1bf3909680523362bcef471d840be12fe9a1f7aa43e39c07b
-        lastCertifiedTimestamp: "2023-07-26T14:54:41.057968-05:00"
-        testedOpenShiftVersion: "4.12"
+            chart: sha256:bca63b8a5fd7083080effe38b5da54e413dd6da6778150590b1313d98e1e8b5a
+            package: 4d971920da45dc948fc57fcb216625c65b20b141c789f8348573c1e32d9a1c72
+        lastCertifiedTimestamp: "2023-09-11T12:28:34.708017-04:00"
+        testedOpenShiftVersion: "4.13"
         supportedOpenShiftVersions: '>=4.2'
         webCatalogOnly: false
     chart:
@@ -47,38 +47,48 @@ metadata:
         type: ""
     chart-overrides: ""
 results:
-    - check: v1.0/contains-test
+    - check: v1.0/chart-testing
       type: Mandatory
       outcome: PASS
-      reason: Chart test files exist
-    - check: v1.0/is-helm-v3
+      reason: Chart tests have passed
+    - check: v1.0/helm-lint
       type: Mandatory
       outcome: PASS
-      reason: API version is V2, used in Helm 3
-    - check: v1.0/not-contains-crds
-      type: Mandatory
-      outcome: PASS
-      reason: Chart does not contain CRDs
-    - check: v1.0/not-contain-csi-objects
-      type: Mandatory
-      outcome: PASS
-      reason: CSI objects do not exist
-    - check: v1.0/contains-values-schema
-      type: Mandatory
-      outcome: PASS
-      reason: Values schema file exist
-    - check: v1.0/contains-values
-      type: Mandatory
-      outcome: PASS
-      reason: Values file exist
+      reason: Helm lint successful
     - check: v1.1/has-kubeversion
       type: Mandatory
       outcome: PASS
       reason: Kubernetes version specified
+    - check: v1.0/contains-values-schema
+      type: Mandatory
+      outcome: PASS
+      reason: Values schema file exist
+    - check: v1.1/images-are-certified
+      type: Mandatory
+      outcome: PASS
+      reason: |-
+        Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault-k8s:0.14.1-ubi
+        Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault:1.9.0-ubi
+    - check: v1.0/not-contain-csi-objects
+      type: Mandatory
+      outcome: PASS
+      reason: CSI objects do not exist
+    - check: v1.0/not-contains-crds
+      type: Mandatory
+      outcome: PASS
+      reason: Chart does not contain CRDs
     - check: v1.0/has-readme
       type: Mandatory
       outcome: PASS
       reason: Chart has a README
+    - check: v1.0/is-helm-v3
+      type: Mandatory
+      outcome: PASS
+      reason: API version is V2, used in Helm 3
+    - check: v1.0/contains-test
+      type: Mandatory
+      outcome: PASS
+      reason: Chart test files exist
     - check: v1.0/required-annotations-present
       type: Mandatory
       outcome: PASS
@@ -87,18 +97,8 @@ results:
       type: Mandatory
       outcome: SKIPPED
       reason: 'Chart is not signed : Signature verification not required'
-    - check: v1.0/helm-lint
+    - check: v1.0/contains-values
       type: Mandatory
       outcome: PASS
-      reason: Helm lint successful
-    - check: v1.1/images-are-certified
-      type: Mandatory
-      outcome: PASS
-      reason: |-
-        Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault-k8s:0.14.1-ubi
-        Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault:1.9.0-ubi
-    - check: v1.0/chart-testing
-      type: Mandatory
-      outcome: PASS
-      reason: Chart tests have passed
+      reason: Values file exist
 

--- a/tests/data/HC-18/redhat/report.yaml
+++ b/tests/data/HC-18/redhat/report.yaml
@@ -6,13 +6,13 @@ metadata:
         profile:
             VendorType: redhat
             version: v1.2
-        reportDigest: uint64:11930215818488035709
+        reportDigest: uint64:1045709973763296907
         chart-uri: https://github.com/openshift-helm-charts/development/blob/main/tests/data/vault-0.18.0.tgz?raw=true
         digests:
-            chart: sha256:c9663a0f5efe22bfb89d10cdd282959c8d880a3cef8a6301fca2ccf150dd703d
-            package: c82f8931f67747d1bf3909680523362bcef471d840be12fe9a1f7aa43e39c07b
-        lastCertifiedTimestamp: "2023-07-26T14:55:19.243533-05:00"
-        testedOpenShiftVersion: "4.12"
+            chart: sha256:bca63b8a5fd7083080effe38b5da54e413dd6da6778150590b1313d98e1e8b5a
+            package: 4d971920da45dc948fc57fcb216625c65b20b141c789f8348573c1e32d9a1c72
+        lastCertifiedTimestamp: "2023-09-11T12:29:00.41305-04:00"
+        testedOpenShiftVersion: "4.13"
         supportedOpenShiftVersions: '>=4.2'
         webCatalogOnly: false
     chart:
@@ -47,10 +47,22 @@ metadata:
         type: ""
     chart-overrides: ""
 results:
-    - check: v1.0/signature-is-valid
+    - check: v1.0/contains-test
       type: Mandatory
-      outcome: SKIPPED
-      reason: 'Chart is not signed : Signature verification not required'
+      outcome: PASS
+      reason: Chart test files exist
+    - check: v1.0/contains-values-schema
+      type: Mandatory
+      outcome: PASS
+      reason: Values schema file exist
+    - check: v1.0/is-helm-v3
+      type: Mandatory
+      outcome: PASS
+      reason: API version is V2, used in Helm 3
+    - check: v1.0/has-readme
+      type: Mandatory
+      outcome: PASS
+      reason: Chart has a README
     - check: v1.0/helm-lint
       type: Mandatory
       outcome: PASS
@@ -65,40 +77,28 @@ results:
       type: Mandatory
       outcome: PASS
       reason: CSI objects do not exist
-    - check: v1.0/chart-testing
-      type: Mandatory
-      outcome: PASS
-      reason: Chart tests have passed
-    - check: v1.1/has-kubeversion
-      type: Mandatory
-      outcome: PASS
-      reason: Kubernetes version specified
-    - check: v1.0/has-readme
-      type: Mandatory
-      outcome: PASS
-      reason: Chart has a README
     - check: v1.0/required-annotations-present
       type: Mandatory
       outcome: PASS
       reason: All required annotations present
-    - check: v1.0/contains-values-schema
+    - check: v1.0/signature-is-valid
+      type: Mandatory
+      outcome: SKIPPED
+      reason: 'Chart is not signed : Signature verification not required'
+    - check: v1.1/has-kubeversion
       type: Mandatory
       outcome: PASS
-      reason: Values schema file exist
-    - check: v1.0/not-contains-crds
-      type: Mandatory
-      outcome: PASS
-      reason: Chart does not contain CRDs
-    - check: v1.0/is-helm-v3
-      type: Mandatory
-      outcome: PASS
-      reason: API version is V2, used in Helm 3
-    - check: v1.0/contains-test
-      type: Mandatory
-      outcome: PASS
-      reason: Chart test files exist
+      reason: Kubernetes version specified
     - check: v1.0/contains-values
       type: Mandatory
       outcome: PASS
       reason: Values file exist
+    - check: v1.0/not-contains-crds
+      type: Mandatory
+      outcome: PASS
+      reason: Chart does not contain CRDs
+    - check: v1.0/chart-testing
+      type: Mandatory
+      outcome: PASS
+      reason: Chart tests have passed
 

--- a/tests/data/HC-19/report_edited_sha_bad/report.yaml
+++ b/tests/data/HC-19/report_edited_sha_bad/report.yaml
@@ -6,13 +6,13 @@ metadata:
         profile:
             VendorType: partner
             version: v1.2
-        reportDigest: uint64:16298400239424284705
+        reportDigest: uint64:15115294433749692156
         chart-uri: https://github.com/openshift-helm-charts/development/blob/main/tests/data/vault-0.17.0.tgz?raw=true
         digests:
-            chart: sha256:aba56e4bc68704aa933a180a7a7abb309b73c7020a53020a3f2c17565faf12a3
-            package: 72f8d48aad2df1fe49e864a33a112793d2c8a67874d62a466d94bbe4e5f54fee
-        lastCertifiedTimestamp: "2023-07-26T14:57:54.024672-05:00"
-        testedOpenShiftVersion: "4.11"
+            chart: sha256:d075d16bb33bb33f66cc6fb8af5cce935b647972de4b4af49be385fcce7bed05
+            package: 641f6c03aac5117eb679b341426adaa612829acc546c18e59c58ea1b45b2e513
+        lastCertifiedTimestamp: "2023-09-11T12:29:52.704863-04:00"
+        testedOpenShiftVersion: "4.12"
         supportedOpenShiftVersions: '>=4.2'
         webCatalogOnly: false
     chart:
@@ -47,58 +47,58 @@ metadata:
         type: ""
     chart-overrides: ""
 results:
-    - check: v1.0/required-annotations-present
-      type: Mandatory
-      outcome: PASS
-      reason: All required annotations present
     - check: v1.0/not-contain-csi-objects
       type: Mandatory
       outcome: PASS
       reason: CSI objects do not exist
-    - check: v1.0/not-contains-crds
-      type: Mandatory
-      outcome: PASS
-      reason: Chart does not contain CRDs
-    - check: v1.0/contains-test
-      type: Mandatory
-      outcome: PASS
-      reason: Chart test files exist
-    - check: v1.0/has-readme
-      type: Mandatory
-      outcome: PASS
-      reason: Chart has a README
-    - check: v1.0/is-helm-v3
-      type: Mandatory
-      outcome: PASS
-      reason: API version is V2, used in Helm 3
-    - check: v1.0/contains-values-schema
-      type: Mandatory
-      outcome: PASS
-      reason: Values schema file exist
-    - check: v1.1/has-kubeversion
-      type: Mandatory
-      outcome: PASS
-      reason: Kubernetes version specified
-    - check: v1.1/images-are-certified
-      type: Mandatory
-      outcome: PASS
-      reason: |-
-        Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault-k8s:0.14.0-ubi
-        Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault:1.8.4-ubi
     - check: v1.0/signature-is-valid
       type: Mandatory
       outcome: SKIPPED
       reason: 'Chart is not signed : Signature verification not required'
-    - check: v1.0/contains-values
+    - check: v1.0/contains-values-schema
       type: Mandatory
       outcome: PASS
-      reason: Values file exist
+      reason: Values schema file exist
+    - check: v1.0/has-readme
+      type: Mandatory
+      outcome: PASS
+      reason: Chart has a README
+    - check: v1.1/images-are-certified
+      type: Mandatory
+      outcome: PASS
+      reason: |-
+        Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault:1.8.4-ubi
+        Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault-k8s:0.14.0-ubi
     - check: v1.0/helm-lint
       type: Mandatory
       outcome: PASS
       reason: Helm lint successful
+    - check: v1.0/contains-test
+      type: Mandatory
+      outcome: PASS
+      reason: Chart test files exist
+    - check: v1.0/is-helm-v3
+      type: Mandatory
+      outcome: PASS
+      reason: API version is V2, used in Helm 3
+    - check: v1.0/not-contains-crds
+      type: Mandatory
+      outcome: PASS
+      reason: Chart does not contain CRDs
+    - check: v1.0/required-annotations-present
+      type: Mandatory
+      outcome: PASS
+      reason: All required annotations present
     - check: v1.0/chart-testing
       type: Mandatory
       outcome: PASS
       reason: Chart tests have passed
+    - check: v1.0/contains-values
+      type: Mandatory
+      outcome: PASS
+      reason: Values file exist
+    - check: v1.1/has-kubeversion
+      type: Mandatory
+      outcome: PASS
+      reason: Kubernetes version specified
 

--- a/tests/data/HC-19/report_sha_bad/report.yaml
+++ b/tests/data/HC-19/report_sha_bad/report.yaml
@@ -6,13 +6,13 @@ metadata:
         profile:
             VendorType: partner
             version: v1.2
-        reportDigest: uint64:16298400239424284704
+        reportDigest: uint64:15115294433749691337
         chart-uri: https://github.com/openshift-helm-charts/development/blob/main/tests/data/vault-0.17.0.tgz?raw=true
         digests:
-            chart: sha256:aba56e4bc68704aa933a180a7a7abb309b73c7020a53020a3f2c17565faf12a3
-            package: 72f8d48aad2df1fe49e864a33a112793d2c8a67874d62a466d94bbe4e5f54fee
-        lastCertifiedTimestamp: "2023-07-26T14:57:54.024672-05:00"
-        testedOpenShiftVersion: "4.12"
+            chart: sha256:d075d16bb33bb33f66cc6fb8af5cce935b647972de4b4af49be385fcce7bed05
+            package: 641f6c03aac5117eb679b341426adaa612829acc546c18e59c58ea1b45b2e513
+        lastCertifiedTimestamp: "2023-09-11T12:29:52.704863-04:00"
+        testedOpenShiftVersion: "4.13"
         supportedOpenShiftVersions: '>=4.2'
         webCatalogOnly: false
     chart:
@@ -47,58 +47,58 @@ metadata:
         type: ""
     chart-overrides: ""
 results:
-    - check: v1.0/required-annotations-present
-      type: Mandatory
-      outcome: PASS
-      reason: All required annotations present
     - check: v1.0/not-contain-csi-objects
       type: Mandatory
       outcome: PASS
       reason: CSI objects do not exist
-    - check: v1.0/not-contains-crds
-      type: Mandatory
-      outcome: PASS
-      reason: Chart does not contain CRDs
-    - check: v1.0/contains-test
-      type: Mandatory
-      outcome: PASS
-      reason: Chart test files exist
-    - check: v1.0/has-readme
-      type: Mandatory
-      outcome: PASS
-      reason: Chart has a README
-    - check: v1.0/is-helm-v3
-      type: Mandatory
-      outcome: PASS
-      reason: API version is V2, used in Helm 3
-    - check: v1.0/contains-values-schema
-      type: Mandatory
-      outcome: PASS
-      reason: Values schema file exist
-    - check: v1.1/has-kubeversion
-      type: Mandatory
-      outcome: PASS
-      reason: Kubernetes version specified
-    - check: v1.1/images-are-certified
-      type: Mandatory
-      outcome: PASS
-      reason: |-
-        Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault-k8s:0.14.0-ubi
-        Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault:1.8.4-ubi
     - check: v1.0/signature-is-valid
       type: Mandatory
       outcome: SKIPPED
       reason: 'Chart is not signed : Signature verification not required'
-    - check: v1.0/contains-values
+    - check: v1.0/contains-values-schema
       type: Mandatory
       outcome: PASS
-      reason: Values file exist
+      reason: Values schema file exist
+    - check: v1.0/has-readme
+      type: Mandatory
+      outcome: PASS
+      reason: Chart has a README
+    - check: v1.1/images-are-certified
+      type: Mandatory
+      outcome: PASS
+      reason: |-
+        Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault:1.8.4-ubi
+        Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault-k8s:0.14.0-ubi
     - check: v1.0/helm-lint
       type: Mandatory
       outcome: PASS
       reason: Helm lint successful
+    - check: v1.0/contains-test
+      type: Mandatory
+      outcome: PASS
+      reason: Chart test files exist
+    - check: v1.0/is-helm-v3
+      type: Mandatory
+      outcome: PASS
+      reason: API version is V2, used in Helm 3
+    - check: v1.0/not-contains-crds
+      type: Mandatory
+      outcome: PASS
+      reason: Chart does not contain CRDs
+    - check: v1.0/required-annotations-present
+      type: Mandatory
+      outcome: PASS
+      reason: All required annotations present
     - check: v1.0/chart-testing
       type: Mandatory
       outcome: PASS
       reason: Chart tests have passed
+    - check: v1.0/contains-values
+      type: Mandatory
+      outcome: PASS
+      reason: Values file exist
+    - check: v1.1/has-kubeversion
+      type: Mandatory
+      outcome: PASS
+      reason: Kubernetes version specified
 

--- a/tests/data/HC-19/report_sha_good/report.yaml
+++ b/tests/data/HC-19/report_sha_good/report.yaml
@@ -6,13 +6,13 @@ metadata:
         profile:
             VendorType: partner
             version: v1.2
-        reportDigest: uint64:16298400239424284705
+        reportDigest: uint64:15115294433749692156
         chart-uri: https://github.com/openshift-helm-charts/development/blob/main/tests/data/vault-0.17.0.tgz?raw=true
         digests:
-            chart: sha256:aba56e4bc68704aa933a180a7a7abb309b73c7020a53020a3f2c17565faf12a3
-            package: 72f8d48aad2df1fe49e864a33a112793d2c8a67874d62a466d94bbe4e5f54fee
-        lastCertifiedTimestamp: "2023-07-26T14:57:54.024672-05:00"
-        testedOpenShiftVersion: "4.12"
+            chart: sha256:d075d16bb33bb33f66cc6fb8af5cce935b647972de4b4af49be385fcce7bed05
+            package: 641f6c03aac5117eb679b341426adaa612829acc546c18e59c58ea1b45b2e513
+        lastCertifiedTimestamp: "2023-09-11T12:29:52.704863-04:00"
+        testedOpenShiftVersion: "4.13"
         supportedOpenShiftVersions: '>=4.2'
         webCatalogOnly: false
     chart:
@@ -47,58 +47,58 @@ metadata:
         type: ""
     chart-overrides: ""
 results:
-    - check: v1.0/required-annotations-present
-      type: Mandatory
-      outcome: PASS
-      reason: All required annotations present
     - check: v1.0/not-contain-csi-objects
       type: Mandatory
       outcome: PASS
       reason: CSI objects do not exist
-    - check: v1.0/not-contains-crds
-      type: Mandatory
-      outcome: PASS
-      reason: Chart does not contain CRDs
-    - check: v1.0/contains-test
-      type: Mandatory
-      outcome: PASS
-      reason: Chart test files exist
-    - check: v1.0/has-readme
-      type: Mandatory
-      outcome: PASS
-      reason: Chart has a README
-    - check: v1.0/is-helm-v3
-      type: Mandatory
-      outcome: PASS
-      reason: API version is V2, used in Helm 3
-    - check: v1.0/contains-values-schema
-      type: Mandatory
-      outcome: PASS
-      reason: Values schema file exist
-    - check: v1.1/has-kubeversion
-      type: Mandatory
-      outcome: PASS
-      reason: Kubernetes version specified
-    - check: v1.1/images-are-certified
-      type: Mandatory
-      outcome: PASS
-      reason: |-
-        Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault-k8s:0.14.0-ubi
-        Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault:1.8.4-ubi
     - check: v1.0/signature-is-valid
       type: Mandatory
       outcome: SKIPPED
       reason: 'Chart is not signed : Signature verification not required'
-    - check: v1.0/contains-values
+    - check: v1.0/contains-values-schema
       type: Mandatory
       outcome: PASS
-      reason: Values file exist
+      reason: Values schema file exist
+    - check: v1.0/has-readme
+      type: Mandatory
+      outcome: PASS
+      reason: Chart has a README
+    - check: v1.1/images-are-certified
+      type: Mandatory
+      outcome: PASS
+      reason: |-
+        Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault:1.8.4-ubi
+        Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault-k8s:0.14.0-ubi
     - check: v1.0/helm-lint
       type: Mandatory
       outcome: PASS
       reason: Helm lint successful
+    - check: v1.0/contains-test
+      type: Mandatory
+      outcome: PASS
+      reason: Chart test files exist
+    - check: v1.0/is-helm-v3
+      type: Mandatory
+      outcome: PASS
+      reason: API version is V2, used in Helm 3
+    - check: v1.0/not-contains-crds
+      type: Mandatory
+      outcome: PASS
+      reason: Chart does not contain CRDs
+    - check: v1.0/required-annotations-present
+      type: Mandatory
+      outcome: PASS
+      reason: All required annotations present
     - check: v1.0/chart-testing
       type: Mandatory
       outcome: PASS
       reason: Chart tests have passed
+    - check: v1.0/contains-values
+      type: Mandatory
+      outcome: PASS
+      reason: Values file exist
+    - check: v1.1/has-kubeversion
+      type: Mandatory
+      outcome: PASS
+      reason: Kubernetes version specified
 

--- a/tests/data/common/community/report.yaml
+++ b/tests/data/common/community/report.yaml
@@ -6,13 +6,13 @@ metadata:
         profile:
             VendorType: community
             version: v1.2
-        reportDigest: uint64:8706487021119090591
+        reportDigest: uint64:4418111533202713217
         chart-uri: https://github.com/openshift-helm-charts/development/blob/main/tests/data/vault-0.17.0.tgz?raw=true
         digests:
-            chart: sha256:aba56e4bc68704aa933a180a7a7abb309b73c7020a53020a3f2c17565faf12a3
-            package: 72f8d48aad2df1fe49e864a33a112793d2c8a67874d62a466d94bbe4e5f54fee
-        lastCertifiedTimestamp: "2023-07-26T14:34:28.721432-05:00"
-        testedOpenShiftVersion: "4.12"
+            chart: sha256:d075d16bb33bb33f66cc6fb8af5cce935b647972de4b4af49be385fcce7bed05
+            package: 641f6c03aac5117eb679b341426adaa612829acc546c18e59c58ea1b45b2e513
+        lastCertifiedTimestamp: "2023-09-11T12:23:19.160549-04:00"
+        testedOpenShiftVersion: "4.13"
         supportedOpenShiftVersions: '>=4.2'
         webCatalogOnly: false
     chart:
@@ -51,44 +51,42 @@ results:
       type: Optional
       outcome: PASS
       reason: CSI objects do not exist
-    - check: v1.0/required-annotations-present
-      type: Optional
-      outcome: PASS
-      reason: All required annotations present
-    - check: v1.0/chart-testing
-      type: Optional
-      outcome: PASS
-      reason: Chart tests have passed
     - check: v1.0/contains-values-schema
       type: Optional
       outcome: PASS
       reason: Values schema file exist
-    - check: v1.1/images-are-certified
-      type: Optional
-      outcome: PASS
-      reason: |-
-        Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault-k8s:0.14.0-ubi
-        Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault:1.8.4-ubi
-    - check: v1.0/helm-lint
-      type: Mandatory
-      outcome: PASS
-      reason: Helm lint successful
     - check: v1.0/not-contains-crds
       type: Optional
       outcome: PASS
       reason: Chart does not contain CRDs
-    - check: v1.0/signature-is-valid
+    - check: v1.0/required-annotations-present
       type: Optional
-      outcome: SKIPPED
-      reason: 'Chart is not signed : Signature verification not required'
+      outcome: PASS
+      reason: All required annotations present
     - check: v1.0/contains-values
       type: Optional
       outcome: PASS
       reason: Values file exist
+    - check: v1.0/has-readme
+      type: Optional
+      outcome: PASS
+      reason: Chart has a README
+    - check: v1.0/helm-lint
+      type: Mandatory
+      outcome: PASS
+      reason: Helm lint successful
     - check: v1.0/is-helm-v3
       type: Optional
       outcome: PASS
       reason: API version is V2, used in Helm 3
+    - check: v1.0/signature-is-valid
+      type: Optional
+      outcome: SKIPPED
+      reason: 'Chart is not signed : Signature verification not required'
+    - check: v1.0/chart-testing
+      type: Optional
+      outcome: PASS
+      reason: Chart tests have passed
     - check: v1.0/contains-test
       type: Optional
       outcome: PASS
@@ -97,8 +95,10 @@ results:
       type: Optional
       outcome: PASS
       reason: Kubernetes version specified
-    - check: v1.0/has-readme
+    - check: v1.1/images-are-certified
       type: Optional
       outcome: PASS
-      reason: Chart has a README
+      reason: |-
+        Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault-k8s:0.14.0-ubi
+        Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault:1.8.4-ubi
 

--- a/tests/data/common/partner/report.yaml
+++ b/tests/data/common/partner/report.yaml
@@ -6,13 +6,13 @@ metadata:
         profile:
             VendorType: partner
             version: v1.2
-        reportDigest: uint64:16939048952212352520
+        reportDigest: uint64:7407049884959662603
         chart-uri: https://github.com/openshift-helm-charts/development/blob/main/tests/data/vault-0.17.0.tgz?raw=true
         digests:
-            chart: sha256:aba56e4bc68704aa933a180a7a7abb309b73c7020a53020a3f2c17565faf12a3
-            package: 72f8d48aad2df1fe49e864a33a112793d2c8a67874d62a466d94bbe4e5f54fee
-        lastCertifiedTimestamp: "2023-07-26T14:32:29.116507-05:00"
-        testedOpenShiftVersion: "4.12"
+            chart: sha256:d075d16bb33bb33f66cc6fb8af5cce935b647972de4b4af49be385fcce7bed05
+            package: 641f6c03aac5117eb679b341426adaa612829acc546c18e59c58ea1b45b2e513
+        lastCertifiedTimestamp: "2023-09-11T12:22:29.724879-04:00"
+        testedOpenShiftVersion: "4.13"
         supportedOpenShiftVersions: '>=4.2'
         webCatalogOnly: false
     chart:
@@ -47,48 +47,40 @@ metadata:
         type: ""
     chart-overrides: ""
 results:
-    - check: v1.0/chart-testing
-      type: Mandatory
-      outcome: PASS
-      reason: Chart tests have passed
-    - check: v1.0/has-readme
-      type: Mandatory
-      outcome: PASS
-      reason: Chart has a README
-    - check: v1.0/required-annotations-present
-      type: Mandatory
-      outcome: PASS
-      reason: All required annotations present
-    - check: v1.0/contains-values
-      type: Mandatory
-      outcome: PASS
-      reason: Values file exist
-    - check: v1.1/has-kubeversion
-      type: Mandatory
-      outcome: PASS
-      reason: Kubernetes version specified
     - check: v1.0/helm-lint
       type: Mandatory
       outcome: PASS
       reason: Helm lint successful
-    - check: v1.0/contains-values-schema
-      type: Mandatory
-      outcome: PASS
-      reason: Values schema file exist
-    - check: v1.1/images-are-certified
-      type: Mandatory
-      outcome: PASS
-      reason: |-
-        Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault-k8s:0.14.0-ubi
-        Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault:1.8.4-ubi
-    - check: v1.0/is-helm-v3
-      type: Mandatory
-      outcome: PASS
-      reason: API version is V2, used in Helm 3
     - check: v1.0/not-contain-csi-objects
       type: Mandatory
       outcome: PASS
       reason: CSI objects do not exist
+    - check: v1.0/contains-values-schema
+      type: Mandatory
+      outcome: PASS
+      reason: Values schema file exist
+    - check: v1.0/contains-values
+      type: Mandatory
+      outcome: PASS
+      reason: Values file exist
+    - check: v1.1/images-are-certified
+      type: Mandatory
+      outcome: PASS
+      reason: |-
+        Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault:1.8.4-ubi
+        Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault-k8s:0.14.0-ubi
+    - check: v1.0/is-helm-v3
+      type: Mandatory
+      outcome: PASS
+      reason: API version is V2, used in Helm 3
+    - check: v1.0/signature-is-valid
+      type: Mandatory
+      outcome: SKIPPED
+      reason: 'Chart is not signed : Signature verification not required'
+    - check: v1.1/has-kubeversion
+      type: Mandatory
+      outcome: PASS
+      reason: Kubernetes version specified
     - check: v1.0/not-contains-crds
       type: Mandatory
       outcome: PASS
@@ -97,8 +89,16 @@ results:
       type: Mandatory
       outcome: PASS
       reason: Chart test files exist
-    - check: v1.0/signature-is-valid
+    - check: v1.0/required-annotations-present
       type: Mandatory
-      outcome: SKIPPED
-      reason: 'Chart is not signed : Signature verification not required'
+      outcome: PASS
+      reason: All required annotations present
+    - check: v1.0/chart-testing
+      type: Mandatory
+      outcome: PASS
+      reason: Chart tests have passed
+    - check: v1.0/has-readme
+      type: Mandatory
+      outcome: PASS
+      reason: Chart has a README
 

--- a/tests/data/common/redhat/report.yaml
+++ b/tests/data/common/redhat/report.yaml
@@ -6,13 +6,13 @@ metadata:
         profile:
             VendorType: redhat
             version: v1.2
-        reportDigest: uint64:3220258970301292478
+        reportDigest: uint64:9397301599710212940
         chart-uri: https://github.com/openshift-helm-charts/development/blob/main/tests/data/vault-0.17.0.tgz?raw=true
         digests:
-            chart: sha256:aba56e4bc68704aa933a180a7a7abb309b73c7020a53020a3f2c17565faf12a3
-            package: 72f8d48aad2df1fe49e864a33a112793d2c8a67874d62a466d94bbe4e5f54fee
-        lastCertifiedTimestamp: "2023-07-26T14:33:52.398715-05:00"
-        testedOpenShiftVersion: "4.12"
+            chart: sha256:d075d16bb33bb33f66cc6fb8af5cce935b647972de4b4af49be385fcce7bed05
+            package: 641f6c03aac5117eb679b341426adaa612829acc546c18e59c58ea1b45b2e513
+        lastCertifiedTimestamp: "2023-09-11T12:22:53.651364-04:00"
+        testedOpenShiftVersion: "4.13"
         supportedOpenShiftVersions: '>=4.2'
         webCatalogOnly: false
     chart:
@@ -51,54 +51,54 @@ results:
       type: Mandatory
       outcome: PASS
       reason: Chart does not contain CRDs
-    - check: v1.1/has-kubeversion
+    - check: v1.0/contains-test
       type: Mandatory
       outcome: PASS
-      reason: Kubernetes version specified
-    - check: v1.0/has-readme
+      reason: Chart test files exist
+    - check: v1.0/is-helm-v3
       type: Mandatory
       outcome: PASS
-      reason: Chart has a README
+      reason: API version is V2, used in Helm 3
     - check: v1.0/required-annotations-present
       type: Mandatory
       outcome: PASS
       reason: All required annotations present
+    - check: v1.0/not-contain-csi-objects
+      type: Mandatory
+      outcome: PASS
+      reason: CSI objects do not exist
     - check: v1.0/chart-testing
       type: Mandatory
       outcome: PASS
       reason: Chart tests have passed
+    - check: v1.1/has-kubeversion
+      type: Mandatory
+      outcome: PASS
+      reason: Kubernetes version specified
     - check: v1.0/helm-lint
       type: Mandatory
       outcome: PASS
       reason: Helm lint successful
+    - check: v1.0/contains-values-schema
+      type: Mandatory
+      outcome: PASS
+      reason: Values schema file exist
     - check: v1.0/contains-values
       type: Mandatory
       outcome: PASS
       reason: Values file exist
+    - check: v1.0/has-readme
+      type: Mandatory
+      outcome: PASS
+      reason: Chart has a README
     - check: v1.1/images-are-certified
       type: Mandatory
       outcome: PASS
       reason: |-
         Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault-k8s:0.14.0-ubi
         Image is Red Hat certified : registry.connect.redhat.com/hashicorp/vault:1.8.4-ubi
-    - check: v1.0/is-helm-v3
-      type: Mandatory
-      outcome: PASS
-      reason: API version is V2, used in Helm 3
-    - check: v1.0/not-contain-csi-objects
-      type: Mandatory
-      outcome: PASS
-      reason: CSI objects do not exist
     - check: v1.0/signature-is-valid
       type: Mandatory
       outcome: SKIPPED
       reason: 'Chart is not signed : Signature verification not required'
-    - check: v1.0/contains-values-schema
-      type: Mandatory
-      outcome: PASS
-      reason: Values schema file exist
-    - check: v1.0/contains-test
-      type: Mandatory
-      outcome: PASS
-      reason: Chart test files exist
 


### PR DESCRIPTION
Unblocks #250

Summary:
* Regenerated reports for the vault charts that were updated due to recent breakage from a chart-verifier bugfix.