### PR TITLE
Wrap owners file content access function in try except

### DIFF
--- a/scripts/src/packagemapping/generatelocks.py
+++ b/scripts/src/packagemapping/generatelocks.py
@@ -72,11 +72,12 @@ def main():
             )
             return 20
 
-        owners_content_loaded, owners_content = owners_file.get_owner_data_from_file(
-            filename
-        )
-        if not owners_content_loaded:
-            logError(f"Failed to load OWNERS file content. filename: {filename}")
+        try:
+            owners_content = owners_file.get_owner_data_from_file(filename)
+        except owners_file.OwnersFileError as of_err:
+            logError(
+                f"Failed to load OWNERS file content. filename: {filename} with error {of_err}"
+            )
             return 30
 
         owners_value_chart_name = owners_file.get_chart(owners_content)


### PR DESCRIPTION
The return values for `owners_file.get_owner_data_from_file` was [changed recently](https://github.com/openshift-helm-charts/development/pull/321) such that it no longer returns a boolean reflecting whether accessing the OWNERS file was successful, instead favoring a Raised exception. 

This PR updates the chart lock generation logic. See https://github.com/openshift-helm-charts/charts/actions/runs/9470017334