### PR TITLE
Enable metadata assertion and chart lock generation

### DIFF
--- a/scripts/setup.cfg
+++ b/scripts/setup.cfg
@@ -47,4 +47,6 @@ console_scripts =
     pushowners=metrics.pushowners:main
     update-index=updateindex.updateindex:main
     user-is-repo-owner=owners.user_is_repo_owner:main
-
+    generate-chart-locks=packagemapping.generatelocks:main
+    extract-metadata-from-pr=pullrequest.metadata:main
+    assert-redhat-owners-file-meta=owners.redhat_metadata:main

--- a/scripts/src/owners/owners_file.py
+++ b/scripts/src/owners/owners_file.py
@@ -33,6 +33,15 @@ def get_vendor(owner_data):
     return vendor
 
 
+def get_vendor_label(owner_data):
+    vendor = ""
+    try:
+        vendor = owner_data["vendor"]["label"]
+    except Exception:
+        pass
+    return vendor
+
+
 def get_chart(owner_data):
     chart = ""
     try:

--- a/scripts/src/owners/redhat_metadata.py
+++ b/scripts/src/owners/redhat_metadata.py
@@ -58,7 +58,16 @@ def assert_redhat_metadata(contents):
 
 
 def main():
-    """The CLI entrypoint. Returns an exit code."""
+    """The CLI entrypoint.
+
+    Return codes:
+        0:  everything has gone well.
+        10: something unexpected has occurred when reading owner
+            data from disk.
+        20: The OWNERS file has invalid content.
+        90: Something unexpected has occured when asserting
+            the content of the OWNERS file.
+    """
     parser = ArgumentParser()
     parser.add_argument("category")
     parser.add_argument("organization")

--- a/scripts/src/owners/redhat_metadata.py
+++ b/scripts/src/owners/redhat_metadata.py
@@ -64,8 +64,6 @@ def main():
         0:  everything has gone well.
         10: The OWNERS file was not found.
         20: The OWNERS file has invalid content.
-        90: Something unexpected has occured when asserting
-            the content of the OWNERS file.
     """
     parser = ArgumentParser()
     parser.add_argument("category")
@@ -88,9 +86,6 @@ def main():
     except RedHatOwnersFileInvalidContentsError as e:
         print(f"[Error] Invalid contents, {e}")
         return 20
-    except Exception as e:
-        print(f"[Error] Unexpected error: {e}")
-        return 90
 
     print("[Info] LGTM!")
     return 0

--- a/scripts/src/owners/redhat_metadata.py
+++ b/scripts/src/owners/redhat_metadata.py
@@ -62,8 +62,7 @@ def main():
 
     Return codes:
         0:  everything has gone well.
-        10: something unexpected has occurred when reading owner
-            data from disk.
+        10: The OWNERS file was not found.
         20: The OWNERS file has invalid content.
         90: Something unexpected has occured when asserting
             the content of the OWNERS file.
@@ -77,12 +76,11 @@ def main():
         f"[Info] Checking OWNERS file content for {args.category}/{args.organization}/{args.chartname}"
     )
 
-    try:
-        _, ownerdata = owners_file.get_owner_data(
-            args.category, args.organization, args.chartname
-        )
-    except Exception as e:
-        print(e)
+    ownerDataFound, ownerdata = owners_file.get_owner_data(
+        args.category, args.organization, args.chartname
+    )
+    if not ownerDataFound:
+        print("[Error] OWNERS file not found")
         return 10
 
     try:

--- a/scripts/src/owners/redhat_metadata.py
+++ b/scripts/src/owners/redhat_metadata.py
@@ -1,4 +1,5 @@
 from argparse import ArgumentParser
+
 from . import owners_file
 
 REQUIRED_VENDOR_LABEL = "redhat"

--- a/scripts/src/owners/redhat_metadata.py
+++ b/scripts/src/owners/redhat_metadata.py
@@ -20,9 +20,11 @@ class RedHatOwnersFileInvalidContentsError(Exception):
 def assert_redhat_metadata(contents):
     """Ensures contents of owners file for Red Hat submissions
 
