### PR TITLE
Release v1.7.1

### DIFF
--- a/release/release_info.json
+++ b/release/release_info.json
@@ -1,9 +1,25 @@
 {
-  "version": "1.7.0",
+  "version": "1.7.1",
   "info": [
-    "Add more debug information when E2E tests fail (#326) by @mgoerens",
-    "Correct default virtualenv location (#328) by @komish",
-    "Implement bugfix for chart dependencies and gitops. (#331) by @komish"
+    "Standardize action runner versions across workflows by @komish",
+    "Correctly determine the OWNERS file change type by @komish",
+    "Initialize the Submission data structure by @mgoerens",
+    "Allow token access to redhat OWNERS file metadata check automation by @komish",
+    "Remove unused function in 'signed_chart.py' by @mgoerens",
+    "Ping maintainers if the release job fails by @mgoerens",
+    "Rework owners_file.py and add custom exception by @mgoerens",
+    "Add debug information when tests fail to create PR by @mgoerens",
+    "Fix empty PR number in tests logs by @mgoerens",
+    "New chart fixture with plus sign in version by @jsm84",
+    "Rename crysostat fixture & rm whitespace in provider name by @jsm84",
+    "Added new test scenario plus-in-version to HC-17 by @jsm84",
+    "Cleanup unused report fixtures for HC-16 by @jsm84",
+    "Added new test scenario plus-in-version to HC-17 by @jsm84",
+    "Cleanup unused report fixtures for HC-16 by @jsm84",
+    "Inform caller if web_catatog_only key is missing by @mgoerens",
+    "Add check for web_catalog_only to Submission by @mgoerens",
+    "Inform caller if web_catatog_only key is missing by @mgoerens",
+    "Add check for web_catalog_only to Submission by @mgoerens"
   ],
   "charts": {
     "development": {


### PR DESCRIPTION
Summary:
* Standardize action runner versions across workflows by @komish in https://github.com/openshift-helm-charts/development/pull/339
* Correctly determine the OWNERS file change type by @komish in https://github.com/openshift-helm-charts/development/pull/340
* Initialize the Submission data structure by @mgoerens in https://github.com/openshift-helm-charts/development/pull/332
* Allow token access to redhat OWNERS file metadata check automation by @komish in https://github.com/openshift-helm-charts/development/pull/338
* Remove unused function in 'signed_chart.py' by @mgoerens in https://github.com/openshift-helm-charts/development/pull/322
* Ping maintainers if the release job fails by @mgoerens in https://github.com/openshift-helm-charts/development/pull/343
* Rework owners_file.py and add custom exception by @mgoerens in https://github.com/openshift-helm-charts/development/pull/321
* Add debug information when tests fail to create PR by @mgoerens in https://github.com/openshift-helm-charts/development/pull/346
* Fix empty PR number in tests logs by @mgoerens in https://github.com/openshift-helm-charts/development/pull/348
* New chart fixture with plus sign in version by @jsm84 in https://github.com/openshift-helm-charts/development/pull/349
* Rename crysostat fixture & rm whitespace in provider name by @jsm84 in https://github.com/openshift-helm-charts/development/pull/351
* Added new test scenario plus-in-version to HC-17 by @jsm84 in https://github.com/openshift-helm-charts/development/pull/350
* Cleanup unused report fixtures for HC-16 by @jsm84 in charts/development/pull/351
* Added new test scenario plus-in-version to HC-17 by @jsm84 in https://github.com/openshift-helm-charts/development/pull/350
* Cleanup unused report fixtures for HC-16 by @jsm84 in https://github.com/openshift-helm-charts/development/pull/352
* Inform caller if web_catatog_only key is missing by @mgoerens in https://github.com/openshift-helm-charts/development/pull/345
* Add check for web_catalog_only to Submission by @mgoerens in https://github.com/openshift-helm-charts/development/pull/344 https://github.com/openshift-helm-charts/development/pull/352
* Inform caller if web_catatog_only key is missing by @mgoerens in https://github.com/openshift-helm-charts/development/pull/345
* Add check for web_catalog_only to Submission by @mgoerens in https://github.com/openshift-helm-charts/development/pull/344

**Full Changelog**: https://github.com/openshift-helm-charts/development/compare/1.7.0...1.7.1