### PR TITLE
Ensure submission category metadata is in place for OWNERS-only submissions

### DIFF
--- a/scripts/src/submission/submission.py
+++ b/scripts/src/submission/submission.py
@@ -324,6 +324,8 @@ class Submission:
                 self.chart.register_chart_info(category, organization, name, version)
                 self.set_tarball(file_path, match)
             elif file_category == "owners":
+                category, organization, name = match.groups()
+                self.chart.register_chart_info(category, organization, name)
                 self.modified_owners.append(file_path)
             elif file_category == "unknown":
                 self.modified_unknown.append(file_path)

--- a/scripts/src/submission/submission_test.py
+++ b/scripts/src/submission/submission_test.py
@@ -178,6 +178,12 @@ scenarios_submission_init = [
         ],
         expected_submission=submission.Submission(
             api_url="https://api.github.com/repos/openshift-helm-charts/charts/pulls/6",
+            chart=submission.Chart(
+                category=expected_chart.category,
+                organization=expected_chart.organization,
+                name=expected_chart.name,
+                # OWNERS submissions do not contain version information.
+            ),
             modified_files=[
                 f"charts/{expected_category}/{expected_organization}/{expected_name}/OWNERS"
             ],


### PR DESCRIPTION
OWNERS file modifications made by partners would receive the typical response for non-partners (e.g. "must be reviewed by maintainers") instead of instructing them to make changes in their partner dashboard. This seemed to be caused by the submission category not being populated because of this missing matcher, which reads the submission path. Should be resolved here.