### PR TITLE
Add dependabot configuration for core scripts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    groups:
+      core-scripts:
+        applies-to: "version-updates"
+        patterns:
+          - "*"
+    directory: "/scripts"
+    schedule:
+      interval: "monthly"

--- a/release/release_info.json
+++ b/release/release_info.json
@@ -24,7 +24,8 @@
         ".github/workflows/release.yml",
         ".github/workflows/nightly_test.yml",
         ".github/workflows/metrics.yml",
-        ".github/workflows/codeql.yml"
+        ".github/workflows/codeql.yml",
+        ".github/dependabot.yml"
       ]
     },
     "stage": {
@@ -40,7 +41,8 @@
         ".github/workflows/owners.yml",
         ".github/workflows/version_check.yml",
         ".github/workflows/codeql.yml",
-        ".github/workflows/check-locks-on-owners-submission.yml"
+        ".github/workflows/check-locks-on-owners-submission.yml",
+        ".github/dependabot.yml"
       ]
     }
   }


### PR DESCRIPTION
- Repository configuration will be updated to enable dependabot after this merges.
- Release info updated so that this configuration doesn't end up in the various other downstream repos.