### PR TITLE
Add permissions at workflow call point

### DIFF
--- a/.github/workflows/nightly_test.yml
+++ b/.github/workflows/nightly_test.yml
@@ -8,6 +8,8 @@ jobs:
   nightly-test:
     name: Nightly Test
     if: github.repository == 'openshift-helm-charts/development'
+    permissions:
+      contents: read
     uses: ./.github/workflows/behave.yml
     with:
       tags: full

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ jobs:
   check-contributor:
     name: Check contributor
     uses: ./.github/workflows/check-contributor.yml
+    permissions:
+      contents: read
     with:
       user: ${{ github.event.pull_request.user.login }}
       fail-workflow-if-not: true
@@ -129,6 +131,8 @@ jobs:
     if: |
       needs.determine-workflow-conditions.outputs.create-pull-requests == 'true'
     uses: ./.github/workflows/behave.yml
+    permissions:
+      contents: read
     with:
       tags: full
       behave-logging-level: WARNING

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,8 @@ jobs:
   check-contributor:
     name: Check contributor
     uses: ./.github/workflows/check-contributor.yml
+    permissions:
+      contents: read
     with:
       user: ${{ github.event.pull_request.user.login }}
 
@@ -120,6 +122,8 @@ jobs:
     if: |
       needs.determine-workflow-conditions.outputs.run-tests == 'true'
     uses: ./.github/workflows/behave.yml
+    permissions:
+      contents: read
     with:
       # Default tags to 'full' if test-tags is unset for any reason by the time
       # we get here.


### PR DESCRIPTION
Documentation is a little unclear but this adds permissions blocks at workflow call point that should align with the workflow call itself, just in case it matters.