### PR TITLE
Add debug information when tests fail to create PR

### DIFF
--- a/tests/functional/behave_features/common/utils/chart_certification.py
+++ b/tests/functional/behave_features/common/utils/chart_certification.py
@@ -135,9 +135,15 @@ vendor:
         logging.debug(f"PR_BODY Content: {pr_body}")
         logging.info(f"Create PR from '{remote_repo}:{pr_branch}'")
         r = github_api("post", f"repos/{remote_repo}/pulls", bot_token, json=data)
-        j = json.loads(r.text)
+
+        try:
+            j = json.loads(r.text)
+        except json.JSONDecodeError as e:
+            raise AssertionError(f"error decoding GitHub response: {r.__dict__}") from e
+
         if "number" not in j:
             raise AssertionError(f"error sending pull request, response was: {r.text}")
+
         return j["number"]
 
     def create_and_push_owners_file(


### PR DESCRIPTION
https://github.com/openshift-helm-charts/development/actions/runs/8778116626 Failed with:

```
2024-04-22T07:35:12.3970113Z       Traceback (most recent call last):
2024-04-22T07:35:12.3979348Z         File "/home/runner/work/development/development/ve1/lib/python3.10/site-packages/behave/model.py", line 1329, in run
2024-04-22T07:35:12.3980225Z           match.run(runner.context)
2024-04-22T07:35:12.3981201Z         File "/home/runner/work/development/development/ve1/lib/python3.10/site-packages/behave/matchers.py", line 98, in run
2024-04-22T07:35:12.3981996Z           self.func(context, *args, **kwargs)
2024-04-22T07:35:12.3982867Z         File "tests/functional/behave_features/steps/implementation.py", line 272, in user_sends_a_pull_request
2024-04-22T07:35:12.3983665Z           context.workflow_test.send_pull_request()
2024-04-22T07:35:12.3984925Z         File "/home/runner/work/development/development/tests/functional/behave_features/common/utils/chart_certification.py", line 888, in send_pull_request
2024-04-22T07:35:12.3986123Z           self.secrets.pr_number = super().send_pull_request(
2024-04-22T07:35:12.3987526Z         File "/home/runner/work/development/development/tests/functional/behave_features/common/utils/chart_certification.py", line 138, in send_pull_request
2024-04-22T07:35:12.3988536Z           j = json.loads(r.text)
2024-04-22T07:35:12.3989256Z         File "/opt/hostedtoolcache/Python/3.10.14/x64/lib/python3.10/json/__init__.py", line 346, in loads
2024-04-22T07:35:12.3989991Z           return _default_decoder.decode(s)
2024-04-22T07:35:12.3990984Z         File "/opt/hostedtoolcache/Python/3.10.14/x64/lib/python3.10/json/decoder.py", line 337, in decode
2024-04-22T07:35:12.3991801Z           obj, end = self.raw_decode(s, idx=_w(s, 0).end())
2024-04-22T07:35:12.3992622Z         File "/opt/hostedtoolcache/Python/3.10.14/x64/lib/python3.10/json/decoder.py", line 355, in raw_decode
2024-04-22T07:35:12.3993538Z           raise JSONDecodeError("Expecting value", s, err.value) from None
2024-04-22T07:35:12.3994241Z       json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

This PR aims to give additional debug information so that we can better understand what would cause this issue.