### PR TITLE
Standardize runner images to ubuntu-22.04

### DIFF
--- a/.github/workflows/check-contributor.yml
+++ b/.github/workflows/check-contributor.yml
@@ -37,7 +37,7 @@ jobs:
     outputs:
       is-repo-owner: ${{ steps.populate-output.outputs.is-repo-owner }}
     name: Contributor is repo owner
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository base
         uses: actions/checkout@v4

--- a/.github/workflows/ci-enabled.yml
+++ b/.github/workflows/ci-enabled.yml
@@ -18,7 +18,7 @@ name: Ensure CI is Enabled
 #
 #   next_task:
 #     needs: ensure_ci_enabled
-#     runs-on: ubuntu-latest
+#     runs-on: ubuntu-22.04
 #     steps:
 #     - ...
 
@@ -31,7 +31,7 @@ on:
 
 jobs:
   fail_if_ci_disabled:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Check enablement value
       run: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.repository == 'openshift-helm-charts/development'
 
     strategy:

--- a/.github/workflows/mercury_bot.yml
+++ b/.github/workflows/mercury_bot.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   owners-file-check:
     name: OWNERS file PR checker
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: github.event.pull_request.draft == false && github.actor == 'redhat-mercury-bot'
     steps:
       - name: Checkout

--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   metrics:
     name: Collect and Send Metrics
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       SEGMENT_WRITE_KEY: ${{ secrets.SEGMENT_WRITE_KEY }}
       SEGMENT_TEST_WRITE_KEY: ${{ secrets.SEGMENT_TEST_WRITE_KEY }}

--- a/.github/workflows/nightly_test.yml
+++ b/.github/workflows/nightly_test.yml
@@ -8,7 +8,7 @@ jobs:
   nightly-test:
     name: Nightly Test
     if: github.repository == 'openshift-helm-charts/development'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/owners.yml
+++ b/.github/workflows/owners.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   owners-metrics:
     name: Send Owner Metrics
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: github.actor == 'redhat-mercury-bot'
     env:
       SEGMENT_WRITE_KEY: ${{ secrets.SEGMENT_WRITE_KEY }}

--- a/.github/workflows/python-style.yml
+++ b/.github/workflows/python-style.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   enforce:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout code
       uses: actions/checkout@v4

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   enforce:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout code
       uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
   chart-workflow-release:
     name: Chart Workflow Release
     needs: [check-contributor]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: |
       github.event.pull_request.draft == false &&
       needs.check-contributor.outputs.is-repo-owner == 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
   workflow-test:
     name: Workflow Test
     needs: [check-contributor]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: |
       github.event.pull_request.draft == false &&
       needs.check-contributor.outputs.is-repo-owner == 'true'

--- a/.github/workflows/version_check.yml
+++ b/.github/workflows/version_check.yml
@@ -25,7 +25,7 @@ on:
 jobs:
   check-ocp:
     name: Check OpenShift Version
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
 
       - name: check schedule and main repository
@@ -245,7 +245,7 @@ jobs:
     if: ${{ always() }}
     needs: check-ocp
     name: Check Chart Verifier Version
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: check schedule and main repository
         id: check_repo


### PR DESCRIPTION
This replaces all ubuntu-* references that are not 22.04 to explicitly use 22.04 (which is the equivalent of ubuntu-latest at the time of this writing)