### PR TITLE
Implement bugfix for chart dependencies and gitops.

### DIFF
--- a/.github/workflows/check-locks-on-owners-submission.yml
+++ b/.github/workflows/check-locks-on-owners-submission.yml
@@ -1,28 +1,33 @@
-name: OWNERS PR Check
+name: Check Chart Lock Status
 
-# Checks OWNERS file additions and modifications submitted by mercury-bot on a
-# partner's behalf, typically in response to a partner updating their project
-# metadata.
+# Checks Red Hat and Community OWNERS file additions against our chart lockfile.
+# 
+# Red Hat and Community OWNERS files are not auto-merged, and require maintainer
+# review and action. This is intended to automate checking lock files.
 #
-# Automatically approves modifications mercury-bot makes. Sanity checks
-# net-new OWNERS files to ensure their addition does not conflict with
-# existing locks.
+# Technically maintainers should re-run this workflow just before merging. This is
+# noted in the comment sent to the PR.
+#
+# This does not fail even if a chart is locked. A modification to an existing chart
+# lock is considered valid, and therefore maintainers will use their discretion
+# to merge modifications.
 
 on:
   pull_request_target:
     types: [opened, synchronize, reopened, edited, ready_for_review, labeled]
     paths:
-    - charts/partners/**/OWNERS
-
+    - charts/community/**/OWNERS
+    - charts/redhat/**/OWNERS
 
 jobs:
   owners-file-check:
     name: OWNERS file PR checker
-    runs-on: ubuntu-20.04
-    if: github.event.pull_request.draft == false && github.actor == 'redhat-mercury-bot'
+    runs-on: ubuntu-22.04
+    if: |
+      github.event.pull_request.draft == false
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
         
       - name: Set up Python 3.x Part 1
         uses: actions/setup-python@v5
@@ -52,19 +57,19 @@ jobs:
         env:
           pr_files_py: "${{ steps.get_files_changed.outputs.pr_files }}"
         run: |
