### PR TITLE
Draft: Fail OWNERS PR from partners

### DIFF
--- a/scripts/src/submission/submission.py
+++ b/scripts/src/submission/submission.py
@@ -362,23 +362,28 @@ class Submission:
 
         return False, ""
 
-    def is_valid_owners_submission(self):
-        """Check wether the file in this Submission are valid for an OWNERS PR
+    def is_valid_owners_submission(self) -> tuple[bool, str]:
+        """Check wether the files in this Submission are valid for an OWNERS PR
 
-        Returns True if the PR only modified files is an OWNERS file.
+        A valid OWNERS PR contains only the OWNERS file, and is not submitted by a partner
 
-        Returns False in all other cases.
         """
+        if (self.chart.category == "partners") and self.modified_owners:
+            # The PR contains an OWNERS file for a partner
+            msg = "[ERROR] OWNERS file should never be set directly by partners. See certification docs."
+            return False, msg
+
         if len(self.modified_owners) == 1 and len(self.modified_files) == 1:
-            return True, ""
+            # Happy path: PR contains a single modified files that is an OWNERS, and is not for a partner
+            return True, "[INFO] OWNERS file changes require manual review by maintainers."
 
-        msg = ""
         if self.modified_owners:
+            # At least one OWNERS file, with other files (modified_files > 1) - or multiple OWNERS files
             msg = "[ERROR] Send OWNERS file by itself in a separate PR."
-        else:
-            msg = "No OWNERS file provided"
+            return False, msg
 
-        return False, msg
+        # No OWNERS have been provided
+        return False, "No OWNERS file provided"
 
     def parse_web_catalog_only(self, repo_path=""):
         """Set the web_catalog_only attribute


### PR DESCRIPTION
In case of an OWNERS PR submitted by a partner, the error message is different than in the case of a community/redhat OWNERS PR.

This copies the existing behavior that can be found here:
https://github.com/openshift-helm-charts/development/blob/3ac6de443b51d842c4438d9d4922b58b37bbe4c3/scripts/src/checkprcontent/checkpr.py#L172-L189