### PR TITLE
replace pulled content with hash over branch reference

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,10 @@ env:
   # information.
   RESOLVED_GITHUB_REF: ${{ github.ref || format('refs/heads/{0}', (github.event.pull_request.base.ref || ''))  }}
 
+concurrency:
+  group: cert-ci-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   setup:
     name: Setup CI
@@ -163,7 +167,7 @@ jobs:
         if: ${{ needs.setup.outputs.run_build == 'true' }}
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           path: "pr-branch"
 
@@ -263,7 +267,7 @@ jobs:
         if: ${{ needs.setup.outputs.run_build == 'true' }}
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           path: "pr-branch"
 
@@ -480,7 +484,7 @@ jobs:
         if: ${{ needs.setup.outputs.run_build == 'true' }}
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           path: "pr-branch"
 
@@ -631,7 +635,7 @@ jobs:
         if: ${{ needs.setup.outputs.run_build == 'true' }}
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           path: "pr-branch"
 


### PR DESCRIPTION
This pull request limits CI runs for a given pull request to 1 active workflow run at a time. In addition, it replaces ref-based pull request content pulls (e.g. for testing the submitted chart content).