### PR TITLE
Add tool-enforced import sorting

### DIFF
--- a/scripts/ruff.toml
+++ b/scripts/ruff.toml
@@ -1,4 +1,7 @@
 ignore = [
     "E402", # import ordering (komish): import ordering isn't handled by Black so we need to handle this manually.
     "E501", # line length (komish): line length is not enforced by Black so we need to handle these manually.
-] 
+]
+
+# Enable the isort rules.
+extend-select = ["I"]

--- a/scripts/src/chartprreview/chartprreview.py
+++ b/scripts/src/chartprreview/chartprreview.py
@@ -1,17 +1,16 @@
-import re
+import argparse
+import hashlib
 import os
 import os.path
-import sys
-import argparse
+import re
 import subprocess
-import hashlib
+import sys
 
-from environs import Env
-
-import semver
-import semantic_version
 import requests
+import semantic_version
+import semver
 import yaml
+from environs import Env
 
 try:
     from yaml import CLoader as Loader
@@ -19,11 +18,10 @@ except ImportError:
     from yaml import Loader
 
 sys.path.append("../")
-from report import report_info
-from report import verifier_report
-from signedchart import signedchart
 from pullrequest import prartifact
 from reporegex import matchers
+from report import report_info, verifier_report
+from signedchart import signedchart
 from tools import gitutils
 
 

--- a/scripts/src/chartprreview/chartprreview_test.py
+++ b/scripts/src/chartprreview/chartprreview_test.py
@@ -1,8 +1,12 @@
 import os
+
 import pytest
-from chartprreview.chartprreview import verify_user
-from chartprreview.chartprreview import check_owners_file_against_directory_structure
-from chartprreview.chartprreview import write_error_log
+
+from chartprreview.chartprreview import (
+    check_owners_file_against_directory_structure,
+    verify_user,
+    write_error_log,
+)
 
 
 def test_verify_user():

--- a/scripts/src/chartrepomanager/chartrepomanager.py
+++ b/scripts/src/chartrepomanager/chartrepomanager.py
@@ -22,30 +22,32 @@ update occurs in a later step.
 import argparse
 import base64
 import json
-import shutil
 import os
-import sys
 import re
+import shutil
 import subprocess
+import sys
 import tempfile
 import time
 import urllib.parse
-from environs import Env
 
 import yaml
+from environs import Env
 
 try:
-    from yaml import CLoader as Loader, CDumper as Dumper
+    from yaml import CDumper as Dumper
+    from yaml import CLoader as Loader
 except ImportError:
-    from yaml import Loader, Dumper
+    from yaml import Dumper, Loader
 
 sys.path.append("../")
-from report import report_info
-from chartrepomanager import indexannotations
-from signedchart import signedchart
 from pullrequest import prartifact
 from reporegex import matchers
+from report import report_info
+from signedchart import signedchart
 from tools import gitutils
+
+from chartrepomanager import indexannotations
 
 
 def _encode_chart_entry(chart_entry):

--- a/scripts/src/chartrepomanager/indexannotations.py
+++ b/scripts/src/chartrepomanager/indexannotations.py
@@ -1,4 +1,5 @@
 import sys
+
 import semantic_version
 
 sys.path.append("../")

--- a/scripts/src/checkautomerge/checkautomerge.py
+++ b/scripts/src/checkautomerge/checkautomerge.py
@@ -1,7 +1,7 @@
-import time
-import sys
 import argparse
 import os
+import sys
+import time
 
 import requests
 

--- a/scripts/src/checkprcontent/checkpr.py
+++ b/scripts/src/checkprcontent/checkpr.py
@@ -1,13 +1,12 @@
-import re
-import os
-import sys
 import argparse
 import json
+import os
+import re
+import sys
 
 import requests
 import semver
 import yaml
-
 from reporegex import matchers
 
 try:
@@ -17,8 +16,8 @@ except ImportError:
 
 sys.path.append("../")
 from owners import owners_file
