### PR TITLE
Adds scripts required to support OWNERS file testing and Workflow repository management.

### DIFF
--- a/tests/functional/behave_features/common/utils/chart_certification.py
+++ b/tests/functional/behave_features/common/utils/chart_certification.py
@@ -329,7 +329,7 @@ vendor:
     ):
         try:
             # Check workflow conclusion
-            run_id = get_run_id(self.secrets, pr_number)
+            run_id = get_run_id(self.secrets, WORKFLOW_CERTIFICATION_CI, pr_number)
             conclusion = get_run_result(self.secrets, run_id)
             if conclusion == expect_result:
                 logging.info(
@@ -735,7 +735,7 @@ class ChartCertificationE2ETestSingle(ChartCertificationE2ETest):
                         with open(path, "w") as fd:
                             fd.write(yaml.dump(chart))
                     except Exception as e:
-                        raise AssertionError("Failed to update version in yaml file")
+                        raise AssertionError(f"Failed to update version in yaml file: {e}")
 
     def remove_readme_file(self):
         with SetDirectory(Path(self.temp_dir.name)):

--- a/tests/functional/behave_features/common/utils/e2e_templates.py
+++ b/tests/functional/behave_features/common/utils/e2e_templates.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+"""String templates to be used for generating various files throughout E2E testing."""
+
+# The base OWNERS file string template.
+base_owners_file: str = """\
+chart:
+  name: ${chart_name}
+  shortDescription: Test chart for testing chart submission workflows.
+publicPgpKey: ${public_key}
+providerDelivery: ${provider_delivery}
+users:
+- githubUsername: ${bot_name}
+vendor:
+  label: ${vendor}
+  name: ${vendor_pretty}
+"""

--- a/tests/functional/behave_features/common/utils/owner_file_submission.py
+++ b/tests/functional/behave_features/common/utils/owner_file_submission.py
@@ -313,27 +313,29 @@ class OwnersFileSubmissionsE2ETest:
         try:
             run_id = github.get_run_id(self.secrets, workflow_name, pr_number)
             conclusion = github.get_run_result(self.secrets, run_id)
-            if conclusion == expected_result:
-                logging.info(
-                    f"PR{pr_number} Workflow run was '{expected_result}' which is expected"
-                )
-            else:
-                if failure_type == "warning":
-                    logging.warning(
-                        f"PR{pr_number if pr_number else self.secrets.pr_number} Workflow run was '{conclusion}' which is unexpected, run id: {run_id}"
-                    )
-                else:
-                    raise AssertionError(
-                        f"PR{pr_number if pr_number else self.secrets.pr_number} Workflow run was '{conclusion}' which is unexpected, run id: {run_id}"
-                    )
-
-            return run_id, conclusion
         except Exception as e:
             if failure_type == "error":
                 raise AssertionError(e)
             else:
                 logging.warning(e)
                 return None, None
+        
+        if conclusion == expected_result:
+            logging.info(
+                f"PR{pr_number} Workflow run was '{expected_result}' which is expected"
+            )
+        else:
+            if failure_type == "error":
+                raise AssertionError(
+                    f"PR{pr_number if pr_number else self.secrets.pr_number} Workflow run was '{conclusion}' which is unexpected, run id: {run_id}"
+                )
+            else:
+                logging.warning(
+                    f"PR{pr_number if pr_number else self.secrets.pr_number} Workflow run was '{conclusion}' which is unexpected, run id: {run_id}"
+                )
+
+        return run_id, conclusion
+
 
     def set_chart_name(self, basename):
         """Generates a unique chart name from basename and stores both in self.

--- a/tests/functional/behave_features/common/utils/owner_file_submission.py
+++ b/tests/functional/behave_features/common/utils/owner_file_submission.py
@@ -8,7 +8,7 @@ import uuid
 import git
 import json
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from tempfile import TemporaryDirectory
 from string import Template
 from pathlib import Path
@@ -26,11 +26,11 @@ import common.utils.setttings as settings
 class OwnersFileSubmissionsE2ETest:
     # Generated at initialization. Identifies each instance uniquely.
     # Used for PRs titles, branch names, etc.
-    uuid: str = ""
+    uuid: str = field(default_factory=lambda: uuid.uuid4().hex, init=False)
     head_sha: str = ""
     # Meaningful test name for this test, displayed in PR title
     test_name: str = ""  
-    secrets: E2ETestSecretOneShot = None
+    secrets: E2ETestSecretOneShot = field(default_factory=lambda: E2ETestSecretOneShot(), init=False)
     old_cwd: str = os.getcwd()
     # This is the worktree for this test run. To be used for context management where applicable.
     temp_dir: TemporaryDirectory = None
@@ -51,7 +51,7 @@ class OwnersFileSubmissionsE2ETest:
 
     # Manages the local repository, branches, worktress, etc.
     # and facilitates pushes to remotes.
-    repo_manager: WorkflowRepoManager = None
+    repo_manager: WorkflowRepoManager = field(default_factory=lambda: WorkflowRepoManager(), init=False)
 
     # Combines this instance's unique ID + the repository base branch hash
     branch_base_id: str = None
@@ -59,11 +59,6 @@ class OwnersFileSubmissionsE2ETest:
     def __post_init__(self) -> None:
         """Generates identifiers for an instance to use."""
         logging.debug("RedHatOwnersFileSubmissionE2ETest --> __post_init__ called!")
-        # New data for this instance.
-        self.uuid = uuid.uuid4().hex
-        self.repo_manager = WorkflowRepoManager()
-        self.secrets = E2ETestSecretOneShot()
-
         # Credentials and paths
         bot_name, bot_token = env.get_bot_name_and_token()
         test_repo = settings.TEST_REPO

--- a/tests/functional/behave_features/common/utils/owner_file_submission.py
+++ b/tests/functional/behave_features/common/utils/owner_file_submission.py
@@ -1,0 +1,351 @@
+# -*- coding: utf-8 -*-
+"""Utility class for setting up and manipulating owner file submissions"""
+
+import os
+import logging
+import pathlib
+import uuid
+import git
+import json
+
+from dataclasses import dataclass
+from tempfile import TemporaryDirectory
+from string import Template
+from pathlib import Path
+
+from common.utils.workflow_repo_manager import WorkflowRepoManager
+from common.utils.secret import E2ETestSecretOneShot
+from common.utils.set_directory import SetDirectory
+from common.utils.e2e_templates import base_owners_file
+import common.utils.github as github
+import common.utils.env as env
+import common.utils.setttings as settings
+
+
+@dataclass
+class OwnersFileSubmissionsE2ETest:
+    # Generated at initialization. Identifies each instance uniquely.
+    # Used for PRs titles, branch names, etc.
+    uuid: str = ""
+    head_sha: str = ""
+
+    test_name: str = ""  # Meaningful test name for this test, displayed in PR title
+    # test_report: str = ''
+    # chart_directory: str = ''
+    secrets: E2ETestSecretOneShot = E2ETestSecretOneShot()
+    old_cwd: str = os.getcwd()
+    # This is the worktree for this test run. To be used for context management where applicable.
+    temp_dir: TemporaryDirectory = None
+    # Whether this is being executed in GitHub Actions.
+    github_actions: str = os.environ.get("GITHUB_ACTIONS")
+    # The name of the chart as supplied by the user.
+    chart_base_name = ""
+    # The name of the chart as supplied by the user appended with a unique identifier.
+    chart_name = ""
+    # The vendor name, e.g. 'redhat'
+    vendor_label = ""
+    # The vendor category, e.g. 'partner'
+    vendor_category = ""
+    # The vendor's pretty name, e.g. 'Red Hat'
+    vendor_name = ""
+    # The PR number in string format for this test run.
+    pull_request: str = ""
+
+    # Manages the local repository, branches, worktress, etc.
+    # and facilitates pushes to remotes.
+    repo_manager: WorkflowRepoManager = None
+    repo: git.Repo = None
+
+    # Combines this instance's unique ID + the repository base branch hash
+    branch_base_id: str = None
+
+    def __post_init__(self) -> None:
+        """Generates identifiers for an instance to use."""
+        logging.debug("RedHatOwnersFileSubmissionE2ETest --> __post_init__ called!")
+        # New data for this instance.
+        self.uuid = uuid.uuid4().hex
+        self.repo_manager = WorkflowRepoManager()
+
+        # Credentials and paths
+        bot_name, bot_token = env.get_bot_name_and_token()
+        test_repo = settings.TEST_REPO
+        self.repo_manager.set_auth_token(bot_token)
+
+        # Create a new branch locally from detached HEAD
+        self.head_sha = self.repo_manager.repo.git.rev_parse("--short", "HEAD")
+        self.branch_base_id = f"{self.head_sha}-{self.uuid}"
+
+        logging.info(f"base branch identifer: {self.unique_branch()}")
+        # Create the base branch for this workflow run.
+        self.repo_manager.checkout_branch(self.unique_branch())
+        logging.debug(
+            f"Active branch name: {self.repo_manager.repo.active_branch.name}"
+        )
+
+        # Create the branch on the remote if it doesn't exist.
+        r = github.github_api("get", f"repos/{test_repo}/branches", bot_token)
+        branches = json.loads(r.text)
+        branch_names = [branch["name"] for branch in branches]
+        logging.debug(f"Remote test repo branch names : {branch_names}")
+        if self.unique_branch() not in branch_names:
+            logging.info(
+                f"{test_repo}:{self.unique_branch()} does not exists, creating with local branch"
+            )
+            self.repo_manager.push_branch(test_repo, self.unique_branch())
+
+        # Create base branch and pr branch.
+        base_branch, pr_branch = self.workflow_branches(self.test_name)
+        logging.debug(f"base branch is set to: {base_branch}")
+        logging.debug(f"pr branch is set to: {pr_branch}")
+
+        # Set "secrets"
+        #
+        # NOTE(komish): This is a carry-over from the chart certification CI.
+        # Not all items are secrets, but it's unclear why these are designated
+        # as such. Prioritizing consistency for now.
+        self.secrets.test_repo = test_repo
+        self.secrets.bot_name = bot_name
+        self.secrets.bot_token = bot_token
+        self.secrets.base_branch = base_branch
+        self.secrets.pr_branch = pr_branch
+        self.secrets.index_file = "index.yaml"
+
+        self.set_git_username_email(bot_name, settings.GITHUB_ACTIONS_BOT_EMAIL)
+        self.temp_dir = self.repo_manager.add_worktree()
+
+    def unique_branch(self) -> str:
+        """Returns this instance's unique branch name."""
+        return f"e2e-owners-{self.branch_base_id}"
+
+    def workflow_branches(self, test_name: str) -> (str, str):
+        """Returns the base_branch and pr_branch names for a given test_name."""
+        pretty_test_name = self.test_name.strip().lower().replace(" ", "-")
+        base_branch = (
+            f"{self.unique_branch()}-{pretty_test_name}"
+            if pretty_test_name
+            else f"{self.unique_branch()}-test"
+        )
+        return base_branch, f"{base_branch}-pr-branch"
+
+    def cleanup(self):
+        """Cleans up all artifacts that are created locally and remotely."""
+        logging.debug("RedHatOwnersFileSubmissionE2ETest --> cleanup called!")
+        if self.repo_manager:
+            try:
+                self.repo_manager.cleanup()
+            except Exception as e:
+                logging.error(
+                    f"failed to execute cleanup of the repo_manager with error: {e}"
+                )
+
+        # Teardown step to cleanup branches
+        if self.temp_dir is not None:
+            self.temp_dir.cleanup()
+
+        if self.repo_manager:
+            self.repo_manager.repo.git.worktree("prune")
+
+    def submission_path(self) -> str:  # charts/partner/mycompany/mychartname
+        """Composes the submission path based on the vendor_type, vendor, and chart_name values."""
+        return os.path.join(
+            "charts", self.vendor_category, self.vendor_label, self.chart_name
+        )
+
+    def set_git_username_email(self, username: str, email: str):
+        """Writes the username and email to the repo's .git/config.
+
+        Note that calling this will overwrite repository-local values, which
+        will supercede global values.
+
+        Args:
+            repo: git.Repo instance of the local directory
+            username: git username to set
+            email: git email to set
+        """
+        self.repo_manager.repo.config_writer().set_value(
+            "user", "name", username
+        ).release()
+        self.repo_manager.repo.config_writer().set_value(
+            "user", "email", email
+        ).release()
+
+    def create_and_commit_owners_file(self):
+        self.repo_manager.checkout_branch(self.secrets.base_branch)
+        self.repo_manager.push_branch(self.secrets.test_repo, self.secrets.base_branch)
+        self.repo_manager.checkout_branch(self.secrets.pr_branch)
+        return self._create_and_commit_owners_file(
+            self.submission_path(),
+            self.secrets.pr_branch,
+            self.chart_name,
+            self.vendor_label,
+            self.vendor_name,
+        )
+
+    def _create_and_commit_owners_file(
+        self,
+        chart_directory: str,
+        pr_branch: str,
+        chart_name: str,
+        vendor_label: str,
+        vendor_name: str,
+    ):
+        """Creates an OWNERS file in the PR branch."""
+        with SetDirectory(Path(self.temp_dir.name)):
+            # Create the OWNERS file from the string template
+            values = {
+                "bot_name": self.secrets.bot_name,
+                "vendor": vendor_label,
+                "vendor_pretty": vendor_name,
+                "chart_name": chart_name,
+                "public_key": "null",
+                "provider_delivery": "false",
+            }
+            content = Template(base_owners_file).substitute(values)
+            logging.debug(f"OWNERS File Content:\n{content}")
+            pathlib.Path(chart_directory).mkdir(parents=True, exist_ok=True)
+            with open(f"{chart_directory}/OWNERS", "w+") as fd:
+                fd.write(content)
+
+            logging.info(f"Push OWNERS file to '{self.secrets.test_repo}:{pr_branch}'")
+            worktree_repo = git.Repo()
+            worktree_repo.git.add(f"{chart_directory}/OWNERS")
+            worktree_repo.git.commit("-m", f"Add {chart_name} OWNERS file")
+            self.repo_manager.push_branch(
+                self.secrets.test_repo, pr_branch, repo=worktree_repo
+            )
+
+    def send_pull_request(self):
+        """Sends a pull request to be evaluated for CI."""
+        self.pull_request = self._send_pull_request(
+            self.secrets.test_repo,
+            self.secrets.base_branch,
+            self.secrets.pr_branch,
+            self.secrets.bot_token,
+            os.environ.get("PR_BODY"),
+        )
+        return self.pull_request
+
+    def _send_pull_request(
+        self,
+        remote_repo: str,
+        base_branch: str,
+        pr_branch: str,
+        gh_token: str,
+        pr_body: str,
+    ):
+        """Sends a pull request using the GitHub API.
+
+        The branches should already exist in the remotes. This only sends the
+        pull request API call referring to two pre-existing branches in
+        remote_repo.
+
+        Pull requests created with this method are not tracked for cleanup.
+        When related branches are deleted, GitHub will automatically close the PR.
+
+        Args:
+            remote_repo: the org/repo string where the PR should be pushed.
+            base_branch: the branch receiving the PR.
+            pr_branch: the modified content to send to base_branch.
+            pr_body: the text to send in the PR body.
+
+        Raises:
+            AssertionError in cases where the pull requests could not be sent.
+
+        Returns:
+            The PR number for the generated PR.
+        """
+        data = {
+            "head": pr_branch,
+            "base": base_branch,
+            "title": base_branch,
+            "body": pr_body,
+        }
+        logging.debug(f"Pull Request Body Text: {pr_body}")
+        logging.info(
+            f"Create PR from '{remote_repo}:{pr_branch}' to '{remote_repo}:{base_branch}'"
+        )
+        r = github.github_api("post", f"repos/{remote_repo}/pulls", gh_token, json=data)
+        j = json.loads(r.text)
+        if "number" not in j:
+            raise AssertionError(f"error sending pull request, response was: {r.text}")
+        return j["number"]
+
+    def check_workflow_conclusion(
+        self,
+        expected_result: str,  # the possible outcomes of a github workflow. e.g. 'success'
+    ):
+        """Checks the input workflow and reports back if expected_result doesn't match reality."""
+
+        # TODO(komish): When this testing is extended to partner/community files,
+        # setting workflow_name should be more dynamic. For now, this always looks
+        # for the Red Hat workflow because those are the only checks that exist.
+        workflow_name = settings.WORKFLOW_REDHAT_OWNERS_CHECK
+
+        return self._check_workflow_conclusion(
+            self.pull_request,
+            workflow_name,
+            expected_result,
+        )
+
+    def _check_workflow_conclusion(
+        self,
+        pr_number: str,  # '1'
+        workflow_name: str,
+        expected_result: str,  # 'success'
+        failure_type="error",
+    ):
+        """Checks the conclusion of workflow_name for expected_result via the GitHub API.
+
+        if failure_type is set to "error", this raises an exception.
+
+        Raises:
+            AssertionError if the conclusion does not match the expected_result.
+        """
+        try:
+            run_id = github.get_run_id(self.secrets, workflow_name, pr_number)
+            conclusion = github.get_run_result(self.secrets, run_id)
+            if conclusion == expected_result:
+                logging.info(
+                    f"PR{pr_number} Workflow run was '{expected_result}' which is expected"
+                )
+            else:
+                if failure_type == "warning":
+                    logging.warning(
+                        f"PR{pr_number if pr_number else self.secrets.pr_number} Workflow run was '{conclusion}' which is unexpected, run id: {run_id}"
+                    )
+                else:
+                    raise AssertionError(
+                        f"PR{pr_number if pr_number else self.secrets.pr_number} Workflow run was '{conclusion}' which is unexpected, run id: {run_id}"
+                    )
+
+            return run_id, conclusion
+        except Exception as e:
+            if failure_type == "error":
+                raise AssertionError(e)
+            else:
+                logging.warning(e)
+                return None, None
+
+    def set_chart_name(self, basename):
+        """Generates a unique chart name from basename and stores both in self.
+
+        Generated values are appended to the basename.
+
+        Returns:
+            The generated chart name value.
+        """
+        self.chart_base_name = basename
+        self.chart_name = self.append_unique_id(basename)
+        logging.debug(
+            f'Caller provided chart name "{self.chart_base_name}", generated unique identifier: "{self.chart_name}"'
+        )
+        return self.chart_name
+
+    def append_unique_id(self, base) -> str:
+        """Appends this class' unique identifier, and optionally, the pr number."""
+        # unique string based on uuid.uuid4()
+        suffix = self.uuid
+        if "PR_NUMBER" in os.environ:
+            pr_num = os.environ["PR_NUMBER"]
+            suffix = f"{suffix}-{pr_num}"
+        return f"{base}-{suffix}"

--- a/tests/functional/behave_features/common/utils/owner_file_submission.py
+++ b/tests/functional/behave_features/common/utils/owner_file_submission.py
@@ -80,7 +80,20 @@ class OwnersFileSubmissionsE2ETest:
         )
 
         # Create the branch on the remote if it doesn't exist.
