### PR TITLE
use a separate approval token for the sandbox repository workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -306,7 +306,10 @@ jobs:
         if: ${{ steps.check_report.conclusion == 'success' }}
         uses: hmarr/auto-approve-action@v3
         with:
-          github-token: ${{ secrets.BOT_TOKEN }}
+          # The token we use for this changes for the Sandbox repository because the sandbox repository
+          # receives PRs from the openshift-helm-charts-bot, and that same bot cannot approve its own
+          # PRs which breaks workflows. Instead, for the Sandbox repo, we approve with the GHA bot.
+          github-token: ${{ github.repository == 'openshift-helm-charts/sandbox' && secrets.GITHUB_TOKEN || secrets.BOT_TOKEN }}
 
       - name: Merge PR
         id: merge_pr


### PR DESCRIPTION
The previous BOT_TOKEN value that was being used in the sandbox repo was another maintainer's PAT, which allowed us to approve PRs created by the openshift-helm-charts-bot in release workflows. That PAT expired, and in replacing it, we're running into issues because of the aforementioned 'user cannot approve their own workflow'.

This PR configures the Approve PR task to use the secrets.GITHUB_TOKEN available within GitHub Actions for the sandbox repository while still using the BOT_TOKEN in other contexts that don't have this problem.