### PR TITLE
Refer to the correct secret during token extraction

### DIFF
--- a/scripts/src/saforcertadmin/create_sa.sh
+++ b/scripts/src/saforcertadmin/create_sa.sh
@@ -2,7 +2,7 @@
 
 user_name='rh-cert-user'
 oc create sa $user_name
-token_secret=$(oc get sa $user_name -o json | jq -r '.secrets[].name | select( index("token") )')
+token_secret=$(oc get secrets --field-selector=type=kubernetes.io/service-account-token -o=jsonpath="{.items[?(@.metadata.annotations.kubernetes\.io/service-account\.name=='"$user_name"')].metadata.name}")
 token=$(oc get secret $token_secret -o json | jq -r .data.token | base64 -d)
 oc apply -f cluster_role_binding.yaml
 


### PR DESCRIPTION
The script that's used to extract the token of the newly created service account on new clusters was referring to a path in the service account resource that doesn't exist anymore. This modification allows us to identify the right secret, and pull the token.