### PR TITLE
Add Python Code Style Enforcement to GitHub Actions

### DIFF
--- a/.github/workflows/python-style.yml
+++ b/.github/workflows/python-style.yml
@@ -1,0 +1,29 @@
+name: Python Style
+
+on:
+  pull_request:
+    paths:
+    # Only trigger on core script changes
+    - 'scripts/**.py'
+
+jobs:
+  enforce:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+    - name: Set up Python 3.x Part 1
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.9"
+    - name: Install style tooling
+      working-directory: scripts
+      run: make venv.codestyle
+    - name: Run formatter
+      working-directory: scripts
+      run: make ci.format
+      # Temporarily auto-pass linting until we are able to manually review and
+      # address.
+    - name: Run linter
+      working-directory: scripts
+      run: make lint || true

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,34 @@ __pycache__
 sanity-check.py
 .cr-release-packages/*.tgz
 oc
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# Virtual Envs
+venv.*/

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -1,13 +1,18 @@
 PY_BIN ?= python3
 
-VENV_CODESTYLE ?= venv.codestyle
+# The virtualenv containing code style tools.
+VENV_CODESTYLE = venv.codestyle
 VENV_CODESTYLE_BIN = $(VENV_CODESTYLE)/bin
 
-VENV_TOOLS ?= venv.tools
+# The virtualenv containing our CI scripts
+VENV_TOOLS = venv.tools
 VENV_TOOLS_BIN = $(VENV_TOOLS)/bin
 
 # This is what we pass to git ls-files.
 LS_FILES_INPUT_STR ?= 'src/*.py'
+
+.PHONY: default
+default: format lint
 
 # The same as format, but will throw a non-zero exit code
 # if the formatter had to make changes.
@@ -16,6 +21,12 @@ ci.format: format
 	git diff --exit-code
 
 venv.codestyle:
+	$(MAKE) venv.codestyle.always-reinstall
+
+# This target will always install the codestyle venv.
+# Useful for development cases.
+.PHONY: venv.codestyle.always-reinstall
+venv.codestyle.always-reinstall:
 	$(PY_BIN) -m venv $(VENV_CODESTYLE)
 	./$(VENV_CODESTYLE_BIN)/pip install --upgrade \
 		black \
@@ -34,6 +45,12 @@ lint: venv.codestyle
 		$$(git ls-files $(LS_FILES_INPUT_STR))
 
 venv.tools:
+	$(MAKE) venv.tools.always-reinstall
+
+# This target will always install the tools at the venv.
+# Useful for development cases.
+.PHONY: venv.tools.always-reinstall
+venv.tools.always-reinstall:
 	$(PY_BIN) -m venv $(VENV_TOOLS)
 	./$(VENV_TOOLS_BIN)/pip install -r requirements.txt
 	./$(VENV_TOOLS_BIN)/python setup.py install

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -1,0 +1,39 @@
+PY_BIN ?= python3
+
+VENV_CODESTYLE ?= venv.codestyle
+VENV_CODESTYLE_BIN = $(VENV_CODESTYLE)/bin
+
+VENV_TOOLS ?= venv.tools
+VENV_TOOLS_BIN = $(VENV_TOOLS)/bin
+
+# This is what we pass to git ls-files.
+LS_FILES_INPUT_STR ?= 'src/*.py'
+
+# The same as format, but will throw a non-zero exit code
+# if the formatter had to make changes.
+.PHONY: ci.format
+ci.format: format
+	git diff --exit-code
+
+venv.codestyle:
+	$(PY_BIN) -m venv $(VENV_CODESTYLE)
+	./$(VENV_CODESTYLE_BIN)/pip install --upgrade \
+		black \
+		ruff
+
+.PHONY: format
+format: venv.codestyle
+	./$(VENV_CODESTYLE_BIN)/black \
+		--verbose \
+		$$(git ls-files $(LS_FILES_INPUT_STR))
+
+.PHONY: lint
+lint: venv.codestyle
+	./$(VENV_CODESTYLE_BIN)/ruff \
+		check \
+		$$(git ls-files $(LS_FILES_INPUT_STR))
+
+venv.tools:
+	$(PY_BIN) -m venv $(VENV_TOOLS)
+	./$(VENV_TOOLS_BIN)/pip install -r requirements.txt
+	./$(VENV_TOOLS_BIN)/python setup.py install

--- a/scripts/ruff.toml
+++ b/scripts/ruff.toml
@@ -1,0 +1,4 @@
+ignore = [
+    "E402", # import ordering (komish): import ordering isn't handled by Black so we need to handle this manually.
+    "E501", # line length (komish): line length is not enforced by Black so we need to handle these manually.
+] 


### PR DESCRIPTION
This PR adds a:

1) A Makefile within the scripts/ directory for use in enforcing style and managing virtualenvs
2) a GitHub Actions that consumes the Makefile targets to enforce style guidelines for changes to tooling within the scripts/ directory
3) An expanded .gitignore to remove a lot of cruft that gets added to the filesystem when building/installing various CI tools.

## Style

We've previously [applied Black](https://github.com/openshift-helm-charts/development/pull/247) to the code in this repository, and fixed a few pep8 complaints. This just takes that a bit further and starts to enforce it on PRs.

Linting is currently configured to auto-pass because we have a lot of things that are not automatically fixable (namely import positioning and line length). The idea here is that, when so motivated, we can review the CI results against the repository and go about fixing them as we go along (vs. requiring an immediate fix to all the line length complaints today).

`ruff` is used as the linter here simply due to its speed promises. If we have issues with it, we can eventually migrate to something else.

## Makefile

I make heavy use of venvs for python-related things. I'm less familiar with newer tooling thats in the same problem space. To that end, I've added Make targets that simply help facilitate the management and installation of virtualenvs. One target `venv.codestyle` is used for style tooling (`black`, `ruff`), the other `venv.tools` is used for our scripts themselves.

For development, there are additional "subtargets" that let you always reinstall these venvs, for cases where you're making changes to scripts and want to call them using the installed executables. E.g. `venv.tools.always-reinstall`.

## gitignore

Just adds various paths. This is borrowed from a partial of the GitHub Python default gitignore that's scaffolded for new projects.