### PR TITLE
Install oc without external action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -267,9 +267,11 @@ jobs:
       - name: Install oc
         id: install-oc
         if: ${{ steps.verify_requires.outputs.cluster_needed == 'true' }}
-        uses: redhat-actions/openshift-tools-installer@v1
-        with:
-          oc: latest
+        run: |
+          wget --quiet https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-client-linux.tar.gz
+          tar -zxvf openshift-client-linux.tar.gz oc -C /usr/local/bin/
+          rm -f openshift-client-linux.tar.gz
+          oc version --client
 
       - name: Set cluster login params
         id: login-params


### PR DESCRIPTION
The redhat-actions/openshift-tools-installer is experiencing slowness when installing oc. This steps can take up to 3 minutes. More info: https://github.com/redhat-actions/openshift-tools-installer/issues/105

Using a custom script reduces the installation of oc to less than 10s.