### PR TITLE
Extend E2E testing logs to include links to relevant PRs and Workflow runs

### DIFF
--- a/tests/functional/behave_features/common/utils/chart_certification.py
+++ b/tests/functional/behave_features/common/utils/chart_certification.py
@@ -339,16 +339,16 @@ vendor:
             conclusion = get_run_result(self.secrets, run_id)
             if conclusion == expect_result:
                 logging.info(
-                    f"PR{pr_number if pr_number else self.secrets.pr_number} Workflow run was '{expect_result}' which is expected"
+                    f"PR{pr_number if pr_number else self.secrets.pr_number} (https://github.com/{TEST_REPO}/pull/{pr_number if pr_number else self.secrets.pr_number}) Workflow run was '{expect_result}' which is expected"
                 )
             else:
                 if failure_type == "warning":
                     logging.warning(
-                        f"PR{pr_number if pr_number else self.secrets.pr_number} Workflow run was '{conclusion}' which is unexpected, run id: {run_id}"
+                        f"PR{pr_number if pr_number else self.secrets.pr_number} (https://github.com/{TEST_REPO}/pull/{pr_number if pr_number else self.secrets.pr_number}) Workflow run was '{conclusion}' which is unexpected, run: https://github.com/{TEST_REPO}/actions/runs/{run_id}"
                     )
                 else:
                     raise AssertionError(
-                        f"PR{pr_number if pr_number else self.secrets.pr_number} Workflow run was '{conclusion}' which is unexpected, run id: {run_id}"
+                        f"PR{pr_number if pr_number else self.secrets.pr_number} (https://github.com/{TEST_REPO}/pull/{pr_number if pr_number else self.secrets.pr_number}) Workflow run was '{conclusion}' which is unexpected, run: https://github.com/{TEST_REPO}/actions/runs/{run_id}"
                     )
 
             return run_id, conclusion

--- a/tests/functional/behave_features/common/utils/owner_file_submission.py
+++ b/tests/functional/behave_features/common/utils/owner_file_submission.py
@@ -340,16 +340,16 @@ class OwnersFileSubmissionsE2ETest:
 
         if conclusion == expected_result:
             logging.info(
-                f"PR{pr_number} Workflow run was '{expected_result}' which is expected"
+                f"PR{pr_number} (https://github.com/{settings.TEST_REPO}/pull/{pr_number}) Workflow run was '{expected_result}' which is expected"
             )
         else:
             if failure_type == "error":
                 raise AssertionError(
-                    f"PR{pr_number if pr_number else self.secrets.pr_number} Workflow run was '{conclusion}' which is unexpected, run id: {run_id}"
+                    f"PR{pr_number if pr_number else self.secrets.pr_number} (https://github.com/{settings.TEST_REPO}/pull/{pr_number if pr_number else self.secrets.pr_number}) Workflow run was '{conclusion}' which is unexpected, run: https://github.com/{settings.TEST_REPO}/actions/runs/{run_id}"
                 )
             else:
                 logging.warning(
-                    f"PR{pr_number if pr_number else self.secrets.pr_number} Workflow run was '{conclusion}' which is unexpected, run id: {run_id}"
+                    f"PR{pr_number if pr_number else self.secrets.pr_number} (https://github.com/{settings.TEST_REPO}/pull/{pr_number if pr_number else self.secrets.pr_number}) Workflow run was '{conclusion}' which is unexpected, run: https://github.com/{settings.TEST_REPO}/actions/runs/{run_id}"
                 )
 
         return run_id, conclusion


### PR DESCRIPTION
Adds links that should be clickable to our E2E logs.