### PR TITLE
Ensure service account token generation for workflows

### DIFF
--- a/scripts/src/saforcertadmin/create_sa.sh
+++ b/scripts/src/saforcertadmin/create_sa.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 
 user_name='rh-cert-user'
+token_secret='rh-cert-user-token'
 oc create sa $user_name
-token_secret=$(oc get secrets --field-selector=type=kubernetes.io/service-account-token -o=jsonpath="{.items[?(@.metadata.annotations.kubernetes\.io/service-account\.name=='"$user_name"')].metadata.name}")
+oc apply -f token_secret.yaml
 token=$(oc get secret $token_secret -o json | jq -r .data.token | base64 -d)
 oc apply -f cluster_role_binding.yaml
 

--- a/scripts/src/saforcertadmin/token_secret.yaml
+++ b/scripts/src/saforcertadmin/token_secret.yaml
@@ -1,0 +1,8 @@
+# Creates the secret. Cluster will populate with data.
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/service-account-token
+metadata:
+  name: rh-cert-user-token
+  annotations:
+    kubernetes.io/service-account.name: rh-cert-user

--- a/scripts/src/saforcharttesting/saforcharttesting.py
+++ b/scripts/src/saforcharttesting/saforcharttesting.py
@@ -24,6 +24,17 @@ metadata:
   namespace: ${name}
 """
 
+token_template = """\
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/service-account-token
+metadata:
+  name: token-${name}
+  namespace: ${name}
+  annotations:
+    kubernetes.io/service-account.name: ${name}
+"""
+
 role_template = """\
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
@@ -162,6 +173,14 @@ def create_serviceaccount(namespace):
     print("stdout:\n", stdout, sep="")
     if stderr.strip():
         print("[ERROR] creating ServiceAccount:", stderr)
+
+
+def create_tokensecret(namespace):
+    print("creating token Secret:", namespace)
+    stdout, stderr = apply_config(token_template, name=namespace)
+    print("stdout:\n", stdout, sep="")
+    if stderr.strip():
+        print("[ERROR] creating token Secret:", stderr)
 
 
 def create_role(namespace):
@@ -344,6 +363,7 @@ def main():
     if args.create:
         create_namespace(args.create)
         create_serviceaccount(args.create)
+        create_tokensecret(args.create)
         create_role(args.create)
         create_rolebinding(args.create)
         create_clusterrole(args.create)


### PR DESCRIPTION
Fixes #365 

For the saforcertadmin scripts, we would previously detect the service account secret and read that for the token value. Since we now know the name of the secret, the logic becomes simpler.

For the saforcharttesting scripts, we just add an additional resource to be created. I left the parsing logic intact as it seems to work in my testing, and remains backwards compatible (not that we really need that here).