### PR TITLE
Match error message with end to end tests

### DIFF
--- a/scripts/src/submission/submission.py
+++ b/scripts/src/submission/submission.py
@@ -380,7 +380,7 @@ class Submission:
 
         return False, msg
 
-    def parse_web_catalog_only(self, repo_path=""):
+    def parse_web_catalog_only(self, repo_path: str = ""):
         """Set the web_catalog_only attribute
 
         This is achieved by:
@@ -442,13 +442,18 @@ class Submission:
             )
 
             if not owners_web_catalog_only == report_web_catalog_only:
-                raise WebCatalogOnlyError(
-                    f"Value of web_catalog_only in OWNERS ({owners_web_catalog_only}) doesn't match the value in report ({report_web_catalog_only})"
-                )
+                if owners_web_catalog_only:
+                    raise WebCatalogOnlyError(
+                        "[ERROR] The web catalog distribution method is set for the chart but is not set in the report."
+                    )
+                if report_web_catalog_only:
+                    raise WebCatalogOnlyError(
+                        "[ERROR] Report indicates web catalog only but the distribution method set for the chart is not web catalog only."
+                    )
 
         self.is_web_catalog_only = owners_web_catalog_only
 
-    def is_valid_web_catalog_only(self, repo_path=""):
+    def is_valid_web_catalog_only(self, repo_path: str = "") -> tuple[bool, str]:
         """Verify that the submission is coherent with being a WebCatalogOnly submission
 
         A valid web_catalog_only submission must:
@@ -459,24 +464,36 @@ class Submission:
             repo_path (str): path under which the repo has been cloned on the local filesystem
 
         Returns:
-            bool: set to True if the submission is a valid WebCatalogOnly submission.
+            (bool, str): set to True if the submission is a valid WebCatalogOnly submission.
+                         set to False otherwise, with the corresponding error message.
 
         Raise:
             WebCatalogOnlyError if the submitted report cannot be found or read at the expected path.
 
         """
+        # (mgoerens) There are currently no end to end tests that checks for this scenario
         if not self.report.found:
-            return False
+            return (
+                False,
+                "[ERROR] The web catalog distribution method requires the pull request to contain a report.",
+            )
 
         if len(self.modified_files) > 1:
-            return False
+            msg = "[ERROR] The web catalog distribution method requires the pull request to be report only."
+            return False, msg
 
         report_path = os.path.join(repo_path, self.report.path)
         found, report_data = verifier_report.get_report_data(report_path)
         if not found:
             raise WebCatalogOnlyError(f"Failed to get report data at {report_path}")
 
-        return verifier_report.get_package_digest(report_data) is not None
+        if verifier_report.get_package_digest(report_data) is None:
+            return (
+                False,
+                "[ERROR] The web catalog distribution method requires a package digest in the report.",
+            )
+
+        return True, ""
 
 
 def get_file_type(file_path):

--- a/scripts/src/submission/submission_test.py
+++ b/scripts/src/submission/submission_test.py
@@ -415,7 +415,8 @@ scenarios_web_catalog_only = [
         owners_web_catalog_only="true",
         report_web_catalog_only="false",
         excepted_exception=pytest.raises(
-            submission.WebCatalogOnlyError, match="doesn't match the value"
+            submission.WebCatalogOnlyError,
+            match="The web catalog distribution method is set for the chart but is not set in the report.",
         ),
     ),
     # Submission contains a report file with WebCatalogOnly set to False, not matching the content of OWNERS
@@ -424,7 +425,8 @@ scenarios_web_catalog_only = [
         owners_web_catalog_only="false",
         report_web_catalog_only="true",
         excepted_exception=pytest.raises(
-            submission.WebCatalogOnlyError, match="doesn't match the value"
+            submission.WebCatalogOnlyError,
+            match="Report indicates web catalog only but the distribution method set for the chart is not web catalog only.",
         ),
     ),
     # Submission doesn't relate to an existing OWNERS
@@ -547,7 +549,8 @@ class IsWebCatalogOnlyScenario:
     input_submission: submission.Submission
     create_report: bool = True
     report_has_digest: bool = None
-    expected_output: bool = None
+    expected_is_valid_web_catalog_only: bool = None
+    expected_reason: str = ""
 
 
 scenarios_is_web_catalog_only = [
@@ -555,19 +558,21 @@ scenarios_is_web_catalog_only = [
     IsWebCatalogOnlyScenario(
         input_submission=make_new_report_only_submission(),
         report_has_digest=True,
-        expected_output=True,
+        expected_is_valid_web_catalog_only=True,
     ),
     # Submission contains only a report, but report contains no digest
     IsWebCatalogOnlyScenario(
         input_submission=make_new_report_only_submission(),
         report_has_digest=False,
-        expected_output=False,
+        expected_is_valid_web_catalog_only=False,
+        expected_reason="The web catalog distribution method requires a package digest in the report.",
     ),
     # Submission contains no report
     IsWebCatalogOnlyScenario(
         input_submission=make_new_tarball_only_submission(),
         create_report=False,
-        expected_output=False,
+        expected_is_valid_web_catalog_only=False,
+        expected_reason="The web catalog distribution method requires the pull request to contain a report.",
     ),
     # Submission contains a report and other files
     IsWebCatalogOnlyScenario(
@@ -590,7 +595,8 @@ scenarios_is_web_catalog_only = [
             ),
         ),
         report_has_digest=True,
-        expected_output=False,
+        expected_is_valid_web_catalog_only=False,
+        expected_reason="The web catalog distribution method requires the pull request to be report only.",
     ),
 ]
 
@@ -630,10 +636,14 @@ def test_is_valid_web_catalog_only(test_scenario):
                 )
             report_file.close()
 
-        assert (
+        is_valid_web_catalog_only, reason = (
             test_scenario.input_submission.is_valid_web_catalog_only(repo_path=temp_dir)
-            == test_scenario.expected_output
         )
+        assert (
+            test_scenario.expected_is_valid_web_catalog_only
+            == is_valid_web_catalog_only
+        )
+        assert test_scenario.expected_reason in reason
 
 
 def create_new_index(charts: list[submission.Chart] = []):


### PR DESCRIPTION
End to end tests expect specific messages to be present in the failed PR comments.

This PR aligns the error message from the submission module so that end to end tests may pass.

For instance: https://github.com/openshift-helm-charts/development/blob/main/tests/functional/behave_features/HC-06_provider_delivery_control.feature#L46-L47