### PR TITLE
Revert 'chore: use the same checkout configuration in test.yml as in build.yml (#306)'

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,8 +34,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          token: ${{ secrets.BOT_TOKEN }}
+          fetch-depth: 0
 
       - name: Set up Python 3.x Part 1
         uses: actions/setup-python@v4


### PR DESCRIPTION
This reverts commit 06f0ba1df4bea2cc2662c0c93920c1474be47eb1.

See reasoning here: https://github.com/openshift-helm-charts/development/issues/305#issuecomment-1861431769