-        r = github.github_api("get", f"repos/{test_repo}/branches", bot_token)
+        try:
+            r = github.github_api("get", f"repos/{test_repo}/branches", bot_token)
+        except Exception as e:
+            raise AssertionError(
+                " ".join(
+                    [
+                        "Failed to Inintialize Test",
+                        "Unable to get branches from the GitHub API.",
+                        "Is GitHub having an outage?",
+                        f"Error: {e}",
+                    ]
+                )
+            )
+
         branches = json.loads(r.text)
         branch_names = [branch["name"] for branch in branches]
         logging.debug(f"Remote test repo branch names : {branch_names}")
@@ -260,7 +273,20 @@ class OwnersFileSubmissionsE2ETest:
         logging.info(
             f"Create PR from '{remote_repo}:{pr_branch}' to '{remote_repo}:{base_branch}'"
         )
-        r = github.github_api("post", f"repos/{remote_repo}/pulls", gh_token, json=data)
+        try:
+            r = github.github_api(
+                "post", f"repos/{remote_repo}/pulls", gh_token, json=data
+            )
+        except Exception as e:
+            raise AssertionError(
+                " ".join(
+                    [
+                        "Failed to send pull request.",
+                        "Is GitHub having an outage?",
+                        f"Error: {e}",
+                    ]
+                )
+            )
         j = json.loads(r.text)
         if "number" not in j:
             raise AssertionError(f"error sending pull request, response was: {r.text}")
