### PR TITLE
Remove openshift-tools-installer workaround

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,11 +4,6 @@ on:
   pull_request_target:
     types: [opened, synchronize, reopened, edited, ready_for_review, labeled]
 
-env:
-  # Temporary workaround. See
-  # https://github.com/redhat-actions/openshift-tools-installer/issues/105
-  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
-
 jobs:
   setup:
     name: Setup CI

--- a/.github/workflows/test-cluster-access.yml
+++ b/.github/workflows/test-cluster-access.yml
@@ -6,11 +6,6 @@ name: Test Cluster Access
 on:
   workflow_dispatch:
 
-env:
-  # Temporary workaround. See
-  # https://github.com/redhat-actions/openshift-tools-installer/issues/105
-  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
-
 jobs:
   test-cluster-access:
     name: Test Cluster Access


### PR DESCRIPTION
With the merging of https://github.com/redhat-actions/openshift-tools-installer/pull/106, the openshift-tools-installer should now be using a Node20 runtime and the issue that was previously observed (3 minute delay for every execution) is now resolved.

This PR removes the workaround that was put in place that allowed a Node16 runtime to be used after its deprecation timeline.

As a sidenote, the openshift-tools-installer@v1.13 is already in use in the pipeline because the PR linked previously is included in the v1 resolution - so we're already using it  we just don't need this environment variable anymore. 

See [here](https://github.com/openshift-helm-charts/sandbox/actions/runs/10091049137/job/27901790294#step:1:39), the commit hash corresponds to https://github.com/redhat-actions/openshift-tools-installer/tree/v1.13
```
Download action repository 'redhat-actions/openshift-tools-installer@v1' (SHA:bee649bbedc67b5bfc2f2de4b19498e11c2e8775)
```