### PR TITLE
ignore not found errors for ignored files that are not found in dest repo

### DIFF
--- a/scripts/src/release/releaser.py
+++ b/scripts/src/release/releaser.py
@@ -112,12 +112,19 @@ def make_required_changes(release_info_dir, origin, destination):
     ignores = release_info.get_ignores(from_repository, to_repository, release_info_dir)
     for ignore in ignores:
         ignore_this = f"{destination}/{ignore}"
-        if os.path.isdir(ignore_this):
-            print(f"Ignore/delete directory {ignore_this}")
-            shutil.rmtree(ignore_this)
-        else:
-            print(f"Ignore/delete file {ignore_this}")
-            os.remove(ignore_this)
+        try:
+            if os.path.isdir(ignore_this):
+                print(f"Ignore/delete directory {ignore_this}")
+                shutil.rmtree(ignore_this)
+            else:
+                print(f"Ignore/delete file {ignore_this}")
+                os.remove(ignore_this)
+        except FileNotFoundError as e:
+            print(
+                f"[INFO] path {ignore_this} is explicitly ignored but was not found when syncing {from_repository} to {to_repository}."
+                + "This file can be removed from the ignore section of release_info.json"
+            )
+            continue
 
 
 def main():


### PR DESCRIPTION
If a maintainer removed a file from the repository that was "ignored" in the release_info.json, which controls the syncing of repositories, the release process would fail. In the case a FileNotFoundError is thrown by either the `shutil.rmtree` or `os.remove` commands during the ignore process, we should treat it as non-fatal given the outcome is the same (the file does not exist in the destination repository).