### PR TITLE
Assume webCatalogOnly=False if not found in OWNERS

### DIFF
--- a/scripts/src/submission/submission.py
+++ b/scripts/src/submission/submission.py
@@ -417,10 +417,15 @@ class Submission:
             owners_web_catalog_only = owners_file.get_web_catalog_only(
                 owners_data, raise_if_missing=True
             )
-        except owners_file.ConfigKeyMissing as e:
-            raise WebCatalogOnlyError(
-                f"Failed to find webCatalogOnly key in OWNERS data at {owners_path}"
-            ) from e
+        except owners_file.ConfigKeyMissing:
+            print(
+                f"[INFO] webCatalogOnly key not found in OWNERS data at {owners_path}. Assuming False"
+            )
+            owners_web_catalog_only = False
+        else:
+            print(
+                f"[INFO] webCatalogOnly/providerDelivery from OWNERS : {owners_web_catalog_only}"
+            )
 
         if self.report.found:
             report_path = os.path.join(repo_path, self.report.path)

--- a/scripts/src/submission/submission_test.py
+++ b/scripts/src/submission/submission_test.py
@@ -445,18 +445,25 @@ scenarios_web_catalog_only = [
             submission.WebCatalogOnlyError, match="Failed to get report data"
         ),
     ),
-    # The OWNERS file for this chart doesn't contain the WebCatalogOnly key
+    # The OWNERS file for this chart doesn't contain the WebCatalogOnly key, defaulting to False, and matching the report value
     WebCatalogOnlyScenario(
         input_submission=make_new_report_only_submission(),
-        owners_web_catalog_only=None,
+        owners_web_catalog_only="false",
         report_web_catalog_only="false",
+        expected_output=False,
+    ),
+    # The OWNERS file for this chart doesn't contain the WebCatalogOnly key, defaulting to False, and not matching the report value
+    WebCatalogOnlyScenario(
+        input_submission=make_new_report_only_submission(),
+        owners_web_catalog_only="false",
+        report_web_catalog_only="true",
         excepted_exception=pytest.raises(submission.WebCatalogOnlyError),
     ),
     # Submission contains a report, that doesn't contain the WebCatalogOnly key
     WebCatalogOnlyScenario(
         input_submission=make_new_report_only_submission(),
-        owners_web_catalog_only=None,
-        report_web_catalog_only="false",
+        owners_web_catalog_only="false",
+        report_web_catalog_only=None,
         excepted_exception=pytest.raises(submission.WebCatalogOnlyError),
     ),
     # Submission doesn't contain a report, OWNERS file has WebCatalogOnly set to True


### PR DESCRIPTION
This mimics the current behavior, see: https://github.com/openshift-helm-charts/development/blob/3ac6de443b51d842c4438d9d4922b58b37bbe4c3/scripts/src/checkprcontent/checkpr.py#L36

When `get_web_catalog_only` is called without `raise_if_missing=True` it defaults to `False`.