### PR TITLE
Add event base ref for debugging

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,8 +31,10 @@ jobs:
       - run: |
           echo "[DEBUG] GITHUB_REF value is ${GITHUB_REF}"
           echo "[DEBUG] github.ref value is ${CONTEXT_REF}"
+          echo "[DEBUG] github.event.pull_request.base.ref is ${EVENT_BASE_REF}"
         env:
           CONTEXT_REF: ${{ github.ref }}
+          EVENT_BASE_REF: ${{ github.event.pull_request.base.ref }}
 
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Testing to see if event base ref is present even if GITHUB_REF or the context-provided value is not. We may merge this to observe the behavior of a failing nightly when the GITHUB_REF value's are empty and fail a workflow.