-    Red Hat submissions are expected to have certain metadata. - The owner label
-    must be "redhat" - The owner organizaton name must be "Red Hat" - The
-    chart's name must be prefixed with "redhat-"
+    Red Hat submissions are expected to have certain metadata.
+
+    - The owner label must be "redhat"
+    - The owner organizaton name must be "Red Hat"
+    - The chart's name must be prefixed with "redhat-"
 
     This raises an exception if the metadata is incorrect.
 
@@ -34,6 +36,7 @@ def assert_redhat_metadata(contents):
     Raises:
         RedHatOwnersFileInvalidContentsError: In cases where the
           content is not as expected.
+
     Returns:
         Nothing.
     """

--- a/scripts/src/owners/redhat_metadata.py
+++ b/scripts/src/owners/redhat_metadata.py
@@ -1,0 +1,89 @@
+from argparse import ArgumentParser
+from . import owners_file
+
+REQUIRED_VENDOR_LABEL = "redhat"
+REQUIRED_VENDOR_NAME = "Red Hat"
+REQUIRED_CHART_PREFIX = "redhat-"
+
+
+class RedHatOwnersFileInvalidContentsError(Exception):
+    message = "The OWNERS does not contain criteria required for Red Hatters"
+
+    def __init__(self, message):
+        if len(message) > 0:
+            self.message = message
+
+        super().__init__(self.message)
+
+
+def assert_redhat_metadata(contents):
+    """Ensures contents of owners file for Red Hat submissions
+
+    Red Hat submissions are expected to have certain metadata. - The owner label
+    must be "redhat" - The owner organizaton name must be "Red Hat" - The
+    chart's name must be prefixed with "redhat-"
+
+    This raises an exception if the metadata is incorrect.
+
+    Args:
+        contents: The contents of the owners
+          file to be evaluated. This should have already
+          been read from disk and yaml.loaded
+
+    Raises:
+        RedHatOwnersFileInvalidContentsError: In cases where the
+          content is not as expected.
+    Returns:
+        Nothing.
+    """
+
+    if not owners_file.get_chart(contents).startswith(REQUIRED_CHART_PREFIX):
+        raise RedHatOwnersFileInvalidContentsError(
+            f"The chart name must be prefixed with '{REQUIRED_CHART_PREFIX}'."
+        )
+
+    if owners_file.get_vendor_label(contents) != REQUIRED_VENDOR_LABEL:
+        raise RedHatOwnersFileInvalidContentsError(
+            f"OWNERS file did not have expected vendor label: '{REQUIRED_VENDOR_LABEL}'"
+        )
+
+    if owners_file.get_vendor(contents) != REQUIRED_VENDOR_NAME:
+        raise RedHatOwnersFileInvalidContentsError(
+            f"OWNERS file did not have expected vendor name: '{REQUIRED_VENDOR_NAME}'"
+        )
+
+
+def main():
+    """The CLI entrypoint. Returns an exit code."""
+    parser = ArgumentParser()
+    parser.add_argument("category")
+    parser.add_argument("organization")
+    parser.add_argument("chartname")
+    args = parser.parse_args()
+    print(
+        f"[Info] Checking OWNERS file content for {args.category}/{args.organization}/{args.chartname}"
+    )
+
+    try:
+        _, ownerdata = owners_file.get_owner_data(
+            args.category, args.organization, args.chartname
+        )
+    except Exception as e:
+        print(e)
+        return 10
+
+    try:
+        assert_redhat_metadata(ownerdata)
+    except RedHatOwnersFileInvalidContentsError as e:
+        print(f"[Error] Invalid contents, {e}")
+        return 20
+    except Exception as e:
+        print(f"[Error] Unexpected error: {e}")
+        return 90
+
+    print("[Info] LGTM!")
+    return 0
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/src/owners/redhat_metadata.py
+++ b/scripts/src/owners/redhat_metadata.py
@@ -1,6 +1,6 @@
 from argparse import ArgumentParser
 
-from . import owners_file
+from owners import owners_file
 
 REQUIRED_VENDOR_LABEL = "redhat"
 REQUIRED_VENDOR_NAME = "Red Hat"

--- a/scripts/src/packagemapping/generatelocks.py
+++ b/scripts/src/packagemapping/generatelocks.py
@@ -1,0 +1,106 @@
+from glob import glob
+import sys
+import yaml
+import re
+from datetime import datetime, timezone
+from json import dumps as to_json
+
+
+def ownerfile_regex():
+    """Return a regex statement that parses relative filepaths of an OWNERS file.
+
+    The filepath is expected to be from the charts directory forward.
+
+    Returns:
+        The compiled regex that groups the category, organization, and chart name.
+
+        E.g. category | organization | chartname
+             partner  | hashicorp    | vault
+    """
+
+    pattern = re.compile(r"charts/(partners|redhat|community)/([\w-]+)/([\w-]+)/OWNERS")
+    return pattern
+
+
+def logError(msg, file=sys.stderr):
+    """logError just prints the msg with an ERROR caption to stderr unless otherwise defined"""
+    print(f"[ERROR] {msg}", file=file)
+
+
+def logInfo(msg, file=sys.stderr):
+    """logError just prints the msg with an INFO caption to stderr unless otherwise defined"""
+    print(f"[INFO] {msg}", file=file)
+
+
+def logWarn(msg, file=sys.stderr):
+    """logWarn just prints the msg with an INFO caption to stderr unless otherwise defined"""
+    print(f"[WARN] {msg}", file=file)
+
+
+def main():
+    packages = {}
+    for filename in glob("charts/**/OWNERS", recursive=True):
+        logInfo(f"processing file {filename}")
+        pattern = ownerfile_regex()
+        matched = pattern.match(filename)
+        if matched is None:
+            # TODO(komish): Consider if we need to have a flag that exits and otherwise make this a warning
+            # For now, we fail here because it means we have a an invalid directory path and therefore can't determine our
+            # category, org, or repo from the path.
+            logError(
+                f"did not successfully parse the input. Did you run this in the right place? filename: {filename}",
+            )
+            # continue
+            sys.exit(1)
+
+        category, organization, chart = matched.groups()
+        if category is None or organization is None or chart is None:
+            logError(
+                f"did not successfully parse the input filename: {filename}",
+                "expecting format charts/{category}/{organization}/{chartname}/OWNERS. Did you run this in the right place?",
+            )
+            sys.exit(1)
+
+        with open(filename, "r") as f:
+            d = yaml.load(f.read(), Loader=yaml.BaseLoader)
+            owners_value_chart_name = d["chart"]["name"]
+            owners_value_vendor_label = d["vendor"]["label"]
+
+        if owners_value_chart_name != chart:
+            logError(
+                f"the chart name in the OWNERS file did not match the chart name directory structure. OWNERS_FILE_VALUE={owners_value_chart_name}, DIRECTORY_VALUE:{chart}"
+            )
+
+        if owners_value_vendor_label != organization:
+            logError(
+                f"the vendor label in the OWNERS file did not match the organization name directory structure. OWNERS_FILE_VALUE={owners_value_chart_name}, DIRECTORY_VALUE:{chart}"
+            )
+
+        new_entry = f"{category}/{organization}/{chart}"
+        if packages.get(chart, None) is not None:
+            logError(
+                f"Duplicate chart name detected. Unable to build unique package list. trying to add: {new_entry}, current_value: {packages[chart]}"
+            )
+            sys.exit(2)
+
+        packages[chart] = new_entry
+
+    if len(packages.keys()) == 0:
+        logError("the package map contained no items!")
+        sys.exit(3)
+
+    now = datetime.now(timezone.utc).astimezone().isoformat()
+
+    print(
+        to_json(
+            {
+                "generated": now,
+                "packages": packages,
+            },
+            sort_keys=True,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/src/packagemapping/generatelocks.py
+++ b/scripts/src/packagemapping/generatelocks.py
@@ -48,6 +48,7 @@ def main():
         10: Parsing failure for the input path to a given OWNERS file.
         20: One of the expected directory values is empty.
         30: The OWNERS file at the provided path did not load correctly.
+        35: The OWNERS file content and the directory structure are mismatched.
         40: A duplicate chart name entry has been found.
         50: The resulting data contained no entries, which
             is certainly unexpected.
@@ -85,11 +86,13 @@ def main():
             logError(
                 f"the chart name in the OWNERS file did not match the chart name directory structure. OWNERS_FILE_VALUE={owners_value_chart_name}, DIRECTORY_VALUE:{chart}"
             )
+            return 35
 
         if owners_value_vendor_label != organization:
             logError(
                 f"the vendor label in the OWNERS file did not match the organization name directory structure. OWNERS_FILE_VALUE={owners_value_chart_name}, DIRECTORY_VALUE:{chart}"
             )
+            return 35
 
         new_entry = f"{category}/{organization}/{chart}"
         if packages.get(chart) is not None:

--- a/scripts/src/packagemapping/generatelocks.py
+++ b/scripts/src/packagemapping/generatelocks.py
@@ -1,9 +1,10 @@
-from glob import glob
-import sys
-import yaml
 import re
+import sys
 from datetime import datetime, timezone
+from glob import glob
 from json import dumps as to_json
+
+import yaml
 
 
 def ownerfile_regex():

--- a/scripts/src/packagemapping/generatelocks.py
+++ b/scripts/src/packagemapping/generatelocks.py
@@ -34,7 +34,7 @@ def logInfo(msg, file=sys.stderr):
 
 
 def logWarn(msg, file=sys.stderr):
-    """logWarn just prints the msg with an INFO caption to stderr unless otherwise defined"""
+    """logWarn just prints the msg with an WARN caption to stderr unless otherwise defined"""
     print(f"[WARN] {msg}", file=file)
 
 

--- a/scripts/src/packagemapping/generatelocks.py
+++ b/scripts/src/packagemapping/generatelocks.py
@@ -4,7 +4,7 @@ from datetime import datetime, timezone
 from glob import glob
 from json import dumps as to_json
 
-import yaml
+from owners import owners_file
 
 
 def ownerfile_regex():
@@ -39,20 +39,29 @@ def logWarn(msg, file=sys.stderr):
 
 
 def main():
+    """Generates a mapping of chart names to their associated paths.
+
+    Prints the resulting output as a JSON blob.
+
+    Return codes:
+        0:  All is well.
+        10: Parsing failure for the input path to a given OWNERS file.
+        20: One of the expected directory values is empty.
+        30: The OWNERS file at the provided path did not load correctly.
+        40: A duplicate chart name entry has been found.
+        50: The resulting data contained no entries, which
+            is certainly unexpected.
+    """
     packages = {}
     for filename in glob("charts/**/OWNERS", recursive=True):
         logInfo(f"processing file {filename}")
         pattern = ownerfile_regex()
         matched = pattern.match(filename)
         if matched is None:
-            # TODO(komish): Consider if we need to have a flag that exits and otherwise make this a warning
-            # For now, we fail here because it means we have a an invalid directory path and therefore can't determine our
-            # category, org, or repo from the path.
             logError(
                 f"did not successfully parse the input. Did you run this in the right place? filename: {filename}",
             )
-            # continue
-            sys.exit(1)
+            return 10
 
         category, organization, chart = matched.groups()
         if category is None or organization is None or chart is None:
@@ -60,12 +69,17 @@ def main():
                 f"did not successfully parse the input filename: {filename}",
                 "expecting format charts/{category}/{organization}/{chartname}/OWNERS. Did you run this in the right place?",
             )
-            sys.exit(1)
+            return 20
 
-        with open(filename, "r") as f:
-            d = yaml.load(f.read(), Loader=yaml.BaseLoader)
-            owners_value_chart_name = d["chart"]["name"]
-            owners_value_vendor_label = d["vendor"]["label"]
+        ownersContentLoaded, ownersContent = owners_file.get_owners_data_from_file(
+            filename
+        )
+        if not ownersContentLoaded:
+            logError(f"Failed to load OWNERS file content. filename: {filename}")
+            return 30
+
+        owners_value_chart_name = owners_file.get_chart(ownersContent)
+        owners_value_vendor_label = owners_file.get_vendor_label(ownersContent)
 
         if owners_value_chart_name != chart:
             logError(
@@ -82,13 +96,13 @@ def main():
             logError(
                 f"Duplicate chart name detected. Unable to build unique package list. trying to add: {new_entry}, current_value: {packages[chart]}"
             )
-            sys.exit(2)
+            return 40
 
         packages[chart] = new_entry
 
     if len(packages.keys()) == 0:
         logError("the package map contained no items!")
-        sys.exit(3)
+        return 50
 
     now = datetime.now(timezone.utc).astimezone().isoformat()
 

--- a/scripts/src/packagemapping/generatelocks.py
+++ b/scripts/src/packagemapping/generatelocks.py
@@ -92,7 +92,7 @@ def main():
             )
 
         new_entry = f"{category}/{organization}/{chart}"
-        if packages.get(chart, None) is not None:
+        if packages.get(chart) is not None:
             logError(
                 f"Duplicate chart name detected. Unable to build unique package list. trying to add: {new_entry}, current_value: {packages[chart]}"
             )

--- a/scripts/src/pullrequest/metadata.py
+++ b/scripts/src/pullrequest/metadata.py
@@ -1,11 +1,12 @@
+import json
 import re
 import sys
-import json
+from argparse import ArgumentParser
+
+from reporegex import matchers
+from tools import gitutils
 
 from . import prartifact
-from tools import gitutils
-from reporegex import matchers
-from argparse import ArgumentParser
 
 
 class NoMatchesError(Exception):

--- a/scripts/src/pullrequest/metadata.py
+++ b/scripts/src/pullrequest/metadata.py
@@ -6,7 +6,7 @@ from argparse import ArgumentParser
 from reporegex import matchers
 from tools import gitutils
 
-from . import prartifact
+from pullrequest import prartifact
 
 
 class NoMatchesError(Exception):
@@ -82,6 +82,13 @@ def extract_from_path_for_pr(pr_api_url):
 
 
 def main():
+    """CLI for determining the the cat/org/chart being modified.
+
+    Return codes:
+        0:  No problems.
+        10: Multiple matches were found.
+        20: No matches were found.
+    """
     parser = ArgumentParser(
         description="""Read the modified files from a GitHub Pull Requests
 and determine the category, organization, and chartname being modified.
