### PR TITLE
Consolidate setup-python version definition to one place

### DIFF
--- a/.github/actions/generate-chart-locks/action.yaml
+++ b/.github/actions/generate-chart-locks/action.yaml
@@ -58,10 +58,8 @@ runs:
     with:
       ref: ${{ steps.resolve.outputs.ref }}
       path: temp-gen-chart-lock-repo
-  - name: Setting up python
-    uses: actions/setup-python@v5
-    with:
-      python-version: "3.10"
+  - name: Set up Python
+    uses: ./.github/actions/setup-python
   - name: Generate lock file JSON from existing charts
     working-directory: temp-gen-chart-lock-repo
     id: generate-chart-locks

--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -1,0 +1,13 @@
+name: Setup Python
+description: |
+  Consistently installs python across this project. Should be used as a
+  replacement for direct calls to actions/setup-python.
+
+  Serves as the single place to update python versions over time across the
+  project.
+runs:
+  using: composite
+  steps:
+  - uses: actions/setup-python@v5
+    with:
+      python-version: '3.10'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,10 +21,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up Python 3.x Part 1
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.10"
+      - name: Set up Python
+        uses: ./.github/actions/setup-python
 
       - name: Set up Python 3.x Part 2
         run: |
@@ -123,10 +121,8 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           path: "pr-branch"
 
-      - name: Set up Python 3.x Part 1
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.10"
+      - name: Set up Python
+        uses: ./.github/actions/setup-python
 
       - name: Set up Python 3.x Part 2
         run: |
@@ -428,10 +424,8 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           path: "pr-branch"
 
-      - name: Set up Python 3.x Part 1
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.10"
+      - name: Set up Python
+        uses: ./.github/actions/setup-python
 
       - name: Set up Python 3.x Part 2
         run: |

--- a/.github/workflows/check-contributor.yml
+++ b/.github/workflows/check-contributor.yml
@@ -43,9 +43,7 @@ jobs:
         uses: actions/checkout@v4
       
       - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.10"
+        uses: ./.github/actions/setup-python
       
       - name: Install CI Scripts
         run: |

--- a/.github/workflows/check-locks-on-owners-submission.yml
+++ b/.github/workflows/check-locks-on-owners-submission.yml
@@ -29,10 +29,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         
-      - name: Set up Python 3.x Part 1
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.10"
+      - name: Set up Python
+        uses: ./.github/actions/setup-python
 
       - name: Set up Python 3.x Part 2
         run: |

--- a/.github/workflows/lock-sanity-check.yml
+++ b/.github/workflows/lock-sanity-check.yml
@@ -18,10 +18,8 @@ jobs:
     steps:
     - name: checkout
       uses: actions/checkout@v4
-    - name: Set up Python 3.x Part 1
-      uses: actions/setup-python@v5
-      with:
-        python-version: "3.10"
+    - name: Set up Python
+      uses: ./.github/actions/setup-python
     - name: Set up Python 3.x Part 2
       run: |
         # set up python

--- a/.github/workflows/mercury_bot.yml
+++ b/.github/workflows/mercury_bot.yml
@@ -24,10 +24,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         
-      - name: Set up Python 3.x Part 1
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.10"
+      - name: Set up Python
+        uses: ./.github/actions/setup-python
 
       - name: Set up Python 3.x Part 2
         run: |

--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -23,10 +23,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up Python 3.x Part 1
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.10"
+      - name: Set up Python
+        uses: ./.github/actions/setup-python
 
       - name: Set up Python 3.x Part 2
         run: |

--- a/.github/workflows/nightly_test.yml
+++ b/.github/workflows/nightly_test.yml
@@ -16,10 +16,8 @@ jobs:
           token: ${{ secrets.BOT_TOKEN }}
           fetch-depth: 0
 
-      - name: Set up Python 3.x Part 1
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.10"
+      - name: Set up Python
+        uses: ./.github/actions/setup-python
 
       - name: Set up Python 3.x Part 2
         run: |

--- a/.github/workflows/owners-redhat.yml
+++ b/.github/workflows/owners-redhat.yml
@@ -49,9 +49,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.10"
+        uses: ./.github/actions/setup-python
 
       - name: Install Python CI tooling
         working-directory: scripts
@@ -83,9 +81,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.10"
+        uses: ./.github/actions/setup-python
       - name: Install Python CI tooling
         working-directory: scripts
         run: |

--- a/.github/workflows/owners.yml
+++ b/.github/workflows/owners.yml
@@ -16,10 +16,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up Python 3.x Part 1
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.10"
+      - name: Set up Python
+        uses: ./.github/actions/setup-python
 
       - name: Set up Python 3.x Part 2
         run: |

--- a/.github/workflows/python-style.yml
+++ b/.github/workflows/python-style.yml
@@ -12,10 +12,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
-    - name: Set up Python 3.x Part 1
-      uses: actions/setup-python@v5
-      with:
-        python-version: "3.10"
+    - name: Set up Python
+      uses: ./.github/actions/setup-python
     - name: Install style tooling
       working-directory: scripts
       run: make venv.codestyle

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -12,10 +12,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
-    - name: Set up Python 3.x Part 1
-      uses: actions/setup-python@v5
-      with:
-        python-version: "3.10"
+    - name: Set up Python
+      uses: ./.github/actions/setup-python
     - name: Set up Python 3.x Part 2
       run: |
         # set up python

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,10 +31,8 @@ jobs:
           fetch-depth: 0
           path: "pr-branch"
 
-      - name: Set up Python 3.x Part 1
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.10"
+      - name: Set up Python
+        uses: ./.github/actions/setup-python
 
       - name: Set up Python scripts in pr-branch
         working-directory: ./pr-branch
@@ -134,9 +132,7 @@ jobs:
 
       - name: Set up Python 3.x Part 1
         if: ${{ steps.reflect_on_pr_content.outputs.create_pull_requests == 'true' }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.10"
+        uses: ./.github/actions/setup-python
 
       - name: Set up Python scripts on dev branch
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,10 +47,8 @@ jobs:
           token: ${{ secrets.BOT_TOKEN }}
           fetch-depth: 0
 
-      - name: Set up Python 3.x Part 1
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.10"
+      - name: Set up Python
+        uses: ./.github/actions/setup-python
 
       - name: Set up Python 3.x Part 2
         run: |

--- a/.github/workflows/version_check.yml
+++ b/.github/workflows/version_check.yml
@@ -156,9 +156,7 @@ jobs:
       - name: Set up Python 3.x Part 1
         if: |
           steps.check_test.outputs.run_tests == 'true'
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.10"
+        uses: ./.github/actions/setup-python
 
       - name: Set up Python 3.x Part 2
         if: |
@@ -363,9 +361,7 @@ jobs:
       - name: Set up Python 3.x Part 1
         if: |
           steps.check_test.outputs.run_tests == 'true'
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.10"
+        uses: ./.github/actions/setup-python
 
       - name: Set up Python 3.x Part 2
         if: |


### PR DESCRIPTION
This PR just consolidates the installation of python into a single place in-repo that can be reused across workflows. In practice, this should allow us to update a single place as the python version advances and have it impact all workflows of interest. 

In the future, we can potentially do this exact same thing with the installation of the CI scripts. Task for another day.