### PR TITLE
Use SafeLoader when loading untrusted YAML

### DIFF
--- a/scripts/src/chartrepomanager/chartrepomanager.py
+++ b/scripts/src/chartrepomanager/chartrepomanager.py
@@ -36,9 +36,9 @@ from environs import Env
 
 try:
     from yaml import CDumper as Dumper
-    from yaml import CLoader as Loader
+    from yaml import CSafeLoader as SafeLoader
 except ImportError:
-    from yaml import Dumper, Loader
+    from yaml import Dumper, SafeLoader
 
 sys.path.append("../")
 from pullrequest import prartifact
@@ -273,7 +273,7 @@ def create_index_from_chart(chart_file_name):
     p = out.stdout.decode("utf-8")
     print(p)
     print(out.stderr.decode("utf-8"))
-    crt = yaml.load(p, Loader=Loader)
+    crt = yaml.load(p, Loader=SafeLoader)
     return crt
 
 
@@ -376,7 +376,7 @@ def update_chart_annotation(
         data = open(
             os.path.join("charts", category, organization, chart, "OWNERS")
         ).read()
-        out = yaml.load(data, Loader=Loader)
+        out = yaml.load(data, Loader=SafeLoader)
         vendor_name = out["vendor"]["name"]
         annotations["charts.openshift.io/provider"] = vendor_name
 
@@ -394,7 +394,7 @@ def update_chart_annotation(
     print(out.stderr.decode("utf-8"))
 
     fd = open(os.path.join(dr, chart, "Chart.yaml"))
-    data = yaml.load(fd, Loader=Loader)
+    data = yaml.load(fd, Loader=SafeLoader)
 
     if "annotations" not in data:
         data["annotations"] = annotations

--- a/scripts/src/owners/owners_file.py
+++ b/scripts/src/owners/owners_file.py
@@ -3,9 +3,9 @@ import os
 import yaml
 
 try:
-    from yaml import CLoader as Loader
+    from yaml import CSafeoader as SafeLoader
 except ImportError:
-    from yaml import Loader
+    from yaml import SafeLoader
 
 
 def get_owner_data(category, organization, chart):
@@ -17,7 +17,7 @@ def get_owner_data(category, organization, chart):
 def get_owner_data_from_file(owner_path):
     try:
         with open(owner_path) as owner_data:
-            owner_content = yaml.load(owner_data, Loader=Loader)
+            owner_content = yaml.load(owner_data, Loader=SafeLoader)
         return True, owner_content
     except Exception as err:
         print(f"Exception loading OWNERS file: {err}")

--- a/scripts/src/report/verifier_report.py
+++ b/scripts/src/report/verifier_report.py
@@ -1,17 +1,17 @@
 """
-Used by github actions,specifically as part of the charts auto release process defined in
+Used by github actions, specifically as part of the charts auto release process defined in
 .github/workflow/release.yml.
 
 Used to loosely determine if a submitted report is valid and has not been tampered with.
 
 An invalid valid report:
 - does not load as a yaml file.
-- does not include  a "kind" attribute set the "verify-report" .
+- does not include a "kind" attribute set to "verify-report".
 - does not include sections: "tool.metadata", "tool.chart", "results".
 
 A tampered report is only determined if the chart-testing check has passed:
 - certifiedOpenShiftVersions or testOpenShiftVersion contain valid semantic versions.
-- certifiedOpenShiftVersions or testOpenShiftVersion specify an OCP version with helm support  (>=4.1.0)
+- certifiedOpenShiftVersions or testOpenShiftVersion specify an OCP version with helm support (>=4.1.0)
 - if the has-kubeversion check has also passed
   - v1.0 profile:
     - if a valid kubeVersion is specified in the chart it must include the certifiedOpenShiftVersions
@@ -29,9 +29,9 @@ import semantic_version
 import yaml
 
 try:
-    from yaml import CLoader as Loader
+    from yaml import CSafeLoader as SafeLoader
 except ImportError:
-    from yaml import Loader
+    from yaml import SafeLoader
 
 sys.path.append("../")
 from report import report_info
@@ -55,7 +55,7 @@ def get_report_data(report_path):
     """
     try:
         with open(report_path) as report_data:
-            report_content = yaml.load(report_data, Loader=Loader)
+            report_content = yaml.load(report_data, Loader=SafeLoader)
         return True, report_content
     except Exception as err:
         print(f"Exception 2 loading file: {err}")


### PR DESCRIPTION
- YAML files added in PRs are considered untrusted (new OWNERS, report.yaml, ...)
- files already commited to the repository are considered trusted (exising OWNERS, current Helm repo index)