### PR TITLE
Workaround openshift-tools-installer taking an extra 3 minutes per executions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -201,7 +201,7 @@ jobs:
         uses: redhat-actions/openshift-tools-installer@v1
         with:
           source: github
-          skip_cache: true
+          skip_cache: false # workaround https://github.com/redhat-actions/openshift-tools-installer/issues/105
           chart-verifier: "${{ needs.setup.outputs.verifier-action-image }}"
 
       - name: determine verify requirements
@@ -446,7 +446,7 @@ jobs:
         uses: redhat-actions/openshift-tools-installer@v1
         with:
           source: github
-          skip_cache: true
+          skip_cache: false # workaround https://github.com/redhat-actions/openshift-tools-installer/issues/105
           chart-verifier: ${{ needs.setup.outputs.verifier-action-image }}
 
       - name: Block until there is no running workflow


### PR DESCRIPTION
For whatever reason, the openshift-tools-installer action now takes 3 minutes in our workflow, and we call it ~3 times. On a bad day, that's causing the containing steps to take 4x their normal duration, which is in turn adding enough time to cause our nightly tests (and presumably full E2E) to fail with a 6 hour timeout.

I observed that enabling caching will speed this back up, but disabling the cache has been a conscious decision because of our reuse of the 0.1.0 tag in chart-verifier. That is, we delete and recreate the 0.1.0 as our development release, always reflecting main. By caching, we run the risk of not properly testing new chart-verifier changes as they happen because we may pull an old binary from the cache.

We'll see if that pans out, but for now, we need to release sometime in the near future to fix a bug. To that end...

This PR enables caching for the openshift-tools-installer execution throughout our workflow.

Reference:

- https://github.com/actions/runner-images/issues/10211
- https://github.com/redhat-actions/openshift-tools-installer/issues/105
