### PR TITLE
Simplify output parameters

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,7 +108,7 @@ jobs:
       message_file: ${{ steps.pr_comment.outputs.message-file }}
       webCatalogOnly: ${{ steps.check_pr_content.outputs.webCatalogOnly }}
       chartEntryName: ${{ steps.check_pr_content.outputs.chart-entry-name }}
-      chartNameWithVersion: ${{ steps.check_pr_content.outputs.chart-name-with-version }}
+      release_tag: ${{ steps.check_pr_content.outputs.release_tag }}
 
     steps:
       - name: Checkout
@@ -425,7 +425,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPORT_CONTENT: ${{ needs.chart-verifier.outputs.report_content }}
           CHART_ENTRY_NAME: ${{ needs.chart-verifier.outputs.chartEntryName }}
-          CHART_NAME_WITH_VERSION: ${{ needs.chart-verifier.outputs.chartNameWithVersion }}
           REDHAT_TO_COMMUNITY: ${{ needs.chart-verifier.outputs.redhat_to_community }}
           WEB_CATALOG_ONLY: ${{ needs.chart-verifier.outputs.webCatalogOnly }}
         id: release-charts
@@ -439,11 +438,11 @@ jobs:
           cd ${CWD}
 
       - name: Release
-        if: ${{ steps.release-charts.outputs.tag != '' }}
+        if: ${{ ! needs.chart-verifier.outputs.webCatalogOnly }}
         uses: softprops/action-gh-release@v0.1.12
         continue-on-error: true
         with:
-          tag_name: ${{ steps.release-charts.outputs.tag }}
+          tag_name: ${{ needs.chart-verifier.outputs.release_tag }}
           files: |
               ${{ steps.release-charts.outputs.report_file }}
               ${{ steps.release-charts.outputs.public_key_file }}

--- a/scripts/src/chartrepomanager/chartrepomanager.py
+++ b/scripts/src/chartrepomanager/chartrepomanager.py
@@ -634,17 +634,12 @@ def main():
         chart_entry, chart_url = create_index_from_report(category, report_path)
 
     if not web_catalog_only:
-        tag = os.environ.get("CHART_NAME_WITH_VERSION")
-        if not tag:
-            print("[ERROR] Internal error: missing chart name with version (tag)")
-            sys.exit(1)
-        gitutils.add_output("tag", tag)
-
         current_dir = os.getcwd()
         gitutils.add_output("report_file", f"{current_dir}/report.yaml")
         if public_key_file:
             print(f"[INFO] Add key file for release : {current_dir}/{public_key_file}")
             gitutils.add_output("public_key_file", f"{current_dir}/{public_key_file}")
+
     print("Sleeping for 10 seconds")
     time.sleep(10)
     update_index_and_push(

--- a/scripts/src/checkprcontent/checkpr.py
+++ b/scripts/src/checkprcontent/checkpr.py
@@ -232,7 +232,7 @@ def ensure_only_chart_is_modified(api_url, repository, branch):
                 sys.exit(1)
 
         tag_name = f"{organization}-{chart}-{version}"
-        gitutils.add_output("chart-name-with-version", tag_name)
+        gitutils.add_output("release_tag", tag_name)
         tag_api = f"https://api.github.com/repos/{repository}/git/ref/tags/{tag_name}"
         headers = {
             "Accept": "application/vnd.github.v3+json",


### PR DESCRIPTION
The "chart-name-with-version" output parameter was only used to create the "tag" output parameter. This is now replaced by a single "release_tag" output parameter.