@@ -296,7 +322,7 @@ class OwnersFileSubmissionsE2ETest:
             pr_number: The pull request for which a worfklow should have executed, e.g. '1'.
             workflow_name: The name of the workflow whose outcome is relevant
             expected_result: The expected conclusion of the workflow. E.g. 'success'
-            failure_type: Determines how this function treats conclusion mismatches. 
+            failure_type: Determines how this function treats conclusion mismatches.
               Raises if set to 'error'.
 
         Raises:
@@ -315,7 +341,7 @@ class OwnersFileSubmissionsE2ETest:
             else:
                 logging.warning(e)
                 return None, None
-        
+
         if conclusion == expected_result:
             logging.info(
                 f"PR{pr_number} Workflow run was '{expected_result}' which is expected"
@@ -331,7 +357,6 @@ class OwnersFileSubmissionsE2ETest:
                 )
 
         return run_id, conclusion
-
 
     def set_chart_name(self, basename):
         """Generates a unique chart name from basename and stores both in self.

--- a/tests/functional/behave_features/common/utils/owner_file_submission.py
+++ b/tests/functional/behave_features/common/utils/owner_file_submission.py
@@ -30,8 +30,6 @@ class OwnersFileSubmissionsE2ETest:
     head_sha: str = ""
 
     test_name: str = ""  # Meaningful test name for this test, displayed in PR title
-    # test_report: str = ''
-    # chart_directory: str = ''
     secrets: E2ETestSecretOneShot = E2ETestSecretOneShot()
     old_cwd: str = os.getcwd()
     # This is the worktree for this test run. To be used for context management where applicable.
@@ -44,7 +42,7 @@ class OwnersFileSubmissionsE2ETest:
     chart_name = ""
     # The vendor name, e.g. 'redhat'
     vendor_label = ""
-    # The vendor category, e.g. 'partner'
+    # The vendor category, e.g. 'partners'
     vendor_category = ""
     # The vendor's pretty name, e.g. 'Red Hat'
     vendor_name = ""
@@ -54,7 +52,6 @@ class OwnersFileSubmissionsE2ETest:
     # Manages the local repository, branches, worktress, etc.
     # and facilitates pushes to remotes.
     repo_manager: WorkflowRepoManager = None
-    repo: git.Repo = None
 
     # Combines this instance's unique ID + the repository base branch hash
     branch_base_id: str = None
@@ -145,7 +142,7 @@ class OwnersFileSubmissionsE2ETest:
         if self.repo_manager:
             self.repo_manager.repo.git.worktree("prune")
 
-    def submission_path(self) -> str:  # charts/partner/mycompany/mychartname
+    def submission_path(self) -> str:  # charts/partners/mycompany/mychartname
         """Composes the submission path based on the vendor_type, vendor, and chart_name values."""
         return os.path.join(
             "charts", self.vendor_category, self.vendor_label, self.chart_name
@@ -158,7 +155,6 @@ class OwnersFileSubmissionsE2ETest:
         will supercede global values.
 
         Args:
-            repo: git.Repo instance of the local directory
             username: git username to set
             email: git email to set
         """

