### PR TITLE
Inform caller if web_catatog_only key is missing

### DIFF
--- a/scripts/src/owners/owners_file.py
+++ b/scripts/src/owners/owners_file.py
@@ -13,6 +13,10 @@ class OwnersFileError(Exception):
     pass
 
 
+class ConfigKeyMissing(Exception):
+    pass
+
+
 def get_owner_data(category, organization, chart):
     path = os.path.join("charts", category, organization, chart, "OWNERS")
     success = False
@@ -61,7 +65,28 @@ def get_chart(owner_data):
     return chart
 
 
-def get_web_catalog_only(owner_data):
+def get_web_catalog_only(owner_data, raise_if_missing=False):
+    """Check the delivery method set in the OWNERS file data
+
+    Args:
+        owner_data (dict): Content of the OWNERS file. Typically this is the return value of the
+            get_owner_data or get_owner_data_from_file function.
+        raise_if_missing (bool, optional): Whether to raise an Exception if the delivery method is
+            not set in the OWNERS data. If set to False, the function returns False.
+
+    Raises:
+        ConfigKeyMissing: if the key is not found in OWNERS and raise_if_missing is set to True
+
+    """
+    if (
+        "web_catalog_only" not in owner_data
+        and "providerDelivery" not in owner_data
+        and raise_if_missing
+    ):
+        raise ConfigKeyMissing(
+            "Neither web_catalog_only nor providerDelivery keys were set"
+        )
+
     return owner_data.get("web_catalog_only", False) or owner_data.get(
         "providerDelivery", False
     )


### PR DESCRIPTION
Add a "success" return value to get_web_catalog function to inform the caller if the file (OWNERS or report.yaml) doesn't contain such a key.

While this is currently not used by callers, this is a pre-requisite for #344 to exit draft status