### PR TITLE
Add BOT_TOKEN env var for tests to run on release

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,6 +79,7 @@ jobs:
           github.event_name == 'pull_request_target' && steps.check_request.outputs.run-tests == 'true'
         env:
           BOT_NAME: ${{ secrets.BOT_NAME }}
+          BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
           PR_API_URL: ${{ github.event.pull_request._links.self.href }}
           SENDER: ${{ github.event.sender.login }}
           PR_BRANCH: ${{ github.event.pull_request.head.ref }}


### PR DESCRIPTION
The PR release on the prod repo is failing to run the end to end tests due to the BOT_TOKEN environment variable to be missing.

Note: This is not actually tested as it would require to create a dummy release on the prod repo with this code... Not sure if it is worth the hassle for such a small change