--- a/tests/functional/behave_features/common/utils/owner_file_submission.py
+++ b/tests/functional/behave_features/common/utils/owner_file_submission.py
@@ -268,7 +268,7 @@ class OwnersFileSubmissionsE2ETest:
 
     def check_workflow_conclusion(
         self,
-        expected_result: str,  # the possible outcomes of a github workflow. e.g. 'success'
+        expected_result: str,
     ):
         """Checks the input workflow and reports back if expected_result doesn't match reality."""
 

--- a/tests/functional/behave_features/common/utils/owner_file_submission.py
+++ b/tests/functional/behave_features/common/utils/owner_file_submission.py
@@ -289,17 +289,26 @@ class OwnersFileSubmissionsE2ETest:
 
     def _check_workflow_conclusion(
         self,
-        pr_number: str,  # '1'
+        pr_number: str,
         workflow_name: str,
-        expected_result: str,  # 'success'
+        expected_result: str,
         failure_type="error",
     ):
         """Checks the conclusion of workflow_name for expected_result via the GitHub API.
 
-        if failure_type is set to "error", this raises an exception.
+        Args:
+            pr_number: The pull request for which a worfklow should have executed, e.g. '1'.
+            workflow_name: The name of the workflow whose outcome is relevant
+            expected_result: The expected conclusion of the workflow. E.g. 'success'
+            failure_type: Determines how this function treats conclusion mismatches. 
+              Raises if set to 'error'.
 
         Raises:
             AssertionError if the conclusion does not match the expected_result.
+
+        Returns:
+            run_id: The ID of the workflow
+            conclusion: The actual conclusion of the workflow.
         """
         try:
             run_id = github.get_run_id(self.secrets, workflow_name, pr_number)

