### PR TITLE
Add additional timeout message returned in helm/v4 timeout conditions

### DIFF
--- a/tests/functional/behave_features/HC-16_chart_test_takes_more_than_30mins.feature
+++ b/tests/functional/behave_features/HC-16_chart_test_takes_more_than_30mins.feature
@@ -10,8 +10,8 @@ Feature: Chart test takes longer time and exceeds default timeout
 
     @partners @full
     Examples:
-      | vendor_type  | vendor    | chart_path                                  | message                                                      |
-      | partners     | hashicorp | tests/data/vault-test-timeout-0.17.0.tgz    | (timeout has expired\|timed out waiting for the condition)  |
+      | vendor_type  | vendor    | chart_path                                  | message                                                                |
+      | partners     | hashicorp | tests/data/vault-test-timeout-0.17.0.tgz    | (timeout has expired\|timed out waiting for the condition\|not ready)  |
     
     @community @full
     Examples:


### PR DESCRIPTION
This message is pretty small, but I'm trying to avoid using the `context deadline exceeded` being returned by the Helm v4 client that we use for this work, as that can happen in a lot of different cases.

Example where this is failing is here: 
https://github.com/openshift-helm-charts/sandbox-2025-11/pull/14008

HC-10 is expected to fail here because the fix for it is in https://github.com/openshift-helm-charts/development/pull/524