### PR TITLE
Update and pin action versions

### DIFF
--- a/.github/actions/generate-chart-locks/action.yaml
+++ b/.github/actions/generate-chart-locks/action.yaml
@@ -54,7 +54,7 @@ runs:
       echo "ref=${resolvedRef}" | tee -a $GITHUB_OUTPUT
   - name: Checkout
     id: clone-repository
-    uses: actions/checkout@v4
+    uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
     with:
       ref: ${{ steps.resolve.outputs.ref }}
       path: temp-gen-chart-lock-repo

--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -12,7 +12,7 @@ outputs:
 runs:
   using: composite
   steps:
-  - uses: actions/setup-python@v5
+  - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
     id: setup-python
     with:
       python-version: '3.10'

--- a/.github/workflows/behave.yml
+++ b/.github/workflows/behave.yml
@@ -76,7 +76,7 @@ jobs:
       features: ${{ steps.find-features.outputs.features }}
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: ${{ inputs.checkout-ref }}
           repository: ${{ inputs.checkout-repository }}
@@ -113,7 +113,7 @@ jobs:
         feature-file: ${{ fromJson(needs.get-features.outputs.features) }}
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           token: ${{ secrets.bot-token }}
           ref: ${{ inputs.checkout-ref }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -596,7 +596,7 @@ jobs:
 
       - name: Block until there is no running workflow
         if: ${{ needs.setup.outputs.run_build == 'true' }}
-        uses: softprops/turnstyle@v2
+        uses: softprops/turnstyle@e565d2d86403c5d23533937e95980570545e5586
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -200,29 +200,17 @@ jobs:
           path: ${{ env.SUBMISSION_PATH }}
 
       - name: Add 'content-ok' label
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
-          script: |
-            github.rest.issues.addLabels({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              labels: ['content-ok']
-            })
+        run: gh pr edit "${PR_NUMBER}" --add-label "content-ok"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.number }}
 
       - name: Remove 'content-ok' label
-        uses: actions/github-script@v7
         if: ${{ failure() && contains( github.event.pull_request.labels.*.name, 'content-ok') }}
-        with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
-          script: |
-            github.rest.issues.removeLabel({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              name: 'content-ok'
-            })
+        run: gh pr edit "${PR_NUMBER}" --remove-label "content-ok"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.number }}
 
 
   chart-verifier:
@@ -273,21 +261,12 @@ jobs:
           name: ${{ env.SUBMISSION_ARTIFACT_NAME }}
 
       - name: Remove 'authorized-request' label from PR
-        uses: actions/github-script@v7
         if: ${{ needs.setup.outputs.run_build == 'true' && contains( github.event.pull_request.labels.*.name, 'authorized-request') }}
         continue-on-error: true
+        run: gh pr edit "${PR_NUMBER}" --remove-label "authorized-request"
         env:
-          GITHUB_EVENT_NUMBER: ${{ github.event.number }}
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            var issue_number = process.env.GITHUB_EVENT_NUMBER;
-            github.rest.issues.removeLabel({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: Number(issue_number),
-              name: 'authorized-request'
-            })
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.number }}
 
       - name: install chart verifier for action
         uses: redhat-actions/openshift-tools-installer@v1
@@ -522,21 +501,11 @@ jobs:
         
       - name: Comment on PR
         if: ${{ needs.setup.outputs.run_build == 'true' }}
-        uses: actions/github-script@v7
+        run: gh pr comment "${PR_NUMBER}" --body-file "${MESSAGE_FILE}"
         env:
-          GITHUB_EVENT_NUMBER: ${{ github.event.number }}
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            var fs = require('fs');
-            var issue_number = process.env.GITHUB_EVENT_NUMBER;
-            var comment = fs.readFileSync('./pr/comment', {encoding:'utf8', flag:'r'});
-            github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: Number(issue_number),
-              body: comment
-            });
+          MESSAGE_FILE: ${{ steps.pr_comment.outputs.message-file }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.number }}
 
       - name: Send message to helm_dev slack channel
         id: notify_to_dev
