### PR TITLE
fixing regex to follow semver and allow +

### DIFF
--- a/scripts/src/chartprreview/chartprreview.py
+++ b/scripts/src/chartprreview/chartprreview.py
@@ -58,7 +58,7 @@ def get_modified_charts(directory, api_url):
     """
     print("[INFO] Get modified charts. %s" % directory)
     files = prartifact.get_modified_files(api_url)
-    pattern = re.compile(r"charts/(\w+)/([\w-]+)/([\w-]+)/([\w\.-]+)/.*")
+    pattern = re.compile(r"charts/(\w+)/([\w-]+)/([\w-]+)/([\w\.\-+]+)/.*")
     for file_path in files:
         m = pattern.match(file_path)
         if m:


### PR DESCRIPTION
This should allow `+` in the version of the folder path, and allow checkouts to happen.

```
charts/partners/yugabytedb/yugaware-openshift/2.18.2+1/report.yaml
```

[Link](https://pythex.org/?regex=charts%2F(%5Cw%2B)%2F(%5B%5Cw-%5D%2B)%2F(%5B%5Cw-%5D%2B)%2F(%5B%5Cw%5C.%5C-%2B%5D%2B)%2F.*&test_string=charts%2Fpartners%2Fyugabytedb%2Fyugaware-openshift%2F2.18.2%2B1%2Freport.yaml&ignorecase=1&multiline=0&dotall=0&verbose=1) to regex test
