### PR TITLE
Update GH actions from redhat-actions to use node 16

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -226,7 +226,7 @@ jobs:
           API_SERVER=$( echo -n ${{ secrets.API_SERVER }} | base64 -d)
           echo "API_SERVER=${API_SERVER}" >> $GITHUB_OUTPUT
 
-      - uses: redhat-actions/oc-login@v1
+      - uses: redhat-actions/oc-login@v1.2
         id: oc_login
         if: ${{ steps.verify_requires.outputs.cluster_needed == 'true' }}
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -226,7 +226,7 @@ jobs:
           API_SERVER=$( echo -n ${{ secrets.API_SERVER }} | base64 -d)
           echo "API_SERVER=${API_SERVER}" >> $GITHUB_OUTPUT
 
-      - uses: redhat-actions/oc-login@v1.2
+      - uses: redhat-actions/oc-login@v1
         id: oc_login
         if: ${{ steps.verify_requires.outputs.cluster_needed == 'true' }}
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -197,7 +197,7 @@ jobs:
             })
 
       - name: install chart verifier for action
-        uses: redhat-actions/openshift-tools-installer@v1.12
+        uses: redhat-actions/openshift-tools-installer@v1
         with:
           source: github
           skip_cache: true
@@ -214,7 +214,7 @@ jobs:
 
       - name: Install oc
         if: ${{ steps.verify_requires.outputs.cluster_needed == 'true' }}
-        uses: redhat-actions/openshift-tools-installer@v1.12
+        uses: redhat-actions/openshift-tools-installer@v1
         with:
           oc: latest
 
@@ -432,7 +432,7 @@ jobs:
           cd ..
 
       - name: install chart verifier for action
-        uses: redhat-actions/openshift-tools-installer@v1.12
+        uses: redhat-actions/openshift-tools-installer@v1
         with:
           source: github
           skip_cache: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -245,7 +245,7 @@ jobs:
           echo "delete_namespace=true" >> $GITHUB_OUTPUT
           echo $KUBECONFIG
 
-      - uses: redhat-actions/chart-verifier@v1.2
+      - uses: redhat-actions/chart-verifier@v1
         id: run-verifier
         if: ${{ steps.verify_requires.outputs.report_needed == 'true' }}
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -197,7 +197,7 @@ jobs:
             })
 
       - name: install chart verifier for action
-        uses: redhat-actions/openshift-tools-installer@v1
+        uses: redhat-actions/openshift-tools-installer@v1.12
         with:
           source: github
           skip_cache: true
@@ -214,7 +214,7 @@ jobs:
 
       - name: Install oc
         if: ${{ steps.verify_requires.outputs.cluster_needed == 'true' }}
-        uses: redhat-actions/openshift-tools-installer@v1
+        uses: redhat-actions/openshift-tools-installer@v1.12
         with:
           oc: latest
 
@@ -432,7 +432,7 @@ jobs:
           cd ..
 
       - name: install chart verifier for action
-        uses: redhat-actions/openshift-tools-installer@v1
+        uses: redhat-actions/openshift-tools-installer@v1.12
         with:
           source: github
           skip_cache: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -245,7 +245,7 @@ jobs:
           echo "delete_namespace=true" >> $GITHUB_OUTPUT
           echo $KUBECONFIG
 
-      - uses: redhat-actions/chart-verifier@v1.1
+      - uses: redhat-actions/chart-verifier@v1.2
         id: run-verifier
         if: ${{ steps.verify_requires.outputs.report_needed == 'true' }}
         with:


### PR DESCRIPTION
Update GitHub workflow actions from `redhat-actions` organization to versions that run on node 16.

This pull request:

* Updates `redhat-actions/openshift-tools-installer@v1` to `v1.12`
* Updates `redhat-actions/oc-login@v1` to `v1.2`
* Updates `redhat-actions/chart-verifier@v1.1` to `v1.2`


https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/