### PR TITLE
Fix bug in PR comment generation caused by missing step ID

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -213,6 +213,7 @@ jobs:
           ../ve1/bin/get-verify-params --directory=pr --api-url=${{ github.event.pull_request._links.self.href }}
 
       - name: Install oc
+        id: install-oc
         if: ${{ steps.verify_requires.outputs.cluster_needed == 'true' }}
         uses: redhat-actions/openshift-tools-installer@v1
         with:

--- a/scripts/src/pullrequest/prepare_pr_comment.py
+++ b/scripts/src/pullrequest/prepare_pr_comment.py
@@ -107,7 +107,7 @@ def prepare_generic_fail_comment():
 
 
 def prepare_oc_install_fail_comment():
-    msg = "Unfortunately the certification process failed to install OpenShift and could not complete.\n\n"
+    msg = "Unfortunately the certification process failed to install OpenShift Client and could not complete.\n\n"
     msg += "This problem will be addressed by maintainers and no further action is required from the submitter at this time.\n\n"
     return msg
 


### PR DESCRIPTION
Addresses the bug in PR https://github.com/openshift-helm-charts/charts/issues/881 - can't close it from here because it's in the production repository. Will close it manually when this merges.

This is also marked as a **draft** because of the ongoing release. I did not want to kick off workflows while the release testing was running.

---

This PR addresses a bug in our PR commenting, where we would indicate to that user that something went wrong, and immediately merge their PR and continue as if everything had gone just fine (which it had).

This was caused by an environment variable that was never set because the link to the corresponding step (by ID) was broken. This PR addresses this, and the comment now looks correct when the OC installation failure takes place.

E.g. 

```
Thank you for submitting PR #9999 for Helm Chart Certification!

Unfortunately the certification process failed to install OpenShift Client and could not complete.

This problem will be addressed by maintainers and no further action is required from the submitter at this time.


---

For information on the certification process see:
- [Red Hat certification requirements and process for Kubernetes applications that are deployed using Helm charts.](https://redhat-connect.gitbook.io/partner-guide-for-red-hat-openshift-and-container/helm-chart-certification/overview).

For support, connect with our [Technology Partner Success Desk](https://redhat-connect.gitbook.io/red-hat-partner-connect-general-guide/managing-your-account/getting-help/technology-partner-success-desk).

/metadata {"vendor_label": "concerthall", "chart_name": "gosnappass"}
```