### PR TITLE
Fix error message for PRs with OWNERS and chart

### DIFF
--- a/scripts/src/submission/submission.py
+++ b/scripts/src/submission/submission.py
@@ -101,7 +101,7 @@ class Chart:
             (self.category and self.category != category)
             or (self.organization and self.organization != organization)
             or (self.name and self.name != name)
-            or (self.version and self.version != version)
+            or (self.version and version and self.version != version)
         ):
             msg = "[ERROR] A PR must contain only one chart. Current PR includes files for multiple charts."
             raise DuplicateChartError(msg)

--- a/scripts/src/submission/submission_test.py
+++ b/scripts/src/submission/submission_test.py
@@ -335,6 +335,33 @@ scenarios_submission_init = [
             ],
         ),
     ),
+    # PR contains a report and an OWNERS file
+    # While this is an invalid PR, there shouldn't be any error during the initalization of the Submission object.
+    # This specific error is handled in the is_valid_certification_submission test.
+    # See https://github.com/openshift-helm-charts/development/issues/477 for context
+    SubmissionInitScenario(
+        api_url="https://api.github.com/repos/openshift-helm-charts/charts/pulls/6",
+        modified_files=[
+            f"charts/{expected_category}/{expected_organization}/{expected_name}/{expected_version}/report.yaml",
+            f"charts/{expected_category}/{expected_organization}/{expected_name}/OWNERS",
+        ],
+        expected_submission=submission.Submission(
+            api_url="https://api.github.com/repos/openshift-helm-charts/charts/pulls/6",
+            chart=expected_chart,
+            modified_files=[
+                f"charts/{expected_category}/{expected_organization}/{expected_name}/{expected_version}/report.yaml",
+                f"charts/{expected_category}/{expected_organization}/{expected_name}/OWNERS",
+            ],
+            report=submission.Report(
+                found=True,
+                signed=False,
+                path=f"charts/{expected_category}/{expected_organization}/{expected_name}/{expected_version}/report.yaml",
+            ),
+            modified_owners=[
+                f"charts/{expected_category}/{expected_organization}/{expected_name}/OWNERS"
+            ],
+        ),
+    ),
     # PR contains additional files, not fitting into any expected category
     SubmissionInitScenario(
         api_url="https://api.github.com/repos/openshift-helm-charts/charts/pulls/7",
@@ -467,6 +494,27 @@ scenarios_certification_submission = [
             modified_files=[
                 f"charts/{expected_category}/{expected_organization}/{expected_name}/OWNERS"
             ],
+            modified_owners=[
+                f"charts/{expected_category}/{expected_organization}/{expected_name}/OWNERS"
+            ],
+        ),
+        expected_is_valid_certification=False,
+        expected_reason="[ERROR] Send OWNERS file by itself in a separate PR.",
+    ),
+    # Invalid certification Submission contains OWNERS file and report file
+    CertificationScenario(
+        input_submission=submission.Submission(
+            api_url="https://api.github.com/repos/openshift-helm-charts/charts/pulls/1",
+            chart=expected_chart,
+            modified_files=[
+                f"charts/{expected_category}/{expected_organization}/{expected_name}/{expected_version}/report.yaml",
+                f"charts/{expected_category}/{expected_organization}/{expected_name}/OWNERS",
+            ],
+            report=submission.Report(
+                found=True,
+                signed=False,
+                path=f"charts/{expected_category}/{expected_organization}/{expected_name}/{expected_version}/report.yaml",
+            ),
             modified_owners=[
                 f"charts/{expected_category}/{expected_organization}/{expected_name}/OWNERS"
             ],


### PR DESCRIPTION
PRs containing a chart and an OWNERS file were getting the wrong error message. This was due to the check for duplicate charts, not taking into account that an OWNERS file doens't relate to a specific version, and thus considering the OWNERS file to be for a different chart.

Specific tests have been added to cover this case.

Fix #477