@@ -553,16 +522,10 @@ jobs:
         if: ${{ needs.validate-submission.outputs.validate-submission-outcome == 'success' &&
                 needs.chart-verifier.outputs.run-verifier-outcome != 'failure' &&
                 needs.setup.outputs.run_build == 'true' }}
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            github.rest.issues.addLabels({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              labels: ['authorized-request']
-            })
+        run: gh pr edit "${PR_NUMBER}" --add-label "authorized-request"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.number }}
 
       - name: Approve PR
         id: approve_pr
@@ -723,21 +686,18 @@ jobs:
             HEAD:refs/heads/${INDEX_BRANCH}
 
       - name: Add a GitHub comment if release has failed
-        uses: actions/github-script@v7
         if: ${{ failure() && github.repository != env.SANDBOX_REPO }}
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body: `### Release job failed
+        run: |
+          gh pr comment "${PR_NUMBER}" --body "${COMMENT_BODY}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.number }}
+          COMMENT_BODY: |
+            ### Release job failed
 
-              An error occured while updating the Helm repository index.
+            An error occured while updating the Helm repository index.
 
-              cc @komish @mgoerens`
-            });
+            cc @komish @mgoerens
 
       # Note(komish): This step is a temporary workaround. Metrics requires the PR comment
       # to be available, but it is written to the filesystem in the previous job.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -530,21 +530,22 @@ jobs:
       - name: Approve PR
         id: approve_pr
         if: ${{ needs.chart-verifier.outputs.check_report-outcome == 'success' }}
-        uses: hmarr/auto-approve-action@v4
-        with:
+        run: gh pr review "${PR_NUMBER}" --approve
+        env:
           # The token we use for this changes for the Sandbox repository because the sandbox repository
           # receives PRs from the openshift-helm-charts-bot, and that same bot cannot approve its own
           # PRs which breaks workflows. Instead, for the Sandbox repo, we approve with the GHA bot.
-          github-token: ${{ github.repository == env.SANDBOX_REPO && secrets.GITHUB_TOKEN || secrets.BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ github.repository == env.SANDBOX_REPO && secrets.GITHUB_TOKEN || secrets.BOT_TOKEN }}
+          PR_NUMBER: ${{ github.event.number }}
 
       - name: Merge PR
         id: merge_pr
         if: ${{ steps.approve_pr.outcome == 'success' }}
-        uses: pascalgn/automerge-action@v0.16.2
+        run: gh pr merge "${PR_NUMBER}" --auto --squash --match-head-commit "${PR_HEAD_COMMIT}"
         env:
           GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
