### PR TITLE
Adds composite actions to generate and check locks

### DIFF
--- a/.github/actions/check-chart-locks/action.yml
+++ b/.github/actions/check-chart-locks/action.yml
@@ -1,0 +1,63 @@
+name: Check For Lock
+description: |
+  Checks for the existence of chart-name in a given chart lock file. If a chart
+  is found to be locked at the URL searched, the lockpath is returned should the
+  caller need it for further evaluation.
+
+  Designed to work with OWNERS file merges to prevent chart naming conflicts.
+inputs:
+  # e.g. vault
+  chart-name:
+    required: true
+    description:
+      Check the lock status of this chart by name.
+  fail-workflow-if-locked:
+    required: false
+    default: 'false'
+    description: |
+      Forces a failure of this action when the chart is locked. Must explicitly
+      be set to the value 'true'. All other values (even a boolean true) are
+      considered false.
+outputs:
+  # e.g. true/false
+  chart-is-locked:
+    description: Whether the chart provided via the chart-name input is locked
+    value: ${{ steps.set-lock-state.outputs.chart-is-locked }}
+  # e.g. charts/category/vendor/chartname if package-is-locked is true, else null
+  locked-to-path:
+    description: The path to which a locked chart is locked.
+    value: ${{ steps.check-for-chart-lock.outputs.locked-to-path }}
+runs:
+  using: composite
+  steps:
+  - name: Generate Locks
+    id: generate-locks
+    uses: ./.github/actions/generate-chart-locks
+  - name: Check lockfile for chart lock
+    id: check-for-chart-lock
+    shell: bash
+    run: |
+      set -e
+      echo "Ensuring expected key exists in lock JSON."
+      jq --exit-status .packages < ${{ steps.generate-locks.outputs.lockfile-path }}
+
+      echo "Checking if chart '${{ inputs.chart-name }}' is locked."
+      LOCK_PATH=$(jq -r '.packages."${{ inputs.chart-name }}"' < ${{ steps.generate-locks.outputs.lockfile-path }})
+
+      echo "locked-to-path=${LOCK_PATH}" | tee -a $GITHUB_OUTPUT
+
+  # Defaults to a locked state as a safeguard.
+  - name: Set lock state output
+    shell: bash
+    id: set-lock-state
+    run: |
+      echo "chart-is-locked=${{ steps.check-for-chart-lock.outputs.locked-to-path != 'null' }}" | tee -a $GITHUB_OUTPUT
+
+  - name: Fail if requested and the chart is locked
+    shell: bash
+    if: |
+      inputs.fail-workflow-if-locked == 'true' &&
+      steps.set-lock-state.outputs.chart-is-locked == 'true'
+    run: |
+      echo "::error::Workflow is failing at the caller's request."
+      exit -1

--- a/.github/actions/generate-chart-locks/action.yaml
+++ b/.github/actions/generate-chart-locks/action.yaml
@@ -1,0 +1,78 @@
+name: Generate Chart Locks
+description: |
+  Generates chart locks at runtime and places the generated contents on the
+  filesystem.
+
+  For pull_request / pull_request_target events, this will pull down the branch
+  receiving the changes as the source of truth.
+
+  In the production repository, this will always pull the main branch, regardless
+  of which branch is receiving the pull request.
+
+  It is expected that the CI scripts have already been installed at call time.
+inputs:
+  to-file:
+    description: Where to write the chart-locks.json file.
+    default: "/tmp/chart-locks.json"
+    required: false
+  generator-cmd-path:
+    description: |
+      The path to the generate-chart-locks command. This action expects CI
+      scripts to be installed by the caller, and so it stands to reason the
+      caller may install scripts at various locations.
+    default: "ve1/bin/generate-chart-locks"
+    required: false
+outputs:
+  lockfile-path:
+    description: |
+      Where the lock file was written. Mostly placed as an output to simplify
+      workflows for callers.
+    value: ${{ steps.generate-chart-locks.outputs.lockfile-path }}
+runs:
+  using: composite
+  steps:
+  - name: Resolve repository ref
+    id: resolve
+    shell: bash
+    run: |
+      set -e
+
+      # PRs to the production repository will always use main.
+      if [ "${GITHUB_REPOSITORY}" == "openshift-helm-charts/charts" ]; then
+        echo "Running in the production repository."
+        echo "The only allowed ref is 'refs/heads/main'."
+        echo "ref=refs/heads/main" | tee -a $GITHUB_OUTPUT
+        exit 0
+      fi
+
+      echo "GITHUB_EVENT_NAME = '${GITHUB_EVENT_NAME}'"
+      echo "GITHUB_BASE_REF = '${GITHUB_BASE_REF}'"
+
+      # GITHUB_BASE_REF is set for pull_requests/pull_requests_targets, but empty for
+      # workflow_dispatch. We'll set it to main if it's not set.
+      resolvedRef="refs/heads/${GITHUB_BASE_REF:-"main"}"
+      echo "ref=${resolvedRef}" | tee -a $GITHUB_OUTPUT
+  - name: Checkout
+    id: clone-repository
+    uses: actions/checkout@v3
+    with:
+      ref: ${{ steps.resolve.outputs.ref }}
+      path: temp-gen-chart-lock-repo
+  - name: Setting up python
+    uses: actions/setup-python@v4
+    with:
+      python-version: "3.10"
+  - name: Generate lock file JSON from existing charts
+    working-directory: temp-gen-chart-lock-repo
+    id: generate-chart-locks
+    shell: bash
+    run: |
+      set -o pipefail
+      ${{ inputs.generator-cmd-path }} | jq | tee ${{ inputs.to-file }}
+      echo "lockfile-path=$(realpath ${{ inputs.to-file }})" | tee -a $GITHUB_OUTPUT
+  - name: Cleanup
+    id: cleanup
+    if: always()
+    shell: bash
+    run: |
+      rm -rf temp-gen-chart-lock-repo


### PR DESCRIPTION
These actions will read the given state of the repository and determine what chart names are associated with what filesystem paths. they're designed to prevent charts being stored with the same name.

These actions currently have no callers, but a non-break worfklow dispatch can be added to test their functionality before they're integrated into CI-breaking workflows.

An example of how check-chart-locks would be called:

```yaml
      - name: Check if chart name is locked
        id: determine-lock-status
        uses: ./.github/actions/check-chart-locks
        with:
          chart-name: ${{ steps.gather-metadata.outputs.chart-name }}
          fail-workflow-if-locked: 'false'
```

An example of how generate-chart-locks would be called:

```yaml
  - name: Generate Locks
    id: generate-locks
    uses: ./.github/actions/generate-chart-locks
```