### PR TITLE
Increase retry timeout when polling CI run result

### DIFF
--- a/tests/functional/behave_features/common/utils/github.py
+++ b/tests/functional/behave_features/common/utils/github.py
@@ -36,7 +36,7 @@ def get_run_id(secrets, workflow_name: str, pr_number: str = None):
         )
 
 
-@retry(stop_max_delay=60_000 * 40, wait_fixed=2000)
+@retry(stop_max_delay=60_000 * 40, wait_fixed=10000)
 def get_run_result(secrets, run_id):
     r = github_api(
         "get", f"repos/{secrets.test_repo}/actions/runs/{run_id}", secrets.bot_token


### PR DESCRIPTION
During end to end tests, we query the GitHub API regularly to check if the pipeline associated with the test PR has completed. This commit increase the retry timeout in order to decrease the total amount of API calls that the bot account is performing. This helps with staying within the GitHub API rate limits as highlighted in #422.