-          MERGE_METHOD: squash
-          MERGE_LABELS: ""
+          PR_NUMBER: ${{ github.event.number }}
+          PR_HEAD_COMMIT: ${{ github.event.pull_request.head.sha }}
 
       - name: Check for PR merge
         if: ${{ steps.merge_pr.outcome == 'success' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -343,7 +343,7 @@ jobs:
       - name: Get profile version set in report provided by the user
         id: get-profile-version
         if: ${{ needs.setup.outputs.run_build == 'true' && steps.verify_requires.outputs.report_provided == 'true' }}
-        uses: mikefarah/yq@master
+        uses: mikefarah/yq@751d8ad57b84f1794661bc70c0afb92a22ad7b3c
         with:
           cmd: yq '.metadata.tool.profile.version' ${{ format('./pr-branch/{0}', steps.verify_requires.outputs.provided_report_relative_path) }}
 
@@ -351,7 +351,7 @@ jobs:
         id: get-kube-range
         if: ${{ needs.setup.outputs.run_build == 'true' && steps.verify_requires.outputs.report_provided == 'true' }}
         continue-on-error: true
-        uses: mikefarah/yq@master
+        uses: mikefarah/yq@751d8ad57b84f1794661bc70c0afb92a22ad7b3c
         with:
           cmd: yq '.metadata.chart.kubeversion' ${{ format('./pr-branch/{0}', steps.verify_requires.outputs.provided_report_relative_path) }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -510,7 +510,7 @@ jobs:
       - name: Send message to helm_dev slack channel
         id: notify_to_dev
         if: github.repository == 'openshift-helm-charts/charts' && steps.pr_comment.outputs.ping_helm_dev == 'true'
-        uses: archive/github-actions-slack@v2.8.0
+        uses: archive/github-actions-slack@433fef9978d3adae73168bfc9c5a7ce722780231
         with:
           slack-bot-user-oauth-access-token: ${{ secrets.SLACK_BOT_USER_OAUTH_ACCESS_TOKEN }}
           slack-channel: C02979BDUPL
@@ -753,7 +753,7 @@ jobs:
       - name: Alert Slack helm_dev on failure to update metrics
         continue-on-error: true
         if: steps.add_metrics.outcome == 'failure'
-        uses: archive/github-actions-slack@v2.8.0
+        uses: archive/github-actions-slack@433fef9978d3adae73168bfc9c5a7ce722780231
         with:
           slack-bot-user-oauth-access-token: ${{ secrets.SLACK_BOT_USER_OAUTH_ACCESS_TOKEN }}
           slack-channel: C02979BDUPL

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -628,7 +628,7 @@ jobs:
       # The release tag format is <organization_name>-<chart_name>-<chart_version>
       - name: Create GitHub release
         if: ${{ needs.validate-submission.outputs.web_catalog_only == 'False' }}
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           tag_name: ${{ needs.validate-submission.outputs.release_tag }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -256,7 +256,7 @@ jobs:
           python-version: ${{ steps.setup-python.outputs.python-version }}
 
       - name: Download submission information
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: ${{ env.SUBMISSION_ARTIFACT_NAME }}
 
@@ -458,13 +458,13 @@ jobs:
 
       # Submission information should always be present
       - name: Download submission information
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: ${{ env.SUBMISSION_ARTIFACT_NAME }}
 
       # Chart report errors are only present if an error has occured during the chart_report
       - name: Download chart_report errors
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         if: ${{ needs.chart-verifier.outputs.upload-chart-report-errors-outcome == 'success' }}
         with:
           name: chart_report_errors

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
       github.actor != 'redhat-mercury-bot'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: ${{ env.TRUSTED_REF }}
 
@@ -152,13 +152,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: ${{ env.TRUSTED_REF }}
 
       - name: Checkout PR Branch
         if: ${{ needs.setup.outputs.run_build == 'true' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
@@ -246,13 +246,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: ${{ env.TRUSTED_REF }}
 
       - name: Checkout PR Branch
         if: ${{ needs.setup.outputs.run_build == 'true' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
@@ -456,13 +456,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: ${{ env.TRUSTED_REF }}
 
       - name: Checkout PR Branch
         if: ${{ needs.setup.outputs.run_build == 'true' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
@@ -602,13 +602,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: ${{ env.TRUSTED_REF }}
 
       - name: Checkout PR Branch
         if: ${{ needs.setup.outputs.run_build == 'true' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -193,7 +193,7 @@ jobs:
             ${CLI_FLAG}
       
       - name: Upload PR information
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         if: ${{ always() && steps.validate-submission.outputs.submission_file_present == 'true' }}
         with:
           name: ${{ env.SUBMISSION_ARTIFACT_NAME }}
@@ -397,7 +397,7 @@ jobs:
 
       - name: Upload chart_report errors
         id: upload-chart-report-errors
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         if: ${{ always() && steps.check_report.outcome == 'failure' }}
         with:
           name: chart_report_errors

--- a/.github/workflows/check-contributor.yml
+++ b/.github/workflows/check-contributor.yml
@@ -42,7 +42,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository base
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       
       - name: Set up Python
         id: setup-python

--- a/.github/workflows/check-locks-on-owners-submission.yml
+++ b/.github/workflows/check-locks-on-owners-submission.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Determine if net-new OWNERS file
         id: populate-file-mod-type
         if: ${{ steps.check_for_owners.outputs.merge_pr == 'true' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/check-locks-on-owners-submission.yml
+++ b/.github/workflows/check-locks-on-owners-submission.yml
@@ -30,7 +30,7 @@ jobs:
       github.event.pull_request.draft == false
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         
       - name: Set up Python
         id: setup-python
@@ -74,7 +74,7 @@ jobs:
 
       # Only used to assert content of the OWNERS file.
       - name: Checkout Pull Request
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -61,7 +61,7 @@ jobs:
     - name: Send message to helm_dev slack channel
       id: notify_dev
       if: ${{ always() &&  github.event_name == 'schedule' && steps.codeql-analysis.conclusion != 'success'}}
-      uses: archive/github-actions-slack@v2.8.0
+      uses: archive/github-actions-slack@433fef9978d3adae73168bfc9c5a7ce722780231
       with:
         slack-bot-user-oauth-access-token: ${{ secrets.SLACK_BOT_USER_OAUTH_ACCESS_TOKEN }}
         slack-channel: C02979BDUPL
@@ -76,7 +76,7 @@ jobs:
     - name: Send message to helm_notify slack channel
       id: notify
       if: ${{ always() &&  github.event_name == 'schedule' && steps.codeql-analysis.conclusion == 'success'}}
-      uses: archive/github-actions-slack@v2.8.0
+      uses: archive/github-actions-slack@433fef9978d3adae73168bfc9c5a7ce722780231
       with:
         slack-bot-user-oauth-access-token: ${{ secrets.SLACK_BOT_USER_OAUTH_ACCESS_TOKEN }}
         slack-channel: C04K1ARMH8A

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -41,20 +41,20 @@ jobs:
           build-mode: none
     steps:
     - name: Checkout repository
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v5.0.0
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       with:
         persist-credentials: false
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@f443b600d91635bebf5b0d9ebc620189c0d6fba5 # v4.30.8
+      uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
 
     - name: Perform CodeQL Analysis
       id: codeql-analysis
-      uses: github/codeql-action/analyze@f443b600d91635bebf5b0d9ebc620189c0d6fba5 # v4.30.8
+      uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225
       with:
         category: "/language:${{matrix.language}}"
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -41,7 +41,7 @@ jobs:
           build-mode: none
     steps:
     - name: Checkout repository
-      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v5.0.0
       with:
         persist-credentials: false
 

--- a/.github/workflows/lock-sanity-check.yml
+++ b/.github/workflows/lock-sanity-check.yml
@@ -34,7 +34,7 @@ jobs:
     - name: notify maintainers on failure
       id: notify
       if: failure() && steps.generate.outcome == 'failure' && github.repository == 'openshift-helm-charts/charts'
-      uses: archive/github-actions-slack@v2.8.0
+      uses: archive/github-actions-slack@433fef9978d3adae73168bfc9c5a7ce722780231
       with:
         slack-bot-user-oauth-access-token: ${{ secrets.SLACK_BOT_USER_OAUTH_ACCESS_TOKEN }}
         slack-channel: C02979BDUPL

--- a/.github/workflows/lock-sanity-check.yml
+++ b/.github/workflows/lock-sanity-check.yml
@@ -20,7 +20,7 @@ jobs:
       issues: write
     steps:
     - name: checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
     - name: Set up Python
       id: setup-python
       uses: ./.github/actions/setup-python

--- a/.github/workflows/mercury_bot.yml
+++ b/.github/workflows/mercury_bot.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Determine if net-new OWNERS file
         id: populate-file-mod-type
         if: ${{ steps.check_for_owners.outputs.merge_pr == 'true' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/mercury_bot.yml
+++ b/.github/workflows/mercury_bot.yml
@@ -183,16 +183,17 @@ jobs:
         if: |
           steps.check_for_owners.outputs.merge_pr == 'true'
           && steps.safe-to-merge.outputs.merge_pr == 'true'
-        uses: hmarr/auto-approve-action@v4
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr review "${PR_NUMBER}" --approve
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.number }}
+
 
       - name: Merge PR
         id: merge_pr
         if: ${{ steps.approve_pr.conclusion == 'success' }}
-        uses: pascalgn/automerge-action@v0.16.2
+        run: gh pr merge "${PR_NUMBER}" --auto --squash --match-head-commit "${PR_HEAD_COMMIT}"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          MERGE_METHOD: squash
-          MERGE_LABELS: ""
-          MERGE_ERROR_FAIL: "true"
+          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
+          PR_NUMBER: ${{ github.event.number }}
+          PR_HEAD_COMMIT: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/mercury_bot.yml
+++ b/.github/workflows/mercury_bot.yml
@@ -164,21 +164,11 @@ jobs:
 
       - name: Comment on PR
         if: ${{ steps.check_for_owners.outputs.merge_pr == 'false' }}
-        uses: actions/github-script@v7
+        run: gh pr comment "${PR_NUMBER}" --body "${OWNER_CHECK_OUTPUT_MSG}"
         env:
-          GITHUB_EVENT_NUMBER: ${{ github.event.number }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.number }}
           OWNER_CHECK_OUTPUT_MSG: ${{ steps.check_for_owners.outputs.msg }}
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-              var issue_number = process.env.GITHUB_EVENT_NUMBER;
-              var comment = process.env.OWNER_CHECK_OUTPUT_MSG;
-              github.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: Number(issue_number),
-                body: comment
-              });
 
       - name: Reflect on check for OWNERS file result
         if: |

--- a/.github/workflows/mercury_bot.yml
+++ b/.github/workflows/mercury_bot.yml
@@ -25,7 +25,7 @@ jobs:
     if: github.event.pull_request.draft == false && github.actor == 'redhat-mercury-bot'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         
       - name: Set up Python
         id: setup-python
@@ -77,7 +77,7 @@ jobs:
 
       # Only used to assert content of the OWNERS file.
       - name: Checkout Pull Request
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}

--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Send message to helm_dev slack channel
         id: notify_dev
         if: ${{ always() && github.event_name == 'schedule' && github.repository == 'openshift-helm-charts/development' && steps.release_metrics.conclusion != 'success' }}
-        uses: archive/github-actions-slack@v2.8.0
+        uses: archive/github-actions-slack@433fef9978d3adae73168bfc9c5a7ce722780231
         with:
           slack-bot-user-oauth-access-token: ${{ secrets.SLACK_BOT_USER_OAUTH_ACCESS_TOKEN }}
           slack-channel: C02979BDUPL
@@ -91,7 +91,7 @@ jobs:
       - name: Send message to helm_notify slack channel
         id: notify
         if: ${{ always() && github.event_name == 'schedule' && github.repository == 'openshift-helm-charts/development' && steps.release_metrics.conclusion == 'success' }}
-        uses: archive/github-actions-slack@v2.8.0
+        uses: archive/github-actions-slack@433fef9978d3adae73168bfc9c5a7ce722780231
         with:
           slack-bot-user-oauth-access-token: ${{ secrets.SLACK_BOT_USER_OAUTH_ACCESS_TOKEN }}
           slack-channel: C04K1ARMH8A

--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -23,7 +23,7 @@ jobs:
       SEGMENT_TEST_WRITE_KEY: ${{ secrets.SEGMENT_TEST_WRITE_KEY }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Set up Python
         id: setup-python

--- a/.github/workflows/nightly_test.yml
+++ b/.github/workflows/nightly_test.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Send message to helm_dev slack channel
         id: notify_to_dev
         if: needs.nightly-test.result != 'success'
-        uses: archive/github-actions-slack@v2.8.0
+        uses: archive/github-actions-slack@433fef9978d3adae73168bfc9c5a7ce722780231
         with:
           slack-bot-user-oauth-access-token: ${{ secrets.SLACK_BOT_USER_OAUTH_ACCESS_TOKEN }}
           slack-channel: C02979BDUPL
@@ -48,7 +48,7 @@ jobs:
       - name: Send message to helm_notify slack channel
         id: notify
         if: needs.nightly-test.result == 'success'
-        uses: archive/github-actions-slack@v2.8.0
+        uses: archive/github-actions-slack@433fef9978d3adae73168bfc9c5a7ce722780231
         with:
           slack-bot-user-oauth-access-token: ${{ secrets.SLACK_BOT_USER_OAUTH_ACCESS_TOKEN }}
           slack-channel: C04K1ARMH8A

--- a/.github/workflows/owners-redhat.yml
+++ b/.github/workflows/owners-redhat.yml
@@ -55,7 +55,7 @@ jobs:
               throw error
             }
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: ${{ env.TRUSTED_REF }}
 
@@ -96,7 +96,7 @@ jobs:
     needs: [gather-metadata]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: ${{ env.TRUSTED_REF }}
       - name: Set up Python
@@ -108,7 +108,7 @@ jobs:
 
       # Only used to assert content of the OWNERS file.
       - name: Checkout Pull Request
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}

--- a/.github/workflows/owners-redhat.yml
+++ b/.github/workflows/owners-redhat.yml
@@ -183,16 +183,8 @@ jobs:
     if: success()
     steps:
     - name: Label PR
-      uses: actions/github-script@v7
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        script: |
-          const issue_number = process.env.PR;
-          const successLabel = process.env.SUCCESS_LABEL;
-
-          github.rest.issues.addLabels({
-            issue_number: Number(issue_number),
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            labels: [successLabel],
-          });
+      run: gh pr edit "${PR_NUMBER}" --add-label "${SUCCESS_LABEL}"
+      env:
+        PR_NUMBER: ${{ env.PR }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SUCCESS_LABEL: ${{ env.SUCCESS_LABEL }}

--- a/.github/workflows/owners-redhat.yml
+++ b/.github/workflows/owners-redhat.yml
@@ -32,7 +32,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Clean up stale label
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
         continue-on-error: true
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -138,7 +138,7 @@ jobs:
     if: failure() && (needs.ensure-prefix-in-path.result == 'failure' || needs.ensure-owners-file-contents.result == 'failure')
     steps:
       - name: Send PR Comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
         env:
           PREFIX_CHECK_RESULT: ${{ needs.ensure-prefix-in-path.result != '' && needs.ensure-prefix-in-path.result || 'unknown' }}
           CONTENT_CHECK_RESULT: ${{ needs.ensure-owners-file-contents.result != '' && needs.ensure-owners-file-contents.result || 'unknown' }}

--- a/.github/workflows/owners.yml
+++ b/.github/workflows/owners.yml
@@ -16,7 +16,7 @@ jobs:
       SEGMENT_TEST_WRITE_KEY: ${{ secrets.SEGMENT_TEST_WRITE_KEY }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Set up Python
         id: setup-python

--- a/.github/workflows/python-style.yml
+++ b/.github/workflows/python-style.yml
@@ -13,7 +13,7 @@ jobs:
       contents: read
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
     - name: Set up Python
       uses: ./.github/actions/setup-python
     - name: Install style tooling

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -13,7 +13,7 @@ jobs:
       contents: read
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
     - name: Set up Python
       id: setup-python
       uses: ./.github/actions/setup-python

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -346,7 +346,7 @@ jobs:
       id: create_release
       if: |
         needs.determine-merge-and-release-conditions.outputs.release-tag  != ''
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         tag_name: ${{ needs.determine-merge-and-release-conditions.outputs.release-tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,10 +35,10 @@ jobs:
       is-dev-release-branch: ${{ steps.check_created_release_pr.outputs.dev_release_branch }}
     steps: 
       - name: Checkout Base Branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Checkout Pull Request
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
@@ -162,10 +162,10 @@ jobs:
       contents: read
     steps:
       - name: Checkout base repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
   
       - name: Checkout charts repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: ${{ github.event.pull_request.base.ref }}
           repository: ${{ needs.determine-workflow-conditions.outputs.charts-repo }}
@@ -173,7 +173,7 @@ jobs:
           path: "charts-repo"
 
       - name: Checkout development repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: ${{ github.event.pull_request.base.ref }}
           repository: ${{ github.event.pull_request.base.repo.full_name }}
@@ -181,7 +181,7 @@ jobs:
           path: "dev-repo"
       
       - name: Checkout stage repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: ${{ github.event.pull_request.base.ref }}
           repository: ${{ needs.determine-workflow-conditions.outputs.stage-repo }}
@@ -303,7 +303,7 @@ jobs:
       needs.determine-merge-and-release-conditions.outputs.release-tag != ''
     steps:
     - name: Checkout base repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
     - name: Set up Python
       id: setup-python

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -318,20 +318,20 @@ jobs:
       id: approve_pr
       if: |
         needs.determine-merge-and-release-conditions.outputs.should-merge == 'true'
-      uses: hmarr/auto-approve-action@v4
-      with:
-        github-token:  ${{ secrets.GITHUB_TOKEN }}
+      run: gh pr review "${PR_NUMBER}" --approve
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        PR_NUMBER: ${{ github.event.number }}
 
     - name: Merge PR
       id: merge_pr
       if: |
         needs.determine-merge-and-release-conditions.outputs.should-merge == 'true'
-      uses: pascalgn/automerge-action@v0.16.2
+      run: gh pr merge "${PR_NUMBER}" --auto --squash --match-head-commit "${PR_HEAD_COMMIT}"
       env:
-        GITHUB_TOKEN:  ${{ secrets.GITHUB_TOKEN }}
-        MERGE_METHOD: squash
-        MERGE_LABELS: ""
-        MERGE_ERROR_FAIL: "true"
+        GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
+        PR_NUMBER: ${{ github.event.number }}
+        PR_HEAD_COMMIT: ${{ github.event.pull_request.head.sha }}
 
     - name: Check for PR merge
       if: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -152,16 +152,16 @@ jobs:
     steps:
     - name: Approve PR
       id: approve_pr
-      uses: hmarr/auto-approve-action@v4
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
+      run: gh pr review "${PR_NUMBER}" --approve
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        PR_NUMBER: ${{ github.event.number }}
 
     - name: Merge PR
       id: merge_pr
-      uses: pascalgn/automerge-action@v0.16.2
+      run: gh pr merge "${PR_NUMBER}" --auto --squash --match-head-commit "${PR_HEAD_COMMIT}"
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        MERGE_METHOD: squash
-        MERGE_LABELS: ""
-        MERGE_ERROR_FAIL: "true"
+        GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
+        PR_NUMBER: ${{ github.event.number }}
+        PR_HEAD_COMMIT: ${{ github.event.pull_request.head.sha }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
       test-tags: ${{ steps.determine-test-tags.outputs.test-tags }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
This PR updates as many action versions to comply with with NodeJS 20 deprecation that's coming soon. A majority of the action updates here will resolve the deprecation warnings.

Notably, the redhat-actions have not been updated here because they have not pushed their nodeJS 24 migration yet.

We also remove some github-script actions in favor of gh cli.

Finally, a few actions were replaced with gh cli. The features were used, as well as the default behavior, was evaluated and if a comparable outcome could be achieved with gh cli, we did so. In some cases, this was not the case out of the box, so we left the original action in place. 

After this has merged and has been tested to our liking, I intend to enable Dependabot support for the github-actions ecosystem to keep these pinned and updated over time.

Here's a list of the actions used

```
actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
archive/github-actions-slack@433fef9978d3adae73168bfc9c5a7ce722780231
github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225
github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225
jitterbit/get-changed-files@v1
mikefarah/yq@751d8ad57b84f1794661bc70c0afb92a22ad7b3c
redhat-actions/chart-verifier@v1
redhat-actions/oc-login@v1
redhat-actions/openshift-tools-installer@v1
softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda
softprops/turnstyle@e565d2d86403c5d23533937e95980570545e5586
```

[EDIT] Fri Apr 24 03:27:30 PM CDT 2026:

Forgot actions/setup-python, it's now been pinned as well

```
actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
```