--- a/tests/functional/behave_features/common/utils/owner_file_submission.py
+++ b/tests/functional/behave_features/common/utils/owner_file_submission.py
@@ -28,9 +28,9 @@ class OwnersFileSubmissionsE2ETest:
     # Used for PRs titles, branch names, etc.
     uuid: str = ""
     head_sha: str = ""
-
-    test_name: str = ""  # Meaningful test name for this test, displayed in PR title
-    secrets: E2ETestSecretOneShot = E2ETestSecretOneShot()
+    # Meaningful test name for this test, displayed in PR title
+    test_name: str = ""  
+    secrets: E2ETestSecretOneShot = None
     old_cwd: str = os.getcwd()
     # This is the worktree for this test run. To be used for context management where applicable.
     temp_dir: TemporaryDirectory = None
@@ -62,6 +62,7 @@ class OwnersFileSubmissionsE2ETest:
         # New data for this instance.
         self.uuid = uuid.uuid4().hex
         self.repo_manager = WorkflowRepoManager()
+        self.secrets = E2ETestSecretOneShot()
 
         # Credentials and paths
         bot_name, bot_token = env.get_bot_name_and_token()

--- a/tests/functional/behave_features/common/utils/setttings.py
+++ b/tests/functional/behave_features/common/utils/setttings.py
@@ -8,7 +8,11 @@ TEST_REPO = "openshift-helm-charts/sandbox"
 PROD_REPO = "openshift-helm-charts/charts"
 # The prod branch where we store all chart files
 PROD_BRANCH = "main"
