### PR TITLE
Reduce concurrency to lower API rate limiting frequency

### DIFF
--- a/.github/workflows/behave.yml
+++ b/.github/workflows/behave.yml
@@ -103,7 +103,7 @@ jobs:
     needs: [get-features]
     strategy:
       fail-fast: false
-      max-parallel: 4
+      max-parallel: 3
       matrix: 
         feature-file: ${{ fromJson(needs.get-features.outputs.features) }}
     steps:


### PR DESCRIPTION
We keep hitting GitHub API limits in nightly testing, which causes failures that succeed in a re-run. I'll spend time in early 2025 investigating what can be done to optimize our API usage, but for the moment, this PR will reduce the concurrency operations to see if it helps get us past these issues until then.

I intend to measure our API usage more aggressively to determine a better course of action in the near future.