### PR TITLE
Failover register original branch in repo_manager

### DIFF
--- a/tests/functional/behave_features/common/utils/workflow_repo_manager.py
+++ b/tests/functional/behave_features/common/utils/workflow_repo_manager.py
@@ -44,7 +44,10 @@ class WorkflowRepoManager:
                 "Unable to initialize git repository. Is the current directory a git repo?"
             ) from e
 
-        self.original_branch = self.repo.active_branch.name
+        try:
+            self.original_branch = self.repo.active_branch.name
+        except TypeError:
+            self.original_branch = self.repo.git.rev_parse("--short", "HEAD")
 
     def set_auth_token(self, token: str):
         """Sets the github API token."""


### PR DESCRIPTION
Upon initialization, WorkflowRepoManager registers the repository original branch, so that it can return to that branch during cleanup. If the tests are run on a detached HEAD, this operation fails as it expects to be on a git branch.

This commit adds a failover to handle that particular case, defaulting to using the commit ID.