-# This is used to find chart certification workflow run id
+# (Deprecated) This is used to find chart certification workflow run id
 CERTIFICATION_CI_NAME = "CI"
+# (Replaces the above) The name of the workflow for certification, used to get its ID.
+WORKFLOW_CERTIFICATION_CI = "CI"
+# The name of the workflow for Red Hat OWNERS check submissions, used to get its ID.
+WORKFLOW_REDHAT_OWNERS_CHECK = "Red Hat OWNERS Files"
 # GitHub actions bot email for git email
 GITHUB_ACTIONS_BOT_EMAIL = "41898282+github-actions[bot]@users.noreply.github.com"

--- a/tests/functional/behave_features/common/utils/workflow_repo_manager.py
+++ b/tests/functional/behave_features/common/utils/workflow_repo_manager.py
@@ -1,0 +1,168 @@
+# -*- coding: utf-8 -*-
+"""Utility class for managing local/remote git branches and worktrees"""
+
+import os
+import logging
+import git
+
+from tempfile import TemporaryDirectory
+
+import common.utils.github as github
+
+
+class WorkflowRepoManager:
+    # Keep a log of things created so we can clean them up.
+    __local_branches_created: [str] = []
+    __local_worktrees_created: [TemporaryDirectory] = []
+    # (remote, branch), e.g. ('openshift-helm-charts/charts, 'my-pr-branch')
+    __remote_branches_created: [(str, str)] = []
+
+    # The token to use for GitHub API operations.
+    __authtoken: str = ""
+
+    # The branch at repo initialization. On Cleanup, we return to this branch
+    # before we remove locally generated branches.
+    original_branch: str = None
+
+    # Working directory at instantiation.
+    old_cwd: str = os.getcwd()
+
+    # The repository at working directory.
+    repo: git.Repo = None
+
+    def __init__(self):
+        logging.debug(f"{self} --> __init__ called!")
+
+        try:
+            self.repo = git.Repo()
+        except Exception as e:
+            raise Exception(
+                f"Expected to be able to initialize a git repository at this path and failed: {e}"
+            )
+
+        self.original_branch = self.repo.active_branch.name
+
+    def set_auth_token(self, token: str):
+        """Sets the github API token."""
+        self.__authtoken = token
+
+    def push_branch(self, remote_name: str, branch_name: str, repo: git.Repo = None):
+        """Pushes the input branch_name to remote_name.
+
+        The branch must exist locally before this is called, as it is not
+        created by this method.
+
+        Args:
+            remote_name: the name of the remote in organization/repository format.
+            branch_name: the branch to push.
+            repo: if set, overrides the use of the internal repo.
+
+        Raises:
+           Exception: An error occurred when pushing the branch
+        """
+        r = repo if repo is not None else self.repo
+        try:
+            r.git.push(
+                f"https://x-access-token:{self.__authtoken}@github.com/{remote_name}",
+                f"HEAD:refs/heads/{branch_name}",
+                "-f",
+            )
+        except Exception as e:
+            raise Exception(f"Unable to push branch to remote: {e}")
+        self.__remote_branches_created.append((remote_name, branch_name))
+
+    def checkout_branch(self, branch_name: str):
+        """Checks out a branch at branch_name and switches to it immediately.
+
+        Branches created with this method are stored internally
+        and cleaned up when cleanup() is called.
+
+        Args:
+            branch_name: The branch name to create.
+
+        Raises:
+           Exception: An error occurred creating the branch.
+        """
+        try:
+            self.repo.git.checkout("-b", branch_name)
+        except Exception as e:
+            raise Exception(f"Unable to create branch: {e}")
+
+        self.__local_branches_created.append(branch_name)
+
+    def add_worktree(self) -> TemporaryDirectory:
+        """Creates a worktree at a generated tempdir.
+
+        Worktrees created with this method are stored internally
+        and cleaned up when cleanup() is called.
+
+        Returns:
+            The TemporaryDirectory for the worktree that was requested.
+
+        Raise:
+            Exception: An error occurred when creating the worktree.
+        """
+        worktree_dir = TemporaryDirectory(prefix="worktree-")
+
+        try:
+            self.repo.git.worktree("add", "--detach", worktree_dir.name, "HEAD")
+        except Exception as e:
+            raise Exception(f"Unable to create worktree: {e}")
+
+        self.__local_worktrees_created.append(worktree_dir)
+
+        return worktree_dir
+
+    def cleanup_local_branches(self):
+        """Cleans up branches created by this repo manager."""
+        for br in self.__local_branches_created:
+            try:
+                logging.info(f'Cleaning up generated local branch: "{br}"')
+                self.repo.git.branch("-D", br)
+            except git.exc.GitCommandError:
+                logging.warn(
+                    f'local branch "{br}" could not be deleted, potentially because it did not exist'
+                )
+        self.__local_branches_created = []
+
+    def cleanup_worktrees(self):
+        """Cleans up local worktrees created by this repo manager."""
+        for wt in self.__local_worktrees_created:
+            logging.info(f'Cleaning up generated local worktree: "{wt}"')
+            try:
+                self.repo.git.worktree("remove", wt.name)
+            except git.exc.GitCommandError:
+                logging.warn(
+                    f'local worktree "{wt}" could not be deleted, potentially because it did not exist'
+                )
+        self.__local_worktrees_created = []
+
+    def cleanup_remote_branches(self):
+        """Cleans up remote branches created by this repo manager."""
+        for rbr in self.__remote_branches_created:
+            remote = rbr[0]
+            branch = rbr[1]
+            logging.info(f'Cleaning up branch "{branch}" from remote "{remote}')
+            try:
+                github.github_api(
+                    "delete",
+                    f"repos/{remote}/git/refs/heads/{branch}",
+                    self.__authtoken,
+                )
+            except git.exc.GitCommandError:
+                logging.warn(
+                    f'remote branch "{branch}" could not be deleted, potentially because it did not exist'
+                )
+        self.__remote_branches_created = []
+
+    def cleanup(self):
+        """Cleans up resources created using this instance.
+
+        Locally created branches and worktrees are removed. Exceptions in removing
+        these will emit a log line at the warn log level.
+        """
+        logging.debug(f"{self} --> cleanup called!")
+        self.repo.git.checkout(self.original_branch)
+        self.cleanup_local_branches()
+        self.cleanup_worktrees()
+        self.cleanup_remote_branches()

