### PR TITLE
chore: use the same checkout configuration in test.yml as in build.yml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,10 +34,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
+          ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.sha }}
-          token: ${{ secrets.BOT_TOKEN }}
-          fetch-depth: 0
 
       - name: Set up Python 3.x Part 1
         uses: actions/setup-python@v4


### PR DESCRIPTION
Credit to @nickboldt for this work. PR has been pulled from the `openshift-helm-charts/charts` repository.


GH action https://github.com/openshift-helm-charts/charts/actions/workflows/test.yml seems to be failing for the last few PR checks. This change might solve that problem?

However I'm not auth'd to run workflow code updates on this repo:

```
  # workflow only change but user not authorized
```

So a code owner will have to run this.


References:
https://github.com/openshift-helm-charts/charts/pull/1136