### PR TITLE
Update actions/checkout to v7

### DIFF
--- a/.github/actions/generate-chart-locks/action.yaml
+++ b/.github/actions/generate-chart-locks/action.yaml
@@ -54,7 +54,7 @@ runs:
       echo "ref=${resolvedRef}" | tee -a $GITHUB_OUTPUT
   - name: Checkout
     id: clone-repository
-    uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+    uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     with:
       ref: ${{ steps.resolve.outputs.ref }}
       path: temp-gen-chart-lock-repo

--- a/.github/workflows/behave.yml
+++ b/.github/workflows/behave.yml
@@ -3,6 +3,9 @@ name: Behave Testing
 # Behave Testing will run the repository's Behave testing with each feature file
 # getting its own runner. All feature files found within the specific path are
 # included.
+#
+# Workflow callers should be gating to approved actors due to actions/checkout
+# checking out contributed content.
 
 on:
   workflow_call:
@@ -76,11 +79,14 @@ jobs:
       features: ${{ steps.find-features.outputs.features }}
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.checkout-ref }}
           repository: ${{ inputs.checkout-repository }}
           fetch-depth: ${{ inputs.checkout-fetch-depth }}
+          # Explicit fork checkout for test execution. Workflow caller
+          # should be gating this to approved actors
+          allow-unsafe-pr-checkout: true
       - name: find features
         # Find the feature files currently defined in repo. We expect to find at
         # least 15 files, though that number is arbitrarily chosen at a figure
@@ -113,12 +119,15 @@ jobs:
         feature-file: ${{ fromJson(needs.get-features.outputs.features) }}
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           token: ${{ secrets.bot-token }}
           ref: ${{ inputs.checkout-ref }}
           repository: ${{ inputs.checkout-repository }}
           fetch-depth: ${{ inputs.checkout-fetch-depth }}
+          # Explicit fork checkout for test execution. Workflow caller
+          # should be gating this to approved actors
+          allow-unsafe-pr-checkout: true
 
       - name: Set up Python
         id: setup-python

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
       github.actor != 'redhat-mercury-bot'
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ env.TRUSTED_REF }}
 
@@ -152,17 +152,19 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ env.TRUSTED_REF }}
 
       - name: Checkout PR Branch
         if: ${{ needs.setup.outputs.run_build == 'true' }}
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           path: "pr-branch"
+          # Explicit fork checkout for certification, read as data only
+          allow-unsafe-pr-checkout: true
 
       - name: Set up Python
         id: setup-python
@@ -234,17 +236,19 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ env.TRUSTED_REF }}
 
       - name: Checkout PR Branch
         if: ${{ needs.setup.outputs.run_build == 'true' }}
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           path: "pr-branch"
+          # Explicit fork checkout for certification, chart-verifier runs if needed
+          allow-unsafe-pr-checkout: true
 
       - name: Set up Python
         id: setup-python
@@ -435,17 +439,19 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ env.TRUSTED_REF }}
 
       - name: Checkout PR Branch
         if: ${{ needs.setup.outputs.run_build == 'true' }}
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           path: "pr-branch"
+          # Explicit fork checkout for certification, read as data only
+          allow-unsafe-pr-checkout: true
 
       - name: Set up Python
         id: setup-python
@@ -566,17 +572,19 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ env.TRUSTED_REF }}
 
       - name: Checkout PR Branch
         if: ${{ needs.setup.outputs.run_build == 'true' }}
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           path: "pr-branch"
+          # Explicit fork checkout for certification, read as data only
+          allow-unsafe-pr-checkout: true
 
       - name: Set up Python
         id: setup-python

--- a/.github/workflows/check-contributor.yml
+++ b/.github/workflows/check-contributor.yml
@@ -42,7 +42,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository base
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       
       - name: Set up Python
         id: setup-python

--- a/.github/workflows/check-locks-on-owners-submission.yml
+++ b/.github/workflows/check-locks-on-owners-submission.yml
@@ -30,7 +30,7 @@ jobs:
       github.event.pull_request.draft == false
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         
       - name: Set up Python
         id: setup-python
@@ -74,13 +74,15 @@ jobs:
 
       # Only used to assert content of the OWNERS file.
       - name: Checkout Pull Request
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           token: ${{ secrets.BOT_TOKEN }}
           fetch-depth: 0
           path: "pr-branch"
+          # Explicit fork checkout to read OWNERS file content
+          allow-unsafe-pr-checkout: true
 
       - name: Ensure OWNERS content and path content align
         working-directory: "pr-branch"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -41,7 +41,7 @@ jobs:
           build-mode: none
     steps:
     - name: Checkout repository
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
 

--- a/.github/workflows/lock-sanity-check.yml
+++ b/.github/workflows/lock-sanity-check.yml
@@ -20,7 +20,7 @@ jobs:
       issues: write
     steps:
     - name: checkout
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: Set up Python
       id: setup-python
       uses: ./.github/actions/setup-python

