### PR TITLE
Allow ignoring the presence of an OWNERS file

### DIFF
--- a/scripts/src/submission/submission.py
+++ b/scripts/src/submission/submission.py
@@ -332,13 +332,20 @@ class Submission:
         else:
             self.modified_unknown.append(file_path)
 
-    def is_valid_certification_submission(self):
+    def is_valid_certification_submission(
+        self, ignore_owners: bool = False
+    ) -> tuple[bool, str]:
         """Check wether the files in this Submission are valid to attempt to certify a Chart
 
         We expect the user to provide either:
         * Only a report file
         * Only a chart - either as source or tarball
         * Both the report and the chart
+
+        Note: While an OWNERS file should never be present in this type of submission, the case of
+        an invalid Submission containing a mix of OWNERS and other files is handled in the
+        is_valid_owners_submission method. The flag "ignore_owners" allows for skipping this
+        speficic check.
 
         Returns False if:
         * The user attempts to create the OWNERS file for its project.
@@ -347,7 +354,7 @@ class Submission:
         Returns True in all other cases
 
         """
-        if self.modified_owners:
+        if self.modified_owners and not ignore_owners:
             return False, "[ERROR] Send OWNERS file by itself in a separate PR."
 
         if self.modified_unknown:


### PR DESCRIPTION
When validating that a PR contains the correct set of file to certify a chart, this PR adds the possibility to ignore the fact that an OWNERS file is also present.

While an OWNERS file should never be present in this type of submission, the case of an invalid Submission containing a mix of OWNERS and other files is handled in the is_valid_owners_submission method.

Eventually, errors related to OWNERS file (which this belongs to) feed the owners-error-message GITHUB OUTPUT, while other errors feed the pr-content-error-message GITHUB OUTPUT.

EDIT: Current behavior can be checked in the checkpr module starting here: https://github.com/openshift-helm-charts/development/blob/3ac6de443b51d842c4438d9d4922b58b37bbe4c3/scripts/src/checkprcontent/checkpr.py#L120