### PR TITLE
use new RateLimitOverview class to check GitHub rate limit information

### DIFF
--- a/scripts/src/metrics/metrics.py
+++ b/scripts/src/metrics/metrics.py
@@ -549,10 +549,11 @@ def send_metric(write_key, id, event, properties):
     analytics.track(id, event, properties)
 
 
-def check_rate_limit(g, force):
+def check_rate_limit(g: Github, force: bool):
+    """Emits a log line containing rate limit information if forced or if running low on remaining requests."""
     rate_limit = g.get_rate_limit()
-    if force or rate_limit.core.remaining < 10:
-        print(f"[INFO] rate limit info: {rate_limit.core}")
+    if force or rate_limit.resources.core.remaining < 10:
+        print(f"[INFO] rate limit info: {rate_limit.resources.core}")
 
 
 def getChartUpdate(type, partner, chart, cwd):


### PR DESCRIPTION
The PyGithub library was updated in this pull request: https://github.com/openshift-helm-charts/development/pull/439.,

It introduced a documented breaking change when requesting rate limit information via the Github object. This pull request implements the changes suggested in their [changelog](https://github.com/PyGithub/PyGithub/blob/ad278c5f33931c33f374de5d03a3f3d0831c4aaf/doc/changes.rst?plain=1#L13-L25) and adds some documentation while I'm working with this function.

Should resolve issues with the "Scheduled Metrics" workflow.