### PR TITLE
Retry getting release asset in index update script

### DIFF
--- a/scripts/src/chartprreview/chartprreview.py
+++ b/scripts/src/chartprreview/chartprreview.py
@@ -7,8 +7,6 @@ import subprocess
 import sys
 
 import requests
-from requests.adapters import HTTPAdapter
-from urllib3.util import Retry
 import semantic_version
 import semver
 import yaml
@@ -459,15 +457,7 @@ def verify_package_digest(url, report):
     target_digest = None
     pkg_digest = None
 
-    retry = Retry(
-        total=3,
-        backoff_factor=2,
-        status_forcelist=[404, 429, 500, 502, 503, 504],
-    )
-    session = requests.Session()
-    session.mount("https://", HTTPAdapter(max_retries=retry))
-
-    response = session.get(url)
+    response = requests.get(url, allow_redirects=True)
     if response.status_code == 200:
         target_digest = hashlib.sha256(response.content).hexdigest()
 

--- a/scripts/src/updateindex/updateindex.py
+++ b/scripts/src/updateindex/updateindex.py
@@ -11,6 +11,8 @@ from datetime import datetime, timezone
 import requests
 import yaml
 from environs import Env
+from requests.adapters import HTTPAdapter
+from urllib3.util import Retry
 
 try:
     from yaml import CDumper as Dumper
@@ -105,7 +107,7 @@ def set_package_digest(chart_entry, chart_url):
     """Check that the digest of the provided chart matches the digest of the chart that
     has been uploaded in the GitHub release.
 
-    Note that this  is the reason why the GitHub release must have been created before
+    Note that this is the reason why the GitHub release must have been created before
     updating the index.
 
     Args:
@@ -115,7 +117,16 @@ def set_package_digest(chart_entry, chart_url):
     """
     print("[INFO] set package digests.")
 
-    head = requests.head(chart_url, allow_redirects=True)
+    retry = Retry(
+        total=3,
+        backoff_factor=2,
+        status_forcelist=[404, 429, 500, 502, 503, 504],
+        raise_on_status=False,
+    )
+    session = requests.Session()
+    session.mount("https://", HTTPAdapter(max_retries=retry))
+
+    head = session.head(chart_url, allow_redirects=True)
     print(f"[DEBUG]: tgz url : {chart_url}")
     print(f"[DEBUG]: response code from head request: {head.status_code}")
 


### PR DESCRIPTION
This reverts commit a24c6f14fcd923d0054c75fac285295eaa357178 and places the intended retry logic at the correct place.