### PR TITLE
Allow token access to redhat OWNERS file metadata check automation

### DIFF
--- a/.github/workflows/owners-redhat.yml
+++ b/.github/workflows/owners-redhat.yml
@@ -5,7 +5,7 @@ name: Red Hat OWNERS Files
 # submissions.
 
 on:
-  pull_request:
+  pull_request_target:
     paths:
     - charts/redhat/**/OWNERS
     - charts/community/redhat/**/OWNERS
@@ -26,7 +26,7 @@ jobs:
         uses: actions/github-script@v3
         continue-on-error: true
         with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const successLabel = '${{ env.SUCCESS_LABEL }}';
             try {
@@ -90,14 +90,26 @@ jobs:
         working-directory: scripts
         run: |
           make venv.tools
+
+      # Only used to assert content of the OWNERS file.
+      - name: Checkout Pull Request
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          token: ${{ secrets.BOT_TOKEN }}
+          fetch-depth: 0
+          path: "pr-branch"
+
       - name: Assert Owners File Content
         id: assert-content
+        working-directory: pr-branch
         env:
           CATEGORY: ${{ needs.gather-metadata.outputs.category }}
           ORGANIZATION: ${{ needs.gather-metadata.outputs.organization }}
           CHARTNAME: ${{ needs.gather-metadata.outputs.chartname }}
         run: |
-          ./scripts/venv.tools/bin/assert-redhat-owners-file-meta \
+          ../scripts/venv.tools/bin/assert-redhat-owners-file-meta \
             "${CATEGORY}" \
             "${ORGANIZATION}" \
             "${CHARTNAME}"


### PR DESCRIPTION
Fixes #337

In testing this workflow used exactly these tokens (GITHUB_TOKEN and BOT_TOKEN) throughout without issue, as written. E.g. https://github.com/komish/openshift-helm-charts/actions/runs/7935140662/job/21667629787#step:6:19

I think, because I'm the repository owner in that case, that there may have been special access to secrets that I don't have in the openshift-helm-charts/charts repository.

This PR changes the trigger to pull_request_target. Remember that we have to be conscious on what code we run when we do that, particularly if we pull the PR branch itself.

Here, I pull the PR branch after all scripts have been installed from the main branch, just so I have access to the OWNERS file, and so I can assert metadata on it. Nothing is executed from the pulled PR branch. This is similar to what we do in other workflows where we both need the content and also need secrets.

