### PR TITLE
Ping maintainers if the release job fails

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -533,6 +533,23 @@ jobs:
             https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }} \
             HEAD:refs/heads/${INDEX_BRANCH}
 
+      - name: Add a GitHub comment if release has failed
+        uses: actions/github-script@v7
+        if: ${{ failure() && env.GITHUB_REPOSITORY != 'openshift-helm-charts/sandbox' }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `### Release job failed
+
+              An error occured while updating the Helm repository index.
+
+              cc @komish @mgoerens`
+            });
+
       # Note(komish): This step is a temporary workaround. Metrics requires the PR comment
       # to be available, but it is written to the filesystem in the previous job.
       # This can be removed once the metrics execution is restructured to have access to the PR


### PR DESCRIPTION
Add a GitHub comment if an error occurs during the update of the helm index that pings the maintainers.

fix #341