### PR TITLE
Specify valid conditions for authorized-request label application

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -520,7 +520,7 @@ jobs:
       # provided a valid report.yaml
       - name: Add 'authorized-request' label to PR
         if: ${{ needs.validate-submission.outputs.validate-submission-outcome == 'success' &&
-                needs.chart-verifier.outputs.run-verifier-outcome != 'failure' &&
+                contains(fromJSON('["success", "skipped"]'), needs.chart-verifier.outputs.run-verifier-outcome) &&
                 needs.setup.outputs.run_build == 'true' }}
         run: gh pr edit "${PR_NUMBER}" --add-label "authorized-request"
         env:


### PR DESCRIPTION
The authorized-request label would be applied to PRs in cases where the chart-verifier job would not complete due to some transient error. Actual user verification is delegated to a script, but we can also prevent this label from being applied by being more specific in what job outcomes matter to us (done here by ensuring that the outcome is either success or failure, and not allowing an empty value.