### PR TITLE
Ensure extracted oc binary ends up in dir specified

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -298,7 +298,7 @@ jobs:
         if: ${{ steps.verify_requires.outputs.cluster_needed == 'true' }}
         run: |
           wget --quiet https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-client-linux.tar.gz
-          tar -zxvf openshift-client-linux.tar.gz oc -C /usr/local/bin/
+          tar -zxvf openshift-client-linux.tar.gz --directory /usr/local/bin/ oc
           rm -f openshift-client-linux.tar.gz
           oc version --client
 


### PR DESCRIPTION
Seeing errors in smoke testing that indicate the oc binary is not in path. Seems linked to the order of operations in the extraction. This pull request fixes the order and expands the short flag (just a preference).