### PR TITLE
Adjust expected timeout message and accept regex in expected message

### DIFF
--- a/tests/functional/behave_features/HC-16_chart_test_takes_more_than_30mins.feature
+++ b/tests/functional/behave_features/HC-16_chart_test_takes_more_than_30mins.feature
@@ -10,8 +10,8 @@ Feature: Chart test takes longer time and exceeds default timeout
 
     @partners @full
     Examples:
-      | vendor_type  | vendor    | chart_path                                  | message                               |
-      | partners     | hashicorp | tests/data/vault-test-timeout-0.17.0.tgz    | * timed out waiting for the condition |
+      | vendor_type  | vendor    | chart_path                                  | message                                                      |
+      | partners     | hashicorp | tests/data/vault-test-timeout-0.17.0.tgz    | (timeout has expired\|timed out waiting for the condition)  |
     
     @community @full
     Examples:

--- a/tests/functional/behave_features/common/utils/chart_certification.py
+++ b/tests/functional/behave_features/common/utils/chart_certification.py
@@ -2,6 +2,7 @@
 """Utility class for setting up and manipulating certification workflow tests."""
 
 import os
+import re
 import json
 import pathlib
 import shutil
@@ -910,7 +911,7 @@ class ChartCertificationE2ETestSingle(ChartCertificationE2ETest):
             raise AssertionError(f"No comment found in the PR {self.secrets.pr_number}")
         complete_comment = response[0]["body"]
 
-        if expect_message in complete_comment:
+        if re.search(expect_message, complete_comment):
             logging.info("Found the expected comment in the PR")
         else:
             raise AssertionError(

--- a/tests/functional/features/HC-16_chart_test_takes_more_than_30mins.feature
+++ b/tests/functional/features/HC-16_chart_test_takes_more_than_30mins.feature
@@ -14,7 +14,7 @@ Feature: Chart test takes longer time and exceeds default timeout
 
     Examples:
       | vendor_type  | vendor         | message                                                                                     |
-      | partners     | hashicorp      | * timed out waiting for the condition                                                       |
+      | partners     | hashicorp      | (timeout has expired\|timed out waiting for the condition)                                 |
       | community    | redhat         | Community charts require maintainer review and approval, a review will be conducted shortly |
   
   Scenario Outline: [HC-16-002] A redhat associate submits a chart that takes more than 30 mins

--- a/tests/functional/utils/chart_certification.py
+++ b/tests/functional/utils/chart_certification.py
@@ -2,6 +2,7 @@
 """Utility class for setting up and manipulating certification workflow tests."""
 
 import os
+import re
 import json
 import pathlib
 import shutil
@@ -818,7 +819,7 @@ class ChartCertificationE2ETestSingle(ChartCertificationE2ETest):
         response = json.loads(r.text)
         complete_comment = response[0]["body"]
 
-        if expect_message in complete_comment:
+        if re.search(expect_message, complete_comment):
             logging.info("Found the expected comment in the PR")
         else:
             pytest.fail(


### PR DESCRIPTION
This PR **should**  fix the pipeline for https://github.com/openshift-helm-charts/development/pull/254

The reason for the failure is because in scenario `HC-16_chart_test_takes_more_than_30mins` for partners, we're expecting the string `* timed out waiting for the condition` in the PR comment. The time out does occur, and the PR does get a comment about a timeout, but it doesn't contains this exact string.
This is the PR in question FYI: https://github.com/openshift-helm-charts/sandbox/pull/65858

I dug around but I can't seem to understand how this was passing until now. They were a few recent changes that could have affected this, but I must be missing something because I can't find the culprit:
* github.com/helm/chart-testing/v3 updated from v3.8.0 to v3.9.0 in chart-verifier
* https://github.com/redhat-certification/chart-verifier/pull/405
* https://github.com/openshift-helm-charts/development/pull/235