### PR TITLE
Increase concurrency back to 4

### DIFF
--- a/.github/workflows/behave.yml
+++ b/.github/workflows/behave.yml
@@ -103,7 +103,7 @@ jobs:
     needs: [get-features]
     strategy:
       fail-fast: false
-      max-parallel: 2
+      max-parallel: 4
       matrix: 
         feature-file: ${{ fromJson(needs.get-features.outputs.features) }}
     steps:


### PR DESCRIPTION
We used to have issues with hitting GitHub API rate limits, which lead us to reduce the concurrency (from 4 to 3, then again to 2) as a mitigation measure.

Following #422, we have reduced our github api consumption and don't hit github api rate limits any longer. It is safe to assume that concurrency can be increased to its original value.

Note that increasing concurrency doesn't means an increase in API consumption, just that we consume the budget faster.