### PR TITLE
fix missing RELEASE_TAG value for index update commits

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -497,6 +497,7 @@ jobs:
         env:
           CHART_ENTRY_NAME: ${{ needs.chart-verifier.outputs.chart_entry_name }}
           WEB_CATALOG_ONLY: ${{ needs.chart-verifier.outputs.web_catalog_only }}
+          RELEASE_TAG: ${{ needs.chart-verifier.outputs.release_tag }}
         run: |
           INDEX_BRANCH=$(if [ "${GITHUB_REF}" = "refs/heads/main" ]; then echo "gh-pages"; else echo "${GITHUB_REF##*/}-gh-pages"; fi)
 


### PR DESCRIPTION
Index update commit messages no longer have the chart's release information (i.e. org-chartname-version).  This is because there is data not being transferred across jobs in the certification workflow.

The `RELEASE_TAG` environment variable is used in this script, but has no value assigned to it. It's being set in a previous job, so we can easily pass along this variable to this script.