### PR TITLE
Configure more locations to use the submission regex matchers

### DIFF
--- a/scripts/src/chartprreview/chartprreview.py
+++ b/scripts/src/chartprreview/chartprreview.py
@@ -23,6 +23,7 @@ from report import report_info
 from report import verifier_report
 from signedchart import signedchart
 from pullrequest import prartifact
+from reporegex import matchers
 from tools import gitutils
 
 
@@ -58,7 +59,9 @@ def get_modified_charts(directory, api_url):
     """
     print("[INFO] Get modified charts. %s" % directory)
     files = prartifact.get_modified_files(api_url)
-    pattern = re.compile(r"charts/(\w+)/([\w-]+)/([\w-]+)/([\w\.\-+]+)/.*")
+    pattern = re.compile(
+        matchers.submission_path_matcher(strict_categories=False) + r"/.*"
+    )
     for file_path in files:
         m = pattern.match(file_path)
         if m:

--- a/scripts/src/chartrepomanager/chartrepomanager.py
+++ b/scripts/src/chartrepomanager/chartrepomanager.py
@@ -24,12 +24,15 @@ from report import report_info
 from chartrepomanager import indexannotations
 from signedchart import signedchart
 from pullrequest import prartifact
+from reporegex import matchers
 from tools import gitutils
 
 
 def get_modified_charts(api_url):
     files = prartifact.get_modified_files(api_url)
-    pattern = re.compile(r"charts/(\w+)/([\w-]+)/([\w-]+)/([\w\.-]+)/.*")
+    pattern = re.compile(
+        matchers.submission_path_matcher(strict_categories=False) + r"/.*"
+    )
     for file_path in files:
         m = pattern.match(file_path)
         if m:

--- a/scripts/src/metrics/metrics.py
+++ b/scripts/src/metrics/metrics.py
@@ -11,8 +11,11 @@ sys.path.append("../")
 from indexfile import index
 from pullrequest import prepare_pr_comment as pr_comment
 from collections import OrderedDict
+from reporegex import matchers
 
-file_pattern = re.compile(r"charts/([\w-]+)/([\w-]+)/([\w\.-]+)/([\w\.-]+)/.*")
+file_pattern = re.compile(
+    matchers.submission_path_matcher(strict_categories=False) + r"/.*"
+)
 chart_downloads_event = "Chart Downloads v1.0"
 ignore_users = [
     "zonggen",


### PR DESCRIPTION
The most recent PR to update our use of submission path regex missed a couple of locations where this was being used, so this PR should address those locations.