### PR TITLE
Better handle oc-install outcome

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -335,7 +335,7 @@ jobs:
           PR_CONTENT_ERROR_MESSAGE: ${{ steps.check_pr_content.outputs.pr-content-error-message }}
           OWNERS_ERROR_MESSAGE: ${{ steps.check_pr_content.outputs.owners-error-message }}
           COMMUNITY_MANUAL_REVIEW: ${{ steps.check_report.outputs.community_manual_review_required }}
-          OC_INSTALL_RESULT: ${{ steps.install-oc.conclusion }}
+          OC_INSTALL_RESULT: ${{ steps.install-oc.outcome }}
           VERIFIER_ERROR_MESSAGE: ${{ steps.check-verifier-result.outputs.verifier_error_message }}
         run: |
           ve1/bin/pr-comment ${{ steps.check_pr_content.outcome }} ${{ steps.run-verifier.outcome }} ${{ steps.check_report.conclusion }}

--- a/scripts/src/pullrequest/prepare_pr_comment.py
+++ b/scripts/src/pullrequest/prepare_pr_comment.py
@@ -207,7 +207,7 @@ def main():
     chart_name = open("./pr/chart").read().strip()
 
     community_manual_review = os.environ.get("COMMUNITY_MANUAL_REVIEW", False)
-    oc_install_result = os.environ.get("OC_INSTALL_RESULT", False)
+    oc_install_result = os.environ.get("OC_INSTALL_RESULT")
 
     msg = f"Thank you for submitting PR #{issue_number} for Helm Chart Certification!"
 
@@ -224,7 +224,7 @@ def main():
         and run_verifier_result in ["success", "skipped"]
         and verify_result == "success"
         # installation of oc may not run if a cluster is not needed.
-        and oc_install_result in ["success", "skipped", False]
+        and oc_install_result in ["success", "skipped"]
     ):
         outcome = "Passed"
         detail_message = append_to(detail_message, get_success_coment())


### PR DESCRIPTION
The oc-install step doesn't continue-on-error, hence we should use .outcome instead of .conclusion to check if it runned successfully, was skipped or failed.

This information is never empty, hence there is no need to default the value of this argument to False in prepare_pr_comment.py.

Closes #287