### PR TITLE
Correct default virtualenv location

### DIFF
--- a/.github/actions/generate-chart-locks/action.yaml
+++ b/.github/actions/generate-chart-locks/action.yaml
@@ -20,7 +20,7 @@ inputs:
       The path to the generate-chart-locks command. This action expects CI
       scripts to be installed by the caller, and so it stands to reason the
       caller may install scripts at various locations.
-    default: "ve1/bin/generate-chart-locks"
+    default: "../ve1/bin/generate-chart-locks"
     required: false
 outputs:
   lockfile-path:
@@ -67,7 +67,7 @@ runs:
     id: generate-chart-locks
     shell: bash
     run: |
-      set -o pipefail
+      set -eo pipefail
       ${{ inputs.generator-cmd-path }} | jq | tee ${{ inputs.to-file }}
       echo "lockfile-path=$(realpath ${{ inputs.to-file }})" | tee -a $GITHUB_OUTPUT
   - name: Cleanup

--- a/scripts/src/packagemapping/generatelocks.py
+++ b/scripts/src/packagemapping/generatelocks.py
@@ -72,15 +72,15 @@ def main():
             )
             return 20
 
-        ownersContentLoaded, ownersContent = owners_file.get_owners_data_from_file(
+        owners_content_loaded, owners_content = owners_file.get_owner_data_from_file(
             filename
         )
-        if not ownersContentLoaded:
+        if not owners_content_loaded:
             logError(f"Failed to load OWNERS file content. filename: {filename}")
             return 30
 
-        owners_value_chart_name = owners_file.get_chart(ownersContent)
-        owners_value_vendor_label = owners_file.get_vendor_label(ownersContent)
+        owners_value_chart_name = owners_file.get_chart(owners_content)
+        owners_value_vendor_label = owners_file.get_vendor_label(owners_content)
 
         if owners_value_chart_name != chart:
             logError(


### PR DESCRIPTION
- Fixes a bug in new actions where the virtualenv `ve1` would be expected to be in the current working directory, but is typically built up one level.
- Adds a shell flag to exit on pipefail for a given task.
- Replaced some camel case variables with snake case equivalents (for style points!)