@@ -131,9 +138,6 @@ subsequent path to determine the category, organization, and chart name.
             return 0
         print(f"[Error] {e}", file=sys.stderr)
         return 20
-    except Exception as e:
-        print("[Error] Something unexpected went wrong", e, file=sys.stderr)
-        return 90
 
     print(
         json.dumps(

--- a/scripts/src/pullrequest/metadata.py
+++ b/scripts/src/pullrequest/metadata.py
@@ -1,0 +1,150 @@
+import re
+import sys
+import json
+
+from . import prartifact
+from tools import gitutils
+from reporegex import matchers
+from argparse import ArgumentParser
+
+
+class NoMatchesError(Exception):
+    def __init__(self):
+        super().__init__(
+            "no file modifications within the chart submission path were detected in this pr"
+        )
+
+
+class MultipleMatchesError(Exception):
+    def __init__(self, first_match, subsequent_match):
+        super().__init__(
+            "pull request contained modifications to files associated with multiple charts"
+        )
+        self.first_match = first_match
+        self.second_match = subsequent_match
+
+
+def extract_from_path_for_pr(pr_api_url):
+    """Extracts chart submission metadata from modified files in a pull request.
+
+    This will check all filenames contained in a given PR and try to extract the
+    category, organization, and chart name from the path.
+
+    Notably, this functionality does NOT pull version information for any submission.
+
+    Args:
+        pr_api_url (str): URL of the GitHub PR
+
+    Raises:
+        NoMatchesError: In cases where the PR did not contain any files that
+          matched the expected format for a chart contribution.
+        MultipleMatchesError: In cases where the PR contained changes to multiple
+          charts, which is explicitly forbidden.
+
+    Returns:
+        Returns the category, organization, and name. E.g. "partner",
+        "hashicorp", "vault".
+    """
+
+    modified_files = prartifact.get_modified_files(pr_api_url)
+    first_match = None
+    modification_matcher = re.compile(
+        matchers.submission_path_matcher(
+            strict_categories=True, include_version_matcher=False
+        )
+    )
+    for file in modified_files:
+        match = modification_matcher.match(file)
+        if not match:
+            continue
+
+        # Store the value of our groupings the first time we match
+        # so that we can track if it changes.
+        if not first_match:
+            first_match = match
+            continue
+
+        if match.groups() != first_match.groups():
+            raise MultipleMatchesError(
+                first_match=first_match.groups(),
+                subsequent_match=match.groups(),
+            )
+
+    # We didn't find a match, so we need to bail.
+    if not first_match:
+        raise NoMatchesError
+
+    cat, org, name = first_match.groups()
+    # normalize the partners directory to partner
+    cat = "partner" if cat == "partners" else cat
+    return cat, org, name
+
+
+def main():
+    parser = ArgumentParser(
+        description="""Read the modified files from a GitHub Pull Requests
+and determine the category, organization, and chartname being modified.
+
+This information is extracted from the relative path of the files being
+modified. Specifically, this reviews the charts/ directory and looks for the
+subsequent path to determine the category, organization, and chart name.
+"""
+    )
+    parser.add_argument(
+        "api_url",
+        help="The API URL for a given pull request. E.g. https://api.github.com/repos/openshift-helm-charts/charts/pulls/1",
+        type=str,
+    )
+    parser.add_argument(
+        "-g",
+        "--emit-to-github-output",
+        help="Sends keys and values to the $GITHUB_OUTPUT.",
+        default=False,
+        dest="emit_to_github",
+        action="store_true",
+    )
+    parser.add_argument(
+        "--ignore-error-no-matches",
+        help="When enabled, returns a zero exit code instead of a non-zero for cases where no matches were found",
+        dest="ignore_no_matches",
+        action="store_true",
+        default=False,
+    )
+    args = parser.parse_args()
+    try:
+        category, organization, chartname = extract_from_path_for_pr(args.api_url)
+    except MultipleMatchesError as e:
+        print(
+            f"[Error] {e}",
+            f"First Match: {e.first_match}",
+            f"Second Match: {e.second_match}",
+            file=sys.stderr,
+        )
+        return 10
+    except NoMatchesError as e:
+        if args.ignore_no_matches:
+            print(
+                "[Info] No metadata was found in the pull request but `--ignore-error-no-matches` is set. Returning 0.",
+                file=sys.stderr,
+            )
+            return 0
+        print(f"[Error] {e}", file=sys.stderr)
+        return 20
+    except Exception as e:
+        print("[Error] Something unexpected went wrong", e, file=sys.stderr)
+        return 90
+
+    print(
+        json.dumps(
+            {"category": category, "organization": organization, "chartname": chartname}
+        )
+    )
+
+    if args.emit_to_github:
+        gitutils.add_output("category", category)
+        gitutils.add_output("organization", organization)
+        gitutils.add_output("chart-name", chartname)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/src/pullrequest/metadata.py
+++ b/scripts/src/pullrequest/metadata.py
@@ -111,13 +111,6 @@ subsequent path to determine the category, organization, and chart name.
         dest="emit_to_github",
         action="store_true",
     )
-    parser.add_argument(
-        "--ignore-error-no-matches",
-        help="When enabled, returns a zero exit code instead of a non-zero for cases where no matches were found",
-        dest="ignore_no_matches",
-        action="store_true",
-        default=False,
-    )
     args = parser.parse_args()
     try:
         category, organization, chartname = extract_from_path_for_pr(args.api_url)
@@ -130,12 +123,6 @@ subsequent path to determine the category, organization, and chart name.
         )
         return 10
     except NoMatchesError as e:
-        if args.ignore_no_matches:
-            print(
-                "[Info] No metadata was found in the pull request but `--ignore-error-no-matches` is set. Returning 0.",
-                file=sys.stderr,
-            )
-            return 0
         print(f"[Error] {e}", file=sys.stderr)
         return 20
 


### PR DESCRIPTION
- The owners module changes enables parsing Red Hat OWNERS files and asserting that metadata meets new expectations of the content.

- The packagemapping module provides hooks to generating chart locks based on the content of a given repository's charts/ directory.

- The pullrequest module changes facilitates asserting metadata given a pull request as an input.

- Entrypoints are then added to setup.cfg to simplify calling of this new logic in CI.

Depends on https://github.com/openshift-helm-charts/development/pull/313 for Python Style to pass.