--- a/.github/workflows/mercury_bot.yml
+++ b/.github/workflows/mercury_bot.yml
@@ -25,7 +25,7 @@ jobs:
     if: github.event.pull_request.draft == false && github.actor == 'redhat-mercury-bot'
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         
       - name: Set up Python
         id: setup-python
@@ -77,13 +77,15 @@ jobs:
 
       # Only used to assert content of the OWNERS file.
       - name: Checkout Pull Request
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           token: ${{ secrets.BOT_TOKEN }}
           fetch-depth: 0
           path: "pr-branch"
+          # Explicit fork checkout, gated to redhat-mercury-bot
+          allow-unsafe-pr-checkout: true
 
       # TODO: Implemented as a shell script temporarily. Future enhancement
       # would re-use some existing logic that we have for the Red Hat OWNERS

--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -23,7 +23,7 @@ jobs:
       SEGMENT_TEST_WRITE_KEY: ${{ secrets.SEGMENT_TEST_WRITE_KEY }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python
         id: setup-python

--- a/.github/workflows/owners-redhat.yml
+++ b/.github/workflows/owners-redhat.yml
@@ -55,7 +55,7 @@ jobs:
               throw error
             }
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ env.TRUSTED_REF }}
 
@@ -96,7 +96,7 @@ jobs:
     needs: [gather-metadata]
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ env.TRUSTED_REF }}
       - name: Set up Python
@@ -108,13 +108,15 @@ jobs:
 
       # Only used to assert content of the OWNERS file.
       - name: Checkout Pull Request
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           token: ${{ secrets.BOT_TOKEN }}
           fetch-depth: 0
           path: "pr-branch"
+          # Explicit fork checkout to read OWNERS file content
+          allow-unsafe-pr-checkout: true
 
       - name: Assert Owners File Content
         id: assert-content

--- a/.github/workflows/owners.yml
+++ b/.github/workflows/owners.yml
@@ -16,7 +16,7 @@ jobs:
       SEGMENT_TEST_WRITE_KEY: ${{ secrets.SEGMENT_TEST_WRITE_KEY }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python
         id: setup-python

--- a/.github/workflows/python-style.yml
+++ b/.github/workflows/python-style.yml
@@ -13,7 +13,7 @@ jobs:
       contents: read
     steps:
     - name: Checkout code
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: Set up Python
       uses: ./.github/actions/setup-python
     - name: Install style tooling

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -13,7 +13,7 @@ jobs:
       contents: read
     steps:
     - name: Checkout code
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: Set up Python
       id: setup-python
       uses: ./.github/actions/setup-python

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,16 +35,18 @@ jobs:
       is-dev-release-branch: ${{ steps.check_created_release_pr.outputs.dev_release_branch }}
     steps: 
       - name: Checkout Base Branch
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Checkout Pull Request
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           token: ${{ secrets.BOT_TOKEN }}
           fetch-depth: 0
           path: "pr-branch"
+          # Explicit fork checkout for test execution, gated by check-contributor
+          allow-unsafe-pr-checkout: true
 
       - name: Set up Python
         id: setup-python
@@ -162,10 +164,10 @@ jobs:
       contents: read
     steps:
       - name: Checkout base repo
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
   
       - name: Checkout charts repo
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.base.ref }}
           repository: ${{ needs.determine-workflow-conditions.outputs.charts-repo }}
@@ -173,7 +175,7 @@ jobs:
           path: "charts-repo"
 
       - name: Checkout development repo
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.base.ref }}
           repository: ${{ github.event.pull_request.base.repo.full_name }}
@@ -181,7 +183,7 @@ jobs:
           path: "dev-repo"
       
       - name: Checkout stage repo
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.base.ref }}
           repository: ${{ needs.determine-workflow-conditions.outputs.stage-repo }}
@@ -303,7 +305,7 @@ jobs:
       needs.determine-merge-and-release-conditions.outputs.release-tag != ''
     steps:
     - name: Checkout base repo
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Set up Python
       id: setup-python

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,12 +33,15 @@ jobs:
       test-tags: ${{ steps.determine-test-tags.outputs.test-tags }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.sha }}
           token: ${{ secrets.BOT_TOKEN }}
           fetch-depth: 0
+          # Explicit fork checkout for test execution, gated by check-contributor
+          # and again by check-pr-for-ci
+          allow-unsafe-pr-checkout: true
 
       - name: Set up Python
         id: setup-python


### PR DESCRIPTION
actions/checkout v7 requires that we indicate that we're explicitly using pull request content in a privileged context, which makes sense for certification workflows. For certain other workflows, we gate the tasks that execute this. Comments have been added to inform future maintainers that they need to ensure they're reviewing their use of a given workflow, and indicate where this is gated (if applicable) in-line with the addition of the option.

This should allow us to maintain functionality with versions of actions/checkout preceding this default behavior change. In the future, we may opt to remove some of these toggles by adjusting how we submit changes, what we ship to other repos, etc.