### PR TITLE
Prevent early exit in cases where a non-workflow file is also modified alongside workflow files

### DIFF
--- a/scripts/src/workflowtesting/checkprforci.py
+++ b/scripts/src/workflowtesting/checkprforci.py
@@ -19,7 +19,7 @@ def check_if_ci_only_is_modified(api_url):
 
     files = prartifact.get_modified_files(api_url)
     workflow_files = [
-        re.compile(r".github/workflows/.*"),
+        re.compile(r".github/(workflows|actions)/.*"),
         re.compile(r"scripts/.*"),
         re.compile(r"tests/.*"),
     ]
@@ -33,19 +33,27 @@ def check_if_ci_only_is_modified(api_url):
         re.compile(r"docs/([\w-]+)\.md"),
     ]
 
+    print(f"[INFO] The following files were modified in this PR: {files}")
+
     workflow_found = False
     others_found = False
     tests_included = False
 
     for filename in files:
         if any([pattern.match(filename) for pattern in workflow_files]):
+            print(f"[DEBUG] Modified file {filename} is a workflow file.")
             workflow_found = True
+            # Tests are considered workflow files AND test files to inform other actions
+            # so we detect both separately.
             if any([pattern.match(filename) for pattern in test_files]):
+                print(f"[DEBUG] Modified file {filename} is also a test file.")
                 tests_included = True
         elif any([pattern.match(filename) for pattern in skip_build_files]):
+            print(f"[DEBUG] Modified file {filename} is a skippable file.")
             others_found = True
         else:
-            return False
+            print(f"[DEBUG] Modified file {filename} did not match any file paths of interest. Ignoring.")
+            continue
 
     if others_found and not workflow_found:
         gitutils.add_output("do-not-build", "true")


### PR DESCRIPTION
This PR fixes a bug in the logic that checks PR contents to detect if workflow files were modified.

PR https://github.com/openshift-helm-charts/development/pull/264 adds a composite action, and also modifies some of the workflows to utilize that composite action. In the testing of that PR, it seems that Workflow Tests didn't run.

This seems to be because the logic that would detect if workflow tests needed to run would fail early because the composite actions path did not match any of the expected paths that would trigger a workflow run.

I believe that the logic here is bugged such that files that don't match any of the expressions defined would cause the check to immediately return indicating that the PR contained non-workflow files and therefore shouldn't trigger workflow tests.

Workflow tests should run if they're modified, even if modified within the context of other changes that are non-workflow related.

This PR fixes that behavior and adds additional log verbosity.

The new output looks something like this:

```
 ❱ check-pr-for-ci --verify-user=mgoerens --api-url=https://api.github.com/repos/openshift-helm-charts/development/pulls/264
[INFO] Query files : https://api.github.com/repos/openshift-helm-charts/development/pulls/264/files?per_page=100&page=1
[DEBUG] X-RateLimit-Limit : 60
[DEBUG] X-RateLimit-Remaining  : 25
[INFO] The following files were modified in this PR: ['.github/actions/get-ocp-range/action.yaml', '.github/workflows/build.yml', 'scripts/src/chartprreview/chartprreview.py', 'scripts/src/chartrepomanager/chartrepomanager.py', 'scripts/src/chartrepomanager/indexannotations.py', 'scripts/src/indexfile/index.py', 'scripts/src/report/verifier_report.py']
[DEBUG] Modified file .github/actions/get-ocp-range/action.yaml is a workflow file.
[DEBUG] Modified file .github/workflows/build.yml is a workflow file.
[DEBUG] Modified file scripts/src/chartprreview/chartprreview.py is a workflow file.
[DEBUG] Modified file scripts/src/chartrepomanager/chartrepomanager.py is a workflow file.
[DEBUG] Modified file scripts/src/chartrepomanager/indexannotations.py is a workflow file.
[DEBUG] Modified file scripts/src/indexfile/index.py is a workflow file.
[DEBUG] Modified file scripts/src/report/verifier_report.py is a workflow file.
[INFO] Verify user. mgoerens
[INFO] mgoerens authorized
[INFO] PR is workflow changes only and user is authorized - run tests.
```

Note that this would run tests, which is what we want to happen.