### PR TITLE
Extract repo path regex matching to a single library and reconfigure scripts to use it

### DIFF
--- a/scripts/src/checkprcontent/checkpr.py
+++ b/scripts/src/checkprcontent/checkpr.py
@@ -8,6 +8,8 @@ import requests
 import semver
 import yaml
 
+from reporegex import matchers
+
 try:
     from yaml import CLoader as Loader
 except ImportError:
@@ -20,7 +22,6 @@ from pullrequest import prartifact
 from tools import gitutils
 
 ALLOW_CI_CHANGES = "allow/ci-changes"
-TYPE_MATCH_EXPRESSION = "(partners|redhat|community)"
 
 
 def check_web_catalog_only(report_in_pr, num_files_in_pr, report_file_match):
@@ -109,15 +110,11 @@ def get_file_match_compiled_patterns():
     charts/partners/hashicorp/vault/0.20.0//report.yaml
     """
 
-    pattern = re.compile(
-        r"charts/" + TYPE_MATCH_EXPRESSION + "/([\w-]+)/([\w-]+)/([\w\.-]+)/.*"
-    )
-    reportpattern = re.compile(
-        r"charts/" + TYPE_MATCH_EXPRESSION + "/([\w-]+)/([\w-]+)/([\w\.-]+)/report.yaml"
-    )
-    tarballpattern = re.compile(
-        r"charts/(partners|redhat|community)/([\w-]+)/([\w-]+)/([\w\.-]+)/(.*\.tgz$)"
-    )
+    base = matchers.submission_path_matcher()
+
+    pattern = re.compile(base + r"/.*")
+    reportpattern = re.compile(base + r"/report.yaml")
+    tarballpattern = re.compile(base + r"/(.*\.tgz$)")
     return pattern, reportpattern, tarballpattern
 
 
@@ -151,7 +148,7 @@ def ensure_only_chart_is_modified(api_url, repository, branch):
                     _, _, chart_name, chart_version, tar_name = tar_match.groups()
                     expected_tar_name = f"{chart_name}-{chart_version}.tgz"
                     if tar_name != expected_tar_name:
-                        msg = f"[ERROR] the tgz file is named incorrectly. Expected: {expected_tar_name}"
+                        msg = f"[ERROR] the tgz file is named incorrectly. Expected: {expected_tar_name}. Got: {tar_name}"
                         print(msg)
                         gitutils.add_output("pr-content-error-message", msg)
                         exit(1)

--- a/scripts/src/release/releasechecker.py
+++ b/scripts/src/release/releasechecker.py
@@ -31,6 +31,7 @@ import semver
 import sys
 from release import release_info
 from release import releaser
+from reporegex import matchers
 
 sys.path.append("../")
 from owners import checkuser
@@ -38,7 +39,6 @@ from tools import gitutils
 from pullrequest import prartifact
 
 VERSION_FILE = "release/release_info.json"
-TYPE_MATCH_EXPRESSION = "(partners|redhat|community)"
 CHARTS_PR_BASE_REPO = gitutils.CHARTS_REPO
 CHARTS_PR_HEAD_REPO = gitutils.CHARTS_REPO
 DEV_PR_BASE_REPO = gitutils.DEVELOPMENT_REPO
@@ -69,7 +69,7 @@ def check_file_in_pr(api_url, pattern, error_value):
 def check_if_only_charts_are_included(api_url):
     print("[INFO] check if only chart files are included")
     chart_pattern = re.compile(
-        r"charts/" + TYPE_MATCH_EXPRESSION + "/([\w-]+)/([\w-]+)/.*"
+        matchers.submission_path_matcher(include_version_matcher=False) + r"./*"
     )
     return check_file_in_pr(api_url, chart_pattern, ERROR_IF_MATCH_NOT_FOUND)
 
@@ -77,7 +77,7 @@ def check_if_only_charts_are_included(api_url):
 def check_if_no_charts_are_included(api_url):
     print("[INFO] check if no chart files are included")
     chart_pattern = re.compile(
-        r"charts/" + TYPE_MATCH_EXPRESSION + "/([\w-]+)/([\w-]+)/.*"
+        matchers.submission_path_matcher(include_version_matcher=False) + r"./*"
     )
     return check_file_in_pr(api_url, chart_pattern, ERROR_IF_MATCH_FOUND)
 

--- a/scripts/src/reporegex/matchers.py
+++ b/scripts/src/reporegex/matchers.py
@@ -1,0 +1,41 @@
+def submission_path_matcher(
+    base_dir="charts", strict_categories=True, include_version_matcher=True
+):
+    """Returns a regex string with various submission-related groupings.
+
+    The groupings returned (in order) are: category, organization, chart name,
+    and optionally, version.
+
+    Callers should append any relevant path matching to the end of the string
+    returned from this function. E.g. "/.*"
+
+    Args:
+        base_dir: The base path of the expression statement. Should
+          not be empty.
+        strict_categories: Whether the category matcher should match only the
+          relevant categories, or any word at all.
+        include_version_matcher: Whether or not the version matcher should be
+          appended. In some cases, the caller of this regex doesn't care about the
+          versioning detail.
+
+    Returns:
+        A regular expression-compatible string with the mentioned groupings.
+    """
+
+    relaxedCategoryMatcher = "\w+"
+    strictCategoryMatcher = "partners|redhat|community"
+
+    categoryMatcher = (
+        strictCategoryMatcher if strict_categories else relaxedCategoryMatcher
+    )
+    organizationMatcher = "[\w-]+"
+    chartMatcher = "[\w-]+"
+    versionMatcher = "[\w\.\-+]+"
+
+    matcher = (
+        rf"{base_dir}/({categoryMatcher})/({organizationMatcher})/({chartMatcher})"
+    )
+    if include_version_matcher:
+        matcher += rf"/({versionMatcher})"
+
+    return matcher

--- a/scripts/src/signedchart/signedchart.py
+++ b/scripts/src/signedchart/signedchart.py
@@ -9,6 +9,7 @@ sys.path.append("../")
 from report import verifier_report
 from owners import owners_file
 from pullrequest import prartifact
+from reporegex import matchers
 
 
 def check_and_prepare_signed_chart(api_url, report_path, owner_path, key_file_path):
@@ -41,10 +42,12 @@ def get_verifier_flags(tar_file, owners_file, temp_dir):
 def is_chart_signed(api_url, report_path):
     if api_url:
         files = prartifact.get_modified_files(api_url)
-        tgz_pattern = re.compile(r"charts/(\w+)/([\w-]+)/([\w-]+)/([\w\.-]+)/.*.tgz")
+        tgz_pattern = re.compile(
+            matchers.submission_path_matcher(strict_categories=False) + r".*.tgz"
+        )
         tgz_found = False
         prov_pattern = re.compile(
-            r"charts/(\w+)/([\w-]+)/([\w-]+)/([\w\.-]+)/.*.tgz.prov"
+            matchers.submission_path_matcher(strict_categories=False) + r".*.tgz.prov"
         )
         prov_found = False
 


### PR DESCRIPTION
In PR https://github.com/openshift-helm-charts/development/pull/269, we fixed an issue in the handling of plus sign values in our chart submission path (e.g. charts/partners/vendor/chartname/0.0.1+1/...) which was preventing us from successfully detecting valid files to modify/submit.

We fixed this in one location, but there are various locations that use nearly the same regex, some which did not include the exact same version support.

This PR extracts out the generation of that string to a library that can be called at any point.

The configurable keyword args were added simply to support the existing use cases in-repo (vs. altering those use cases). The goal here is to allow the library invocation to be compatible, and maybe iterate on how we handle matching these in the future (if needed).