### PR TITLE
Ignore pyenv cookie files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ MANIFEST
 
 # Virtual Envs
 venv.*/
+
+# For Pyenv users
+.python-version


### PR DESCRIPTION
I use Pyenv on my machine to get the right version of Python installed locally, matching GHA. This ignores the cookie file that Pyenv reads.