### PR TITLE
Add Slack ping when PR needs maintainer review

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -543,6 +543,15 @@ jobs:
               body: comment
             });
 
+      - name: Send message to helm_dev slack channel
+        id: notify_to_dev
+        if: github.repository == 'openshift-helm-charts/charts' && steps.pr_comment.outputs.ping_helm_dev == 'true'
+        uses: archive/github-actions-slack@v2.8.0
+        with:
+          slack-bot-user-oauth-access-token: ${{ secrets.SLACK_BOT_USER_OAUTH_ACCESS_TOKEN }}
+          slack-channel: C02979BDUPL
+          slack-text: PR needs maintainer review ${{ github.server_url }}/${{ github.repository }}/pull/${{ github.event.number }}
+
       # The steps running chart-verifier may be skipped in some valid case, for instance if the user
       # provided a valid report.yaml
       - name: Add 'authorized-request' label to PR

--- a/scripts/src/pullrequest/prepare_pr_comment.py
+++ b/scripts/src/pullrequest/prepare_pr_comment.py
@@ -248,6 +248,7 @@ def main():
                 outcome = "Pending Manual Review"
                 detail_message = append_to(detail_message, prepare_community_comment())
                 gitutils.add_output("pr_passed", "true")
+                gitutils.add_output("ping_helm_dev", "true")
             else:
                 detail_message = append_to(detail_message, prepare_failure_comment())
                 gitutils.add_output("pr_passed", "false")


### PR DESCRIPTION
Fix #453

This sends a message to our helm-dev slack channel. ~Note that I haven't actually tested it, but reused the same logic used in other places (just adapted the message and the conditions)~