### PR TITLE
fix token permissions on job with merge step and error on fail

### DIFF
--- a/.github/workflows/mercury_bot.yml
+++ b/.github/workflows/mercury_bot.yml
@@ -175,3 +175,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MERGE_METHOD: squash
           MERGE_LABELS: ""
+          MERGE_ERROR_FAIL: "true"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -331,6 +331,7 @@ jobs:
         GITHUB_TOKEN:  ${{ secrets.GITHUB_TOKEN }}
         MERGE_METHOD: squash
         MERGE_LABELS: ""
+        MERGE_ERROR_FAIL: "true"
 
     - name: Check for PR merge
       if: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -146,7 +146,7 @@ jobs:
     - run-tests
     runs-on: ubuntu-24.04
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
     if: needs.determine-workflow-conditions.outputs.is-charts-release-branch == 'true'
     steps:
@@ -163,4 +163,5 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         MERGE_METHOD: squash
         MERGE_LABELS: ""
+        MERGE_ERROR_FAIL: "true"
 


### PR DESCRIPTION
This patch resolves another location where the automerge action would fail when using the GITHUB_TOKEN because of the missing writeable contents permission. Also adds a non-zero exit on failure to merge.