-          # check if PR contains just one partner OWNERS file
+          # check if PR contains just one redhat/community OWNERS file
           pr_files=($(echo "$pr_files_py" | tr -d '[],'))
           echo "Files in PR: ${pr_files[@]}"
           eval first_file=${pr_files[0]}
           if [ ${#pr_files[@]} == 1 ]; then
             eval first_file=${pr_files[0]}
-            if [[ $first_file == "charts/partners/"*/*"/OWNERS" ]] ; then
+            if [[ $first_file == "charts/redhat/"*/*"/OWNERS" ]] || [[ $first_file == "charts/community/"*/*"/OWNERS" ]] ; then
                 echo "An OWNERS file has been modified or added"
                 echo "merge_pr=true" | tee -a $GITHUB_OUTPUT
             else
-              echo "The file in the PR is not a partner OWNERS file"
+              echo "The file in the PR is not a Red Hat or Community OWNERS file"
               echo "merge_pr=false" | tee -a $GITHUB_OUTPUT
-              echo "msg=ERROR: PR does not include a partner OWNERS file." >> $GITHUB_OUTPUT
+              echo "msg=ERROR: PR does not include a redhat/community OWNERS file." >> $GITHUB_OUTPUT
             fi
           else
             echo "The PR contains multiple files."
@@ -79,7 +84,7 @@ jobs:
       - name: Determine if net-new OWNERS file
         id: populate-file-mod-type
         if: ${{ steps.check_for_owners.outputs.merge_pr == 'true' }}
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -105,7 +110,7 @@ jobs:
 
       # Only used to assert content of the OWNERS file.
       - name: Checkout Pull Request
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
@@ -113,9 +118,6 @@ jobs:
           fetch-depth: 0
           path: "pr-branch"
 
-      # TODO: Implemented as a shell script temporarily. Future enhancement
-      # would re-use some existing logic that we have for the Red Hat OWNERS
-      # check, and build something similar for general use.
       - name: Ensure OWNERS content and path content align
         working-directory: "pr-branch"
         id: fact-check
@@ -123,7 +125,7 @@ jobs:
           file=$(echo ${{ steps.get_files_changed.outputs.pr_files }} | yq .0)
           owner_contents_chart_name=$(yq '.chart.name' ${file})
           owner_contents_vendor_label=$(yq '.vendor.label' ${file})
-          echo "Chart Name Comparison: ${owner_contents_chart_name} = ${{ steps.gather-metadata.outputs.chart-name }}"
+          echo "Chart Name Comparison: ${owner_contents_chart_name} = ${{ steps.gather-metadata.outputs.chart-name }}" 
           echo "Vendor Label Comparison: ${owner_contents_vendor_label} = ${{ steps.gather-metadata.outputs.organization }}"
           test "${owner_contents_chart_name}" = "${{ steps.gather-metadata.outputs.chart-name }}"
           test "${owner_contents_vendor_label}" = "${{ steps.gather-metadata.outputs.organization }}"
@@ -150,53 +152,40 @@ jobs:
           chart-name: ${{ steps.gather-metadata.outputs.chart-name }}
           fail-workflow-if-locked: 'false'
 
-      # Do not merge net-new OWNERS files for locked chart names. Allow a
-      # modification to an existing file. The mercury-bot periodically updates
-      # this file as users make changes to their project settings.
-      - name: Determine if should merge and is safe to merge
-        id: safe-to-merge
+      - name: Comment on PR if chart is locked
+        id: comment-if-locked
+        if: steps.determine-lock-status.outputs.chart-is-locked == 'true'
         run: |
-          echo "OWNERS file is net new: ${{ steps.populate-file-mod-type.outputs.net-new-owners-file }}"
-          echo "Chart name is already locked: ${{ steps.determine-lock-status.outputs.chart-is-locked }}"
-          echo "merge_pr=${{ steps.populate-file-mod-type.outputs.net-new-owners-file == 'false' || (steps.populate-file-mod-type.outputs.net-new-owners-file == 'true' && steps.determine-lock-status.outputs.chart-is-locked == 'false') }}" | tee -a $GITHUB_OUTPUT
-
-      - name: Comment on PR
-        if: ${{ steps.check_for_owners.outputs.merge_pr == 'false' }}
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-              var issue_number = ${{ github.event.number }};
-              var comment = "${{ steps.check_for_owners.outputs.msg }}";
-              github.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: Number(issue_number),
-                body: comment
-              });
-
-      - name: Reflect on check for OWNERS file result
-        if: |
-          steps.check_for_owners.outputs.merge_pr == 'false'
-          || steps.safe-to-merge.outputs.merge_pr == 'false'
-        run: |
-          echo "::error: The PR was not for a single partner OWNERS file, or was for a chart name locked to another contributor"
-          exit 1
-
-      - name: Approve PR
-        id: approve_pr
-        if: |
-          steps.check_for_owners.outputs.merge_pr == 'true'
-          && steps.safe-to-merge.outputs.merge_pr == 'true'
-        uses: hmarr/auto-approve-action@v3
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Merge PR
-        id: merge_pr
-        if: ${{ steps.approve_pr.conclusion == 'success' }}
-        uses: pascalgn/automerge-action@v0.16.2
+          gh pr comment ${{ github.event.number }} --body "${{ env.COMMENT_BODY }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          MERGE_METHOD: squash
-          MERGE_LABELS: ""
+          COMMENT_BODY: |
+            ### :lock: Chart Lock Check
+
+            The OWNERS file contributed here has a chart name that is **LOCKED**!
+
+            | chart name | lock path |
+            | - | - |
+            | ${{ steps.gather-metadata.outputs.chart-name }} | ${{ steps.determine-lock-status.outputs.locked-to-path }} |
+            
+            This OWNERS file is being ${{ steps.populate-file-mod-type.outputs.net-new-owners-file && '**created**' || '**modified**'}} in this pull request.
+
+            _This comment was auto-generated by [GitHub Actions](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})._
+
+      - name: Comment on PR if chart is not locked
+        id: comment-if-available
+        if: steps.determine-lock-status.outputs.chart-is-locked == 'false'
+        run: |
+          gh pr comment ${{ github.event.number }} --body "${{ env.COMMENT_BODY }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMENT_BODY: |
+            ### :unlock: Maintainers:
+
+            The OWNERS file contributed here has a chart name that is **AVAILABLE**!
+
+            The chart name '${{ steps.gather-metadata.outputs.chart-name }}' does not appear in our lockfile.
+
+            After reviewing this pull request, please re-run this workflow once more before merging.
+
+            _This comment was auto-generated by [GitHub Actions](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})._

--- a/.github/workflows/lock-sanity-check.yml
+++ b/.github/workflows/lock-sanity-check.yml
@@ -1,0 +1,57 @@
+name: Chart Lock Generation Sanity Check
+
+# Runs chart generation on every push to main to make
+# sure things are healthy. Alerts maintainers if there
+# are issues.
+#
+# Main should *always* be in a healthy state 
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  ensure-health:
+    runs-on: ubuntu-22.04
+    steps:
+    - name: checkout
+      uses: actions/checkout@v4
+    - name: Set up Python 3.x Part 1
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.10"
+    - name: Set up Python 3.x Part 2
+      run: |
+        # set up python
+        python3 -m venv ve1
+        cd scripts
+        ../ve1/bin/pip3 install -r requirements.txt
+        ../ve1/bin/pip3 install .
+        cd ..
+    - name: generate chart locks
+      id: generate
+      uses: ./.github/actions/generate-chart-locks
+    - name: notify maintainers on failure
+      id: notify
+      if: failure() && steps.generate.outcome == 'failure' && github.repository == 'openshift-helm-charts/charts'
+      uses: archive/github-actions-slack@v2.7.0
+      with:
+        slack-bot-user-oauth-access-token: ${{ secrets.SLACK_BOT_USER_OAUTH_ACCESS_TOKEN }}
+        slack-channel: C02979BDUPL
+        slack-text: |
+          Failing to generate chart locks! '${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}'
+    - name: create issue if notification failure
+      id: allback-notify
+      if: failure() && steps.notify.outcome == 'failure'
+      run: |
+        gh issue create --title "Chart lock generation sanity check is failing" --body "${{ env.COMMENT_BODY }}"
+      env:
+        GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
+        COMMENT_BODY: |
+          While performing a sanity check of the chart generation logic on the main branch, a failure occurred!
+          
+          See workflow: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}
+
+          cc @komish @mgoerens

--- a/.github/workflows/owners-redhat.yml
+++ b/.github/workflows/owners-redhat.yml
@@ -1,0 +1,164 @@
+name: Red Hat OWNERS Files
+
+# On OWNERS file submissions, this workflow will check the path and the
+# contents of the file to make sure it matches expectations for Red Hat
+# submissions.
+
+on:
+  pull_request:
+    paths:
+    - charts/redhat/**/OWNERS
+    - charts/community/redhat/**/OWNERS
+
+env:
+  SUCCESS_LABEL: redhat-owners-content-ok
+
+jobs:
+  gather-metadata:
+    name: Gather Metadata From Path
+    outputs:
+      category: ${{ steps.gather-metadata.outputs.category }}
+      organization: ${{ steps.gather-metadata.outputs.organization }}
+      chartname: ${{ steps.gather-metadata.outputs.chart-name }}
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Clean up stale label
+        uses: actions/github-script@v3
+        continue-on-error: true
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const successLabel = '${{ env.SUCCESS_LABEL }}';
+            try {
+              await github.issues.removeLabel({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: successLabel,
+              })
+            } catch (error) {
+              // a 404 indicates the label isn't here
+              if (error.status == 404) {
+                console.log('The issue did not have the label');
+                return 0;
+              }
+
+              throw error
+            }
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+
+      - name: Install Python CI tooling
+        working-directory: scripts
+        run: |
+          make venv.tools
+      
+      - name: Gather Metadata
+        id: gather-metadata
+        env:
+          API_URL: ${{ github.event.pull_request._links.self.href }}
+          BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
+        run: |
+          ./scripts/venv.tools/bin/extract-metadata-from-pr \
+            --emit-to-github-output \
+            ${{ env.API_URL }}
+  ensure-prefix-in-path:
+    name: Ensure chart name prefix
+    runs-on: ubuntu-22.04
+    needs: [gather-metadata]
+    steps:
+      - name: Confirm Prefix
+        id: confirm-prefix
+        run: echo "${{ needs.gather-metadata.outputs.chartname }}" | grep "^redhat-"
+  ensure-owners-file-contents:
+    name: Ensure OWNERS file contents is valid
+    runs-on: ubuntu-22.04
+    needs: [gather-metadata]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - name: Install Python CI tooling
+        working-directory: scripts
+        run: |
+          make venv.tools
+      - name: Assert Owners File Content
+        id: assert-content
+        env:
+          CATEGORY: ${{ needs.gather-metadata.outputs.category }}
+          ORGANIZATION: ${{ needs.gather-metadata.outputs.organization }}
+          CHARTNAME: ${{ needs.gather-metadata.outputs.chartname }}
+        run: |
+          ./scripts/venv.tools/bin/assert-redhat-owners-file-meta \
+            "${CATEGORY}" \
+            "${ORGANIZATION}" \
+            "${CHARTNAME}"
+  notify-on-failure:
+    name: Notify on failure
+    runs-on: ubuntu-22.04
+    needs: [ensure-prefix-in-path, ensure-owners-file-contents]
+    if: failure() && (needs.ensure-prefix-in-path.result == 'failure' || needs.ensure-owners-file-contents.result == 'failure')
+    steps:
+      - name: Send PR Comment
+        uses: actions/github-script@v6
+        env:
+          PREFIX_CHECK_RESULT: ${{ needs.ensure-prefix-in-path.result != '' && needs.ensure-prefix-in-path.result || 'unknown' }}
+          CONTENT_CHECK_RESULT: ${{ needs.ensure-owners-file-contents.result != '' && needs.ensure-owners-file-contents.result || 'unknown' }}
+          BUILD_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const prefixCheckResult = '${{ env.PREFIX_CHECK_RESULT }}';   
+            const contentCheckResult = '${{ env.CONTENT_CHECK_RESULT }}';
+            const buildURL='${{ env.BUILD_URL }}';
+
+            var comment = '### :x: Red Hat OWNERS File Content and Path Check';
+
+            if (prefixCheckResult == 'failure') {
+              comment = comment.concat('\n\n', 'The chart name in your submission path looks incorrect!');
+            }
+
+            if (contentCheckResult == 'failure') {
+              comment = comment.concat('\n\n', 'The content of your OWNERS file looks incorrect!');
+            }
+
+            comment = comment.concat('\n\n', `Check your [workflow run](${buildURL}) for more information.`);
+
+            var issue_number = ${{ github.event.number }};
+            github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: Number(issue_number),
+              body: comment
+            });
+  label-on-success:
+    name: Label On Success
+    continue-on-error: true
+    needs: [ensure-prefix-in-path, ensure-owners-file-contents]
+    runs-on: ubuntu-22.04
+    env:
+      PR: ${{ github.event.number }}
+    if: success()
+    steps:
+    - name: Label PR
+      uses: actions/github-script@v6
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          const issue_number = ${{ env.PR }};
+          const successLabel = '${{ env.SUCCESS_LABEL }}';
+
+          github.rest.issues.addLabels({
+            issue_number: Number(issue_number),
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            labels: [successLabel],
+          });

--- a/tests/functional/behave_features/HC-20_owners_file.feature
+++ b/tests/functional/behave_features/HC-20_owners_file.feature
@@ -1,0 +1,15 @@
+Feature: OWNERS file submissions
+    redhat can submit OWNERS file.
+
+    Scenario Outline: [HC-20-001] An OWNERS file is submitted by redhat
+        Given a Red Hat OWNERS file is submitted for a chart with name "<chart_name>"
+        When the vendor label set to "<vendor_label>" and vendor name set to "<vendor_name>"
+        Then validation CI should conclude with result "<result>"
+            
+        @owners @full @smoke
+        Examples:
+            | chart_name      | vendor_label | vendor_name   | result  |
+            | redhat-prefixed | redhat       | Red Hat       | success |
+            | missing-prefix  | redhat       | Red Hat       | failure |
+            | redhat-prefixed | notredhat    | Red Hat       | failure |
+            | redhat-prefixed | redhat       | Not Red Hat   | failure |

--- a/tests/functional/behave_features/common/utils/chart_certification.py
+++ b/tests/functional/behave_features/common/utils/chart_certification.py
@@ -215,7 +215,7 @@ vendor:
                     return False
 
         if index:
-            entry = f"{vendor}-{chart_name}"
+            entry = chart_name
             if "entries" not in index or entry not in index["entries"]:
                 if failure_type == "error":
                     raise AssertionError(

--- a/tests/functional/behave_features/environment.py
+++ b/tests/functional/behave_features/environment.py
@@ -1,4 +1,5 @@
 from behave import fixture, use_fixture
+from common.utils.owner_file_submission import OwnersFileSubmissionsE2ETest
 from common.utils.chart_certification import ChartCertificationE2ETestSingle
 from common.utils.chart_certification import ChartCertificationE2ETestMultiple
 
@@ -16,11 +17,32 @@ def submitted_chart_test(context):
     yield context.chart_test
     context.chart_test.cleanup()
 
+@fixture
+def owners_file_test(context):
+    context.owners_file_test = OwnersFileSubmissionsE2ETest(test_name=context.test_name)
+    yield context.owners_file_test
+    context.owners_file_test.cleanup()
 
 def before_scenario(context, scenario):
+    context.test_name = scenario.name.split("@")[0][:-4].split("]")[1]
     if "version-change" in scenario.tags:
         print("[INFO] Using submitted charts fixture")
         use_fixture(submitted_chart_test, context)
+    elif 'owners' in scenario.tags:
+        # TODO(komish): This if/else logic doesn't scale nicely when E2E context
+        # are added OTHER than simply "chart certification". Right now, if I had
+        # a feature file that had both a chart certification AND an OWNERS file
+        # test, we would not have the chart certification related fixtures in
+        # the context.
+        #
+        # In the future, rework this such that the necessary fixtures are all
+        # added to the context for each scenario. That might mean adding tags to
+        # existing features to indicate what type of E2E scenario it is and
+        # adding the necessary fixture that way.
+        #
+        # E.g @certification to indicate the workflow_test fixture is necessary.
+        print('[INFO]: adding owners file tests fixture to context')
+        use_fixture(owners_file_test, context)
     else:
-        context.test_name = scenario.name.split("@")[0][:-4].split("]")[1]
+        print('[INFO]: adding certification workflow test fixture to context')
         use_fixture(workflow_test, context)

--- a/tests/functional/behave_features/steps/implementation_owners.py
+++ b/tests/functional/behave_features/steps/implementation_owners.py
@@ -1,0 +1,17 @@
+from behave import given, when, then
+
+@given('a Red Hat OWNERS file is submitted for a chart with name "{chart_name}"')
+def impl_chart_name(context, chart_name: str):
+    context.owners_file_test.set_chart_name(chart_name)
+
+@when('the vendor label set to "{vendor_label}" and vendor name set to {vendor_name}')
+def impl_label_and_name(context, vendor_label: str, vendor_name: str):
+    context.owners_file_test.vendor_label = vendor_label
+    context.owners_file_test.vendor_name = vendor_name
+    context.owners_file_test.vendor_category = 'redhat'
+    context.owners_file_test.create_and_commit_owners_file()
+    context.owners_file_test.send_pull_request()
+
+@then('validation CI should conclude with result "{result}"')
+def impl_ci_conclusion(context, result: str):
+    context.owners_file_test.check_workflow_conclusion(result)


### PR DESCRIPTION
~Do Not Merge.~

~I will remove :point_up: if and when this this is valid to merge/review. I have intentionally not applied the *draft* label because this prevents certain CI operations from running.~

[EDIT] This is ready for review.

---

This PR contains all of the impactful changes to how the certification pipeline works in order to resolve issues when depending on charts we provide.

In effect, this PR enables:

- Locked helm chart name tracking and generation
- Checks on OWNERS file submission to ensure locks are respected
- Fixes indexing strategy to index on chart names only

In addition, this PR includes E2E testing extensions for some of the new logic.

---
Change summary by file:

.github/workflows/mercury_bot.yml
- Only run this on changes to partner OWNERS files.
- Make sure that the incoming content is valid.
- Make sure the incoming chart name is not locked.

scripts/src/checkprcontent/checkpr.py
- Make sure we're adding the chart name to the github output.
- Ensure redhat charts follow proper standards at chart content check time. This is a secondary check to the one that's executed at OWNERS file submission time via GHA.
- Ensure the index key is set to the chart's name (changed from `org-chart`).

tests/functional/behave_features/common/utils/chart_certification.py
- Ensure the index key is set to the chart's name (changed from `org-chart`).

tests/functional/behave_features/environment.py
- Defines the OWNERS file testing fixture
- Adds the fixture to the scenario when the proper references are added in the scenario tests

.github/workflows/owners-redhat.yml (new)
- On Red Hat OWNERS file submissions, will check to make sure that the content matches standards.

.github/workflows/lock-sanity-check.yml (new)
- Sanity checks chart lock workflows by running on every main push, and notifying on failures.

.github/workflows/check-locks-on-owners-submission.yml (new)
- Ensures new redhat/community owners files do not encroach on locks.

tests/functional/behave_features/HC-20_owners_file.feature (new)
- Defines the new Helm Cert E2E test for OWNERS files,

tests/functional/behave_features/steps/implementation_owners.py (new)
- Implements the new Helm Cert E2E test for OWNERS files.