--- a/tests/functional/behave_features/common/utils/workflow_repo_manager.py
+++ b/tests/functional/behave_features/common/utils/workflow_repo_manager.py
@@ -121,9 +121,9 @@ class WorkflowRepoManager:
             try:
                 logging.info(f'Cleaning up generated local branch: "{br}"')
                 self.repo.git.branch("-D", br)
-            except git.GitCommandError:
+            except (git.GitCommandError, ValueError) as e:
                 logging.warn(
-                    f'local branch "{br}" could not be deleted, potentially because it did not exist'
+                    f'local branch "{br}" could not be deleted, potentially because it did not exist. Error: {e}'
                 )
         self.__local_branches_created = []
 
@@ -133,9 +133,9 @@ class WorkflowRepoManager:
             logging.info(f'Cleaning up generated local worktree: "{wt}"')
             try:
                 self.repo.git.worktree("remove", wt.name)
-            except git.GitCommandError:
+            except (git.GitCommandError, ValueError) as e:
                 logging.warn(
-                    f'local worktree "{wt}" could not be deleted, potentially because it did not exist'
+                    f'local worktree "{wt}" could not be deleted, potentially because it did not exist. Error: {e}'
                 )
         self.__local_worktrees_created = []
 
@@ -146,14 +146,14 @@ class WorkflowRepoManager:
             branch = rbr[1]
             logging.info(f'Cleaning up branch "{branch}" from remote "{remote}')
             try:
