### PR TITLE
Fix exception hierarchy

### DIFF
--- a/scripts/src/submission/submission.py
+++ b/scripts/src/submission/submission.py
@@ -50,7 +50,7 @@ class ReleaseTagError(SubmissionError):
     pass
 
 
-class ChartError(Exception):
+class ChartError(SubmissionError):
     pass
 
 
@@ -238,7 +238,7 @@ class Submission:
     def __post_init__(self):
         """Complete the initialization of the Submission object.
 
-        Only retrieve PR information from the GitHub API if requiered, by checking for the presence
+        Only retrieve PR information from the GitHub API if required, by checking for the presence
         of a value for the modified_files attributes. This check allows to make the distinction
         between the two aforementioned cases of initialization of a Submission object:
         * If modified_files is not set, we're in the case of initializing a brand new Submission


### PR DESCRIPTION
In cases where a new redhat OWNERS file is added but the chart doesn't contain the redhat- prefix, the workflow would fail without creating a comment for the user due to trying to download the Submission artifact.

This artifact is missing (this is expected), because there was an issue during the parsing of the modified file in 'validate-submission'. This step should created a GitHub output 'submission_file_present'. This was not happening in that particular case due to 'ChartError' (exception raised when RedHat chart is missing the redhat- prefix) not being a SubmissionError exception.

Fix #465