### PR TITLE
Add check of tarball content

### DIFF
--- a/scripts/src/submission/validate.py
+++ b/scripts/src/submission/validate.py
@@ -42,7 +42,7 @@ def craft_pr_content_error_msg(
 
     """
     try:
-        s.parse_modified_files()
+        s.parse_modified_files(repo_path="pr-branch")
     except submission.SubmissionError as e:
         raise ParseFilesError(str(e))
 


### PR DESCRIPTION
Checks that the tarball contains a unique directory named after the chart. This directory must contain a Chart.yaml file. The directory may contain additional files or folders. No other files or folder should be placed at the root of the archive.

Fix #342

Running the check on all tarballs currently in the charts repo, I'm getting some (expected) errors with the redhat charts that were renamed:
```
❯ python check_tarfile_content.py -d tarball_dir/
Error with tarball redhat-data-grid-8.3.0.tgz: [ERROR] Incorrect tarball content: expected a redhat-data-grid directory
Error with tarball redhat-data-grid-8.3.1.tgz: [ERROR] Incorrect tarball content: expected a redhat-data-grid directory
Error with tarball redhat-data-grid-8.4.0.tgz: [ERROR] Incorrect tarball content: expected a redhat-data-grid directory
Error with tarball redhat-data-grid-8.4.2.tgz: [ERROR] Incorrect tarball content: expected a redhat-data-grid directory
Error with tarball redhat-data-grid-8.4.3.tgz: [ERROR] Incorrect tarball content: expected a redhat-data-grid directory
Error with tarball redhat-semeru-transition-1.0.0.tgz: [ERROR] Incorrect tarball content: expected a redhat-semeru-transition directory
```

For instance the redhat-data-grid-8.3.0.tgz tarball contains a `data-grid` directory instead. Newer versions of this chart contain valid tarball.

For redhat-semeru-transition-1.0.0.tgz, there is no newer version than 1.0.0