-from report import verifier_report
 from pullrequest import prartifact
+from report import verifier_report
 from tools import gitutils
 
 ALLOW_CI_CHANGES = "allow/ci-changes"

--- a/scripts/src/indexfile/index.py
+++ b/scripts/src/indexfile/index.py
@@ -1,8 +1,9 @@
 import json
-import requests
-import yaml
-import semantic_version
 import sys
+
+import requests
+import semantic_version
+import yaml
 
 sys.path.append("../")
 

--- a/scripts/src/metrics/metrics.py
+++ b/scripts/src/metrics/metrics.py
@@ -1,16 +1,18 @@
 import argparse
 import itertools
-import requests
-import sys
-import analytics
 import os
 import re
+import sys
+
+import analytics
+import requests
 from github import Github
 
 sys.path.append("../")
+from collections import OrderedDict
+
 from indexfile import index
 from pullrequest import prepare_pr_comment as pr_comment
-from collections import OrderedDict
 from reporegex import matchers
 
 file_pattern = re.compile(

--- a/scripts/src/metrics/pushowners.py
+++ b/scripts/src/metrics/pushowners.py
@@ -1,5 +1,6 @@
 import argparse
 import sys
+
 import analytics
 
 sys.path.append("../")

--- a/scripts/src/owners/checkuser.py
+++ b/scripts/src/owners/checkuser.py
@@ -10,10 +10,11 @@ results:
     exit code 1 if pull request contains restricted files and user is not authorized to modify them.
 """
 
-import re
 import argparse
 import os
+import re
 import sys
+
 import yaml
 
 try:
@@ -23,7 +24,6 @@ except ImportError:
 
 sys.path.append("../")
 from pullrequest import prartifact
-
 
 OWNERS_FILE = "OWNERS"
 VERSION_FILE = "release/release_info.json"

--- a/scripts/src/owners/user_is_repo_owner.py
+++ b/scripts/src/owners/user_is_repo_owner.py
@@ -11,6 +11,7 @@ Any other non-zero is considered a failed execution (contextually, something bro
 
 import os
 import sys
+
 import yaml
 
 try:

--- a/scripts/src/pullrequest/prartifact.py
+++ b/scripts/src/pullrequest/prartifact.py
@@ -1,8 +1,8 @@
-import os
-import sys
 import argparse
-import shutil
+import os
 import pathlib
+import shutil
+import sys
 
 import requests
 

--- a/scripts/src/pullrequest/prepare_pr_comment.py
+++ b/scripts/src/pullrequest/prepare_pr_comment.py
@@ -1,5 +1,6 @@
 import os
 import sys
+
 from tools import gitutils
 
 

--- a/scripts/src/release/release_info.py
+++ b/scripts/src/release/release_info.py
@@ -8,7 +8,6 @@ Provides get functions for all data in the release_info.json file.
 import json
 import os
 
-
 RELEASE_INFO_FILE = "release/release_info.json"
 
 RELEASE_INFOS = {}

--- a/scripts/src/release/releasechecker.py
+++ b/scripts/src/release/releasechecker.py
@@ -22,20 +22,21 @@ results:
         PR_release_image : The name of the image from the version file from main branch.
 """
 
-import re
-import os
 import argparse
 import json
-import semver
+import os
+import re
 import sys
-from release import release_info
-from release import releaser
+
+import semver
 from reporegex import matchers
+
+from release import release_info, releaser
 
 sys.path.append("../")
 from owners import checkuser
-from tools import gitutils
 from pullrequest import prartifact
+from tools import gitutils
 
 VERSION_FILE = "release/release_info.json"
 CHARTS_PR_BASE_REPO = gitutils.CHARTS_REPO

--- a/scripts/src/release/releaser.py
+++ b/scripts/src/release/releaser.py
@@ -20,10 +20,11 @@ to the charts and development repositories.
 
 """
 
-import os
 import argparse
-import sys
+import os
 import shutil
+import sys
+
 from release import release_info
 
 sys.path.append("../")

--- a/scripts/src/report/get_verify_params.py
+++ b/scripts/src/report/get_verify_params.py
@@ -1,6 +1,6 @@
+import argparse
 import os
 import sys
-import argparse
 
 sys.path.append("../")
 from chartprreview import chartprreview

--- a/scripts/src/report/report_info.py
+++ b/scripts/src/report/report_info.py
@@ -1,8 +1,9 @@
-import os
-import sys
-import docker
 import json
+import os
 import subprocess
+import sys
+
+import docker
 
 REPORT_ANNOTATIONS = "annotations"
 REPORT_RESULTS = "results"

--- a/scripts/src/report/verifier_report.py
+++ b/scripts/src/report/verifier_report.py
@@ -24,8 +24,8 @@ These are not comprehensive lists - other certification checks will preform furt
 """
 
 import sys
-import semantic_version
 
+import semantic_version
 import yaml
 
 try:

--- a/scripts/src/saforcertadmin/push_secrets.py
+++ b/scripts/src/saforcertadmin/push_secrets.py
@@ -20,14 +20,15 @@ Example Usage:
 
 """
 
-from base64 import b64encode
-from nacl import encoding, public
+import argparse
+import json
 import logging
 import os
 import sys
-import json
+from base64 import b64encode
+
 import requests
-import argparse
+from nacl import encoding, public
 
 sys.path.append("../")
 from pullrequest import prartifact

--- a/scripts/src/saforcharttesting/saforcharttesting.py
+++ b/scripts/src/saforcharttesting/saforcharttesting.py
@@ -1,12 +1,12 @@
-import sys
-import time
-import os
+import argparse
 import base64
 import json
-import argparse
-import subprocess
-import tempfile
+import os
 import re
+import subprocess
+import sys
+import tempfile
+import time
 from string import Template
 
 namespace_template = """\

--- a/scripts/src/signedchart/signedchart.py
+++ b/scripts/src/signedchart/signedchart.py
@@ -1,15 +1,15 @@
-import sys
-import subprocess
 import base64
 import filecmp
 import os
 import re
+import subprocess
+import sys
 
 sys.path.append("../")
-from report import verifier_report
 from owners import owners_file
 from pullrequest import prartifact
 from reporegex import matchers
+from report import verifier_report
 
 
 def check_and_prepare_signed_chart(api_url, report_path, owner_path, key_file_path):

--- a/scripts/src/tools/gitutils.py
+++ b/scripts/src/tools/gitutils.py
@@ -11,9 +11,10 @@ main functions :
 - commit_development_change - directly commits changes to the main branch of the devlopment repository
 """
 
+import json
 import os
 import sys
-import json
+
 import requests
 from git import Repo
 

--- a/scripts/src/updateindex/updateindex.py
+++ b/scripts/src/updateindex/updateindex.py
@@ -6,17 +6,18 @@ import base64
 import hashlib
 import json
 import os
-import requests
 import sys
-import yaml
-
 from datetime import datetime, timezone
+
+import requests
+import yaml
 from environs import Env
 
 try:
-    from yaml import CLoader as Loader, CDumper as Dumper
+    from yaml import CDumper as Dumper
+    from yaml import CLoader as Loader
 except ImportError:
-    from yaml import Loader, Dumper
+    from yaml import Dumper, Loader
 
 
 def _decode_chart_entry(chart_entry_encoded):

--- a/scripts/src/workflowtesting/checkprforci.py
+++ b/scripts/src/workflowtesting/checkprforci.py
@@ -1,8 +1,9 @@
-import re
 import argparse
 import os
-import yaml
+import re
 import sys
+
+import yaml
 
 try:
     from yaml import CLoader as Loader


### PR DESCRIPTION
This PR extends the Ruff configuration to add a barebones, mostly isort-compatible import sorting linter. With the `ruff check --fix` flag, this sorts imports in-place in a similar style. Reasonable to expect: alphabetical per group, E.g. stdlib, local, external)