### PR TITLE
Allow actions to use node16 temporarily

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,11 @@ on:
   pull_request_target:
     types: [opened, synchronize, reopened, edited, ready_for_review, labeled]
 
+env:
+  # Temporary workaround. See
+  # https://github.com/redhat-actions/openshift-tools-installer/issues/105
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+
 jobs:
   setup:
     name: Setup CI
@@ -201,7 +206,7 @@ jobs:
         uses: redhat-actions/openshift-tools-installer@v1
         with:
           source: github
-          skip_cache: false # workaround https://github.com/redhat-actions/openshift-tools-installer/issues/105
+          skip_cache: true
           chart-verifier: "${{ needs.setup.outputs.verifier-action-image }}"
 
       - name: determine verify requirements
@@ -446,7 +451,7 @@ jobs:
         uses: redhat-actions/openshift-tools-installer@v1
         with:
           source: github
-          skip_cache: false # workaround https://github.com/redhat-actions/openshift-tools-installer/issues/105
+          skip_cache: true
           chart-verifier: ${{ needs.setup.outputs.verifier-action-image }}
 
       - name: Block until there is no running workflow

--- a/.github/workflows/test-cluster-access.yml
+++ b/.github/workflows/test-cluster-access.yml
@@ -6,6 +6,11 @@ name: Test Cluster Access
 on:
   workflow_dispatch:
 
+env:
+  # Temporary workaround. See
+  # https://github.com/redhat-actions/openshift-tools-installer/issues/105
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+
 jobs:
   test-cluster-access:
     name: Test Cluster Access


### PR DESCRIPTION
The previously implemented workaround saved us some time, but not enough. It looks like the core issue is that node20 is actually running for workflows that run are setup to use node16. In my testing, node20 exhibits the issue but node 16 and 18 do not, so I'm temporarily enabling node16 until we can get the tools installer to bump their version.

Also reverting the disabled cache.

https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/