### PR TITLE
Re-add function that metric execution calls

### DIFF
--- a/scripts/src/pullrequest/prepare_pr_comment.py
+++ b/scripts/src/pullrequest/prepare_pr_comment.py
@@ -22,6 +22,10 @@ def get_failure_comment():
         "There were one or more errors while building and verifying your pull request."
     )
 
+def get_comment_header(pr_number):
+    return (
+        f"Thank you for submitting PR #{pr_number} for Helm Chart Certification!"
+    )
 
 def get_verifier_errors_comment():
     return "[ERROR] The submitted chart has failed certification. Reason(s):"
@@ -209,7 +213,7 @@ def main():
     community_manual_review = os.environ.get("COMMUNITY_MANUAL_REVIEW", False)
     oc_install_result = os.environ.get("OC_INSTALL_RESULT")
 
-    msg = f"Thank you for submitting PR #{issue_number} for Helm Chart Certification!"
+    msg = get_comment_header(issue_number)
 
     # Assemble the detail separately to control order in which it is added to
     # the overall output.


### PR DESCRIPTION
There's still a bug in the metrics collection script. Currently it's calling a function I removed. My apologies - I missed that it was being referenced by the metrics script here.

Closes https://github.com/openshift-helm-charts/development/issues/300