### PR TITLE
Prioritize long running behave feature

### DIFF
--- a/.github/workflows/behave.yml
+++ b/.github/workflows/behave.yml
@@ -92,7 +92,8 @@ jobs:
         run: |
           set -e
           cd tests/functional/behave_features
-          features=$(find . -name '*.feature' | sed -e 's%\./%%g' | jq -R -s -c 'split("\n") | del(.[] | select(length == 0))')
+          # Format the names of the features into a json array and prioritize the HC-16 feature by placing it at the beginning of the array.
+          features=$(find . -name '*.feature' | sed -e 's%\./%%g' | jq -R -s -c 'split("\n") | del(.[] | select(length == 0)) | sort_by(startswith("HC-16")) | reverse')
           [ "${features}" == "" ] && { echo "The feature file variable was empty"; exit 1 ;}
           echo "Found feature files: ${features}"
           echo "Running sanity checks."


### PR DESCRIPTION
The HC-16 feature takes more than 90 minutes to complete. To optimize the duration of end to end tests, this commits ensures that it is starting first.

The order in which the features are placed in the array is not deterministic when using the find command i.e. the features are ran in a random order.

The sort_by jq filter places the element starting with "HC-16" string at the end of the array, requiring to then reverse the array to place it at the front.

Fix #407