### PR TITLE
Make the PR comment accessible to the metrics step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,6 +106,7 @@ jobs:
       report_content: ${{ steps.check_report.outputs.report_content }}
       redhat_to_community: ${{ steps.check_report.outputs.redhat_to_community }}
       message_file: ${{ steps.pr_comment.outputs.message-file }}
+      message_text_base64: ${{ steps.encode_pr_comment.outputs.message-text-base64 }}
       web_catalog_only: ${{ steps.check_pr_content.outputs.web_catalog_only }}
       chart_entry_name: ${{ steps.check_pr_content.outputs.chart-entry-name }}
       release_tag: ${{ steps.check_pr_content.outputs.release_tag }}
@@ -340,6 +341,15 @@ jobs:
         run: |
           ve1/bin/pr-comment ${{ steps.check_pr_content.outcome }} ${{ steps.run-verifier.outcome }} ${{ steps.check_report.conclusion }}
 
+      # Note(komish): This step is a temporary fix for the metrics step in the next job
+      # which expects the PR comment to exist at the specified filesystem location.
+      - name: Encode PR Comment for Metrics
+        id: encode_pr_comment
+        if: ${{ always() && needs.setup.outputs.run_build == 'true' }}
+        run: |
+          commentBase64=$(base64 --wrap=0 ${{ steps.pr_comment.outputs.message-file }})
+          echo "message-text-base64=${commentBase64}" | tee -a $GITHUB_OUTPUT
+        
       - name: Comment on PR
         if: ${{ always() && needs.setup.outputs.run_build == 'true' }}
         uses: actions/github-script@v6
@@ -488,6 +498,16 @@ jobs:
           fail_on_unmatched_files: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Note(komish): This step is a temporary workaround. Metrics requires the PR comment
+      # to be available, but it is written to the filesystem in the previous job.
+      # This can be removed once the metrics execution is restructured to have access to the PR
+      # comment, or pulled out of the release job entirely.
+      - name: Retrieve PR comment for metrics
+        if: ${{ always() && needs.setup.outputs.run_build == 'true' && env.GITHUB_REPOSITORY != 'openshift-helm-charts/sandbox' }}
+        run: |
+          mkdir -p $(dirname ${{ needs.chart-verifier.outputs.message_file }})
+          echo ${{ needs.chart-verifier.outputs.message_text_base64 }} | base64 -d | tee ${{ needs.chart-verifier.outputs.message_file }}
 
       - name: Add metrics
         if: ${{ always() && needs.setup.outputs.run_build == 'true' && env.GITHUB_REPOSITORY != 'openshift-helm-charts/sandbox' }}


### PR DESCRIPTION
At the moment, Metrics reporting is failing because the PR comment it needs is no longer available in the job where it runs.

https://github.com/openshift-helm-charts/charts/actions/runs/6709583883/job/18233057391#step:11:53

I believe that the metrics step can probably be extracted out into its own execution such that it doesn't cause the release step to fail, but until that gets prioritizes, this PR pulls the PR comment contents from the `chart-verifier` task and into the `release` task by encoding it in a step of the former job, and then writing it back to the expected location in a step of the latter job.

Definitely a temporary measure, but it's a quick way to get the release tasks to start passing. At the moment, I would expect them all to fail, even though all the actual releasing activity (e.g. pushing charts, public keys, indexing) succeeded.

Once this merges, I'll probably cut a release to get this into the production pipeline, even though the content is small.