-                github.github_api(
-                    "delete",
-                    f"repos/{remote}/git/refs/heads/{branch}",
-                    self.__authtoken,
+                self.repo.git.push(
+                    f"https://x-access-token:{self.__authtoken}@github.com/{remote}",
+                    "--delete", 
+                    f"refs/heads/{branch}",
                 )
-            except Exception:
+            except (git.GitCommandError, ValueError) as e:
                 logging.warn(
-                    f'remote branch "{branch}" could not be deleted, potentially because it did not exist'
+                    f'remote branch "{branch}" could not be deleted from {remote}, potentially because it did not exist. Error: {e}'
                 )
         self.__remote_branches_created = []
 


### PR DESCRIPTION
**WorkflowRepoManager** provides some basic hooks into the operations we take against the local GitHub repository (e.g. adding branches, worktrees), and in some cases, the remote. This allows us to more effectively clean up after ourselves locally/remotely.

The end goal for this is to refactor the chart certification workflow to use it in the future.

**OwnersFileSubmissionE2ETest** is a net-new E2E testing class, supporting the testing of OWNERS file submissions from the user, and ensuring certain things take place when that's done.

The rest of the changes support these net new components.

---

Note that there are some changes that impact the production chart_certification script. These changes are minimally impactful to the code, and should be non-impactful to the execution of these in E2E. In an effort to avoid duplicate code paths, I had to modify a function signature that was used by both the new tests as well as the old.