### PR TITLE
Instanciate new empty lists for each instance of WorkflowRepoManager

### DIFF
--- a/tests/functional/behave_features/common/utils/workflow_repo_manager.py
+++ b/tests/functional/behave_features/common/utils/workflow_repo_manager.py
@@ -7,36 +7,27 @@ import git
 
 from tempfile import TemporaryDirectory
 
-import common.utils.github as github
-
-
 class RepoManagementError(Exception):
     pass
 
 
 class WorkflowRepoManager:
-    # Keep a log of things created so we can clean them up.
-    __local_branches_created: [str] = []
-    __local_worktrees_created: [TemporaryDirectory] = []
-    # (remote, branch), e.g. ('openshift-helm-charts/charts, 'my-pr-branch')
-    __remote_branches_created: [(str, str)] = []
-
-    # The token to use for GitHub API operations.
-    __authtoken: str = ""
-
-    # The branch at repo initialization. On Cleanup, we return to this branch
-    # before we remove locally generated branches.
-    original_branch: str = None
-
-    # Working directory at instantiation.
-    old_cwd: str = os.getcwd()
-
-    # The repository at working directory.
-    repo: git.Repo = None
-
     def __init__(self):
         logging.debug(f"{self} --> __init__ called!")
 
+        # Keep a log of things created so we can clean them up.
+        self.__local_branches_created: list[str] = []
+        self.__local_worktrees_created: list[TemporaryDirectory] = []
+        # (remote, branch), e.g. ('openshift-helm-charts/charts, 'my-pr-branch')
+        self.__remote_branches_created: list[tuple(str, str)] = []
+
+        # The token to use for GitHub API operations.
+        self.__authtoken: str = None
+
+        # Working directory at instantiation.
+        self.old_cwd: str = os.getcwd()
+
+        # The repository at working directory.
         try:
             self.repo = git.Repo()
         except git.InvalidGitRepositoryError as e:
@@ -44,6 +35,8 @@ class WorkflowRepoManager:
                 "Unable to initialize git repository. Is the current directory a git repo?"
             ) from e
 
+        # The branch at repo initialization. On Cleanup, we return to this branch
+        # before we remove locally generated branches.
         try:
             self.original_branch = self.repo.active_branch.name
         except TypeError:
@@ -94,6 +87,7 @@ class WorkflowRepoManager:
             self.repo.git.checkout("-b", branch_name)
         except (git.GitCommandError, ValueError) as e:
             raise RepoManagementError("Unable to create branch") from e
+        logging.debug(f'Adding {branch_name} to local_branches_created')
         self.__local_branches_created.append(branch_name)
 
     def add_worktree(self) -> TemporaryDirectory:


### PR DESCRIPTION
Previously we were assigning values to attributes on the class level. For list in particular, this had the side effect of leaking values between instances:

```
>>> m = OwnersFileSubmissionsE2ETest()
>>> m.repo_manager._WorkflowRepoManager__local_branches_created
['e2e-owners-d376dfa-6d3820eb5c624ddc9066f96f1a69640e']
>>> m.cleanup()
>>> m.repo_manager._WorkflowRepoManager__local_branches_created
[]
>>> m = OwnersFileSubmissionsE2ETest()
>>> m.repo_manager._WorkflowRepoManager__local_branches_created
['e2e-owners-d376dfa-6d3820eb5c624ddc9066f96f1a69640e', 'e2e-owners-d376dfa-cc7f8acf1850498cb6c758bc286f2bec']
```

Using a dataclass for WorkflowRepoManager, we can ensure that empty lists are initialized for each new instance, and attributes